### PR TITLE
[test_lib] Update/Add primitives about types/modules

### DIFF
--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -70,6 +70,9 @@ module type S = sig
 
   val test_student_code : 'a Ty.ty -> ('a -> Learnocaml_report.report) -> Learnocaml_report.report
 
+  val test_module_property :
+    'a Ty.ty -> string -> ('a -> Learnocaml_report.report) -> Learnocaml_report.report
+
   (*----------------------------------------------------------------------------*)
 
   type 'a result =
@@ -739,6 +742,16 @@ module Make
     | Introspection.Incompatible msg ->
         [ Message ([ Text "Your code doesn't match the expected signature." ; Break ;
                      Code msg (* TODO: hide or fix locations *) ], Failure) ]
+
+  let test_module_property ty name cb =
+    let open Learnocaml_report in
+    match Introspection.get_value ("Code." ^ name) ty with
+    | Introspection.Present v -> cb v
+    | Introspection.Absent ->
+       [ Message ([ Text "Module" ; Code name ; Text "not found." ], Failure) ]
+    | Introspection.Incompatible msg ->
+       [ Message ([ Text "Module" ; Code name ; Text "doesn't match the expected signature." ;
+                    Break ; Code msg (* TODO: hide or fix locations *) ], Failure) ]
 
   let typed_printer ty ppf v =
     Introspection.print_value ppf v ty

--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -66,7 +66,7 @@ module type S = sig
 
   val compatible_type : expected:string -> string -> Learnocaml_report.report
 
-  val abstract_type : ?allow_private:bool -> string -> bool * Learnocaml_report.report
+  val abstract_type : ?allow_private:bool -> ?score:int -> string -> bool * Learnocaml_report.report
 
   val test_student_code : 'a Ty.ty -> ('a -> Learnocaml_report.report) -> Learnocaml_report.report
 
@@ -722,14 +722,14 @@ module Make
       | Introspection.Present () ->
           Message ([ Text "Type found and compatible" ], Success 5) ]
 
-  let abstract_type ?(allow_private = true) name =
+  let abstract_type ?(allow_private = true) ?(score = 5) name =
     let open Learnocaml_report in
     try let path = Env.lookup_type Longident.(parse ("Code." ^ name)) !Toploop.toplevel_env in
         match Env.find_type path !Toploop.toplevel_env with
         | { Types. type_kind = Types.Type_abstract ; Types. type_manifest = None } ->
-           true, [ Message ([Text "Type" ; Code name ; Text "is abstract as expected." ], Success 5) ]
+           true, [ Message ([Text "Type" ; Code name ; Text "is abstract as expected." ], Success score) ]
         | { Types. type_kind = _ ; type_private = Asttypes.Private } when allow_private ->
-           true, [ Message ([Text "Type" ; Code name ; Text "is private, I'll accept that :-)." ], Success 5) ]
+           true, [ Message ([Text "Type" ; Code name ; Text "is private, I'll accept that :-)." ], Success score) ]
         | { Types. type_kind = _ } ->
            false, [ Message ([Text "Type" ; Code name ; Text "should be abstract!" ], Failure) ]
     with Not_found -> false, [ Message ( [Text "Type" ; Code name ; Text "not found." ], Failure) ]

--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -66,6 +66,8 @@ module type S = sig
 
   val compatible_type : expected:string -> string -> Learnocaml_report.report
 
+  val existing_type : ?score:int -> string -> bool * Learnocaml_report.report
+
   val abstract_type : ?allow_private:bool -> ?score:int -> string -> bool * Learnocaml_report.report
 
   val test_student_code : 'a Ty.ty -> ('a -> Learnocaml_report.report) -> Learnocaml_report.report
@@ -721,6 +723,13 @@ module Make
           Message ([ Text msg ], Failure)
       | Introspection.Present () ->
           Message ([ Text "Type found and compatible" ], Success 5) ]
+
+  let existing_type ?(score = 1) name =
+    let open Learnocaml_report in
+    try let path = Env.lookup_type Longident.(parse ("Code." ^ name)) !Toploop.toplevel_env in
+        let _ = Env.find_type path !Toploop.toplevel_env in
+        true, [ Message ( [ Text "Type" ; Code name ; Text "found" ], Success score ) ]
+    with Not_found -> false, [ Message ( [ Text "type" ; Code name ; Text "not found" ], Failure ) ]
 
   let abstract_type ?(allow_private = true) ?(score = 5) name =
     let open Learnocaml_report in

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -66,7 +66,7 @@ module type S = sig
 
   val compatible_type : expected:string -> string -> Learnocaml_report.report
 
-  val abstract_type : ?allow_private:bool -> string -> bool * Learnocaml_report.report
+  val abstract_type : ?allow_private:bool -> ?score:int -> string -> bool * Learnocaml_report.report
 
   val test_student_code : 'a Ty.ty -> ('a -> Learnocaml_report.report) -> Learnocaml_report.report
 

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -66,6 +66,8 @@ module type S = sig
 
   val compatible_type : expected:string -> string -> Learnocaml_report.report
 
+  val existing_type : ?score:int -> string -> bool * Learnocaml_report.report
+
   val abstract_type : ?allow_private:bool -> ?score:int -> string -> bool * Learnocaml_report.report
 
   val test_student_code : 'a Ty.ty -> ('a -> Learnocaml_report.report) -> Learnocaml_report.report

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -70,6 +70,9 @@ module type S = sig
 
   val test_student_code : 'a Ty.ty -> ('a -> Learnocaml_report.report) -> Learnocaml_report.report
 
+  val test_module_property :
+    'a Ty.ty -> string -> ('a -> Learnocaml_report.report) -> Learnocaml_report.report
+
   (*----------------------------------------------------------------------------*)
 
   type 'a result =


### PR DESCRIPTION
Dear learn-ocaml developers,

For preparing one of our assignments manipulating modules and abstract types, we have been led to add two functions in `test_lib` (and add an optional argument in function `abstract_type`).

As this could be useful for other users of learn-ocaml, I submit this PR (which relies on #5).

Erik