### PR TITLE
[CLI Grader] Add a flag to grade 'student.ml' instead of 'solution.ml'

### DIFF
--- a/src/grader/grader_cli.ml
+++ b/src/grader/grader_cli.ml
@@ -33,9 +33,14 @@ let display_outcomes = ref false
 (* Where to put the graded exercise *)
 let output_json = ref None
 
+(* Should the tool grade 'student.ml' instead of 'solution.ml' ? *)
+let grade_student = ref false
+
 let args = Arg.align @@
   [ "-output-json", Arg.String (fun s -> output_json := Some s),
     "PATH save the graded exercise in JSON format in the given file" ;
+    "-grade-student", Arg.Set grade_student,
+    " grade file 'student.ml' instead of 'solution.ml'";
     "-display-outcomes", Arg.Set display_outcomes,
     " display the toplevel's outcomes" ;
     "-display-progression", Arg.Set display_callback,
@@ -67,12 +72,22 @@ let remove_trailing_slash s =
   let len = String.length s in
   if len <> 0 && s.[len-1] = '/' then String.sub s 0 (len-1) else s
 
+let read_file f =
+  let ic = open_in f in
+  let n = in_channel_length ic in
+  let s = Bytes.create n in
+  really_input ic s 0 n;
+  close_in ic;
+  Bytes.to_string s;;
+
 let grade exercise_dir output_json =
   Lwt.catch
     (fun () ->
        let exercise_dir = remove_trailing_slash exercise_dir in
        read_exercise exercise_dir >>= fun exo ->
-       let solution = Learnocaml_exercise.(get solution) exo in
+       let solution = if !grade_student then
+                        read_file (Filename.concat exercise_dir "student.ml")
+                      else Learnocaml_exercise.(get solution) exo in
        let callback =
          if !display_callback then Some (Printf.printf "[ %s ]\n%!") else None in
        Grading_cli.get_grade ?callback exo solution

--- a/src/grader/grader_cli.ml
+++ b/src/grader/grader_cli.ml
@@ -72,25 +72,31 @@ let remove_trailing_slash s =
   let len = String.length s in
   if len <> 0 && s.[len-1] = '/' then String.sub s 0 (len-1) else s
 
-let read_file f =
-  let ic = open_in f in
-  let n = in_channel_length ic in
-  let s = Bytes.create n in
-  really_input ic s 0 n;
-  close_in ic;
-  Bytes.to_string s;;
+let read_student_file exercise_dir path =
+  let fn =
+    if Filename.is_relative path
+    then Filename.concat exercise_dir path
+    else path in
+  Lwt_unix.file_exists fn >>= fun exists ->
+  if not exists
+  then (Format.eprintf "Cannot find '%s': No such file@." fn; exit 1)
+  else
+    Lwt_io.with_file ~mode:Lwt_io.Input fn @@ fun chan ->
+      Lwt_io.read chan >>= fun content ->
+      Lwt.return content
 
 let grade exercise_dir output_json =
   Lwt.catch
     (fun () ->
        let exercise_dir = remove_trailing_slash exercise_dir in
        read_exercise exercise_dir >>= fun exo ->
-       let solution = if !grade_student then
-                        read_file (Filename.concat exercise_dir "student.ml")
-                      else Learnocaml_exercise.(get solution) exo in
+       let code_to_grade = match !grade_student with
+         | true -> read_student_file exercise_dir "student.ml"
+         | false -> Lwt.return (Learnocaml_exercise.(get solution) exo) in
        let callback =
          if !display_callback then Some (Printf.printf "[ %s ]\n%!") else None in
-       Grading_cli.get_grade ?callback exo solution
+       code_to_grade >>= fun code ->
+       Grading_cli.get_grade ?callback exo code
        >>= fun (result, stdout_contents, stderr_contents, outcomes) ->
        match result with
        | Error exn ->

--- a/src/grader/grader_cli.ml
+++ b/src/grader/grader_cli.ml
@@ -33,14 +33,14 @@ let display_outcomes = ref false
 (* Where to put the graded exercise *)
 let output_json = ref None
 
-(* Should the tool grade 'student.ml' instead of 'solution.ml' ? *)
-let grade_student = ref false
+(* Should the tool grade a student file instead of 'solution.ml' ? *)
+let grade_student = ref None
 
 let args = Arg.align @@
   [ "-output-json", Arg.String (fun s -> output_json := Some s),
     "PATH save the graded exercise in JSON format in the given file" ;
-    "-grade-student", Arg.Set grade_student,
-    " grade file 'student.ml' instead of 'solution.ml'";
+    "-grade-student", Arg.String (fun s -> grade_student := Some s),
+    "PATH grade the given student file instead of 'solution.ml'";
     "-display-outcomes", Arg.Set display_outcomes,
     " display the toplevel's outcomes" ;
     "-display-progression", Arg.Set display_callback,
@@ -91,8 +91,8 @@ let grade exercise_dir output_json =
        let exercise_dir = remove_trailing_slash exercise_dir in
        read_exercise exercise_dir >>= fun exo ->
        let code_to_grade = match !grade_student with
-         | true -> read_student_file exercise_dir "student.ml"
-         | false -> Lwt.return (Learnocaml_exercise.(get solution) exo) in
+         | Some path -> read_student_file exercise_dir path
+         | None -> Lwt.return (Learnocaml_exercise.(get solution) exo) in
        let callback =
          if !display_callback then Some (Printf.printf "[ %s ]\n%!") else None in
        code_to_grade >>= fun code ->


### PR DESCRIPTION
Dear learn-ocaml developers,

I propose to integrate this feature that allows one to use learn-ocaml in "offline" mode as well.

This feature is disabled by default and just consists in grading `student.ml` instead of `solution.ml`.

For example it can be used with [autograde-ocaml](https://github.com/pfitaxel/autograde-ocaml) (a simple tool we have developed for grading assignments in the "PFITA" teaching unit of Univ. Toulouse 3), which amounts to calling `learnocaml-grader.byte` with the CLI flag `-grade-student`.