### PR TITLE
[Grader] Add individual timeout feature

### DIFF
--- a/src/grader/grading.ml
+++ b/src/grader/grading.ml
@@ -42,7 +42,7 @@ let internal_error name err =
 let user_code_error err =
   raise (User_code_error err)
 
-let get_grade ?callback ~divert exo code =
+let get_grade ?callback ?timeout ~divert exo code =
 
   let print_outcome = true in
   let outcomes_buffer = Buffer.create 503 in
@@ -127,11 +127,13 @@ let get_grade ?callback ~divert exo code =
       Introspection.register_callback "set_progress"
         [%ty: string]
         set_progress ;
+      Introspection.insert_in_env "timeout" [%ty: int option] timeout ;
       handle_error (internal_error "while preparing the tests") @@
       Toploop_ext.use_string ~print_outcome ~ppf_answer
         "module Test_lib = Test_lib.Make(struct\n\
         \  let results = results\n\
         \  let set_progress = set_progress\n\
+        \  let timeout = timeout\n\
         \  module Introspection = Introspection\n\
          end)" ;
       handle_error (internal_error "while preparing the tests") @@

--- a/src/grader/grading.mli
+++ b/src/grader/grading.mli
@@ -28,5 +28,6 @@ exception Invalid_grader
     {!Toploop_unix} and {!Toploop_jsoo}. *)
 val get_grade:
   ?callback:(string -> unit) ->
+  ?timeout:int ->
   divert:(string -> out_channel -> (string -> unit) -> (unit -> unit)) ->
   Learnocaml_exercise.t -> string -> (Learnocaml_report.report, exn) result * string * string * string

--- a/src/grader/grading_cli.ml
+++ b/src/grader/grading_cli.ml
@@ -37,7 +37,7 @@ let with_temp_dir f =
     (fun () -> f dir >>= fun res -> remove_dir dir >>= fun () -> Lwt.return res)
     (fun e -> remove_dir dir >>= fun () -> Lwt.fail e)
 
-let get_grade ?callback exo solution =
+let get_grade ?callback ?timeout exo solution =
   with_temp_dir @@ fun cmis_dir ->
   let module ResDump =
     OCamlResFormats.Files (OCamlResSubFormats.Raw) in
@@ -51,4 +51,4 @@ let get_grade ?callback exo solution =
     let redirection = Toploop_unix.redirect_channel name chan cb in
     fun () -> Toploop_unix.stop_channel_redirection redirection in
   Lwt.return
-    (Grading.get_grade ?callback ~divert exo solution)
+    (Grading.get_grade ?callback ?timeout ~divert exo solution)

--- a/src/grader/grading_cli.mli
+++ b/src/grader/grading_cli.mli
@@ -20,5 +20,6 @@
     exceptions defined in module {!Grading}. *)
 val get_grade:
   ?callback:(string -> unit) ->
+  ?timeout:int ->
   Learnocaml_exercise.t -> string ->
   ((Learnocaml_report.report, exn) result * string * string * string) Lwt.t

--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -752,6 +752,8 @@ module Make
   type 'a tester =
     'a Ty.ty -> 'a result -> 'a result -> Learnocaml_report.report
 
+  exception Timeout
+
   let test_generic eq canon ty va vb =
     let to_string v = Format.asprintf "%a" (typed_printer ty) v in
     if eq (canon va) (canon vb) then
@@ -768,6 +770,8 @@ module Make
             Learnocaml_report.[ Message ([ Text "Your code exceeded the output buffer size limit." ], Failure) ]
         | Error Stack_overflow ->
             Learnocaml_report.[ Message ([ Text "Your code did too many recursions." ], Failure) ]
+        | Error Timeout ->
+            Learnocaml_report.[ Message ([ Text "Your code exceeded the time limit. Too many recursions?" ], Failure) ]
         | Error exn ->
             Learnocaml_report.[ Message ([ Text "Wrong exception" ; Code (Printexc.to_string exn) ], Failure) ] end
 
@@ -815,11 +819,22 @@ module Make
 
   (*----------------------------------------------------------------------------*)
 
+let sigalrm_handler = Sys.Signal_handle (fun _ -> raise Timeout) 
+let timeout ?(time = 4) v =
+  let old_behavior = Sys.signal Sys.sigalrm sigalrm_handler in
+  let reset_sigalrm () = Sys.set_signal Sys.sigalrm old_behavior
+  in ignore (Unix.alarm time);
+     try
+       let res = v () in
+       reset_sigalrm (); res
+     with exc ->
+       reset_sigalrm (); raise exc
+
   let exec v =
     Introspection.grab_stdout () ;
     Introspection.grab_stderr () ;
     try
-      let res = v () in
+      let res = timeout v in
       let out = Introspection.release_stdout () in
       let err = Introspection.release_stderr () in
       Ok (res, out, err)

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -351,5 +351,6 @@ module Make : functor
   (Params : sig
      val results : Learnocaml_report.report option ref
      val set_progress : string -> unit
+     val timeout : int option
      module Introspection : Introspection_intf.INTROSPECTION
    end) -> S


### PR DESCRIPTION
Hi,

For grading assignments offline easily (without commenting-out code by-hand if some test enters in an infinite recursion…), it was important for us to have a feature of "individual timeout" (i.e., if a test case exceeds a specified amount of time, the grader still terminates but marks the test case as failed).

After some research on ways to achieve this in OCaml, I implemented the solution gathered in this PR (which relies on #4):
- it relies on Unix signals,
- the relevant part of the code is [here](https://github.com/pfitaxel/learn-ocaml/blob/0aa73c318fb94a9003622793ddc9a386491157e5/src/grader/test_lib.ml#L822-L839),
- and it was inspired by [this section of the online book Developing applications with Objective Caml](http://caml.inria.fr/pub/docs/oreilly-book/html/book-ora168.html).

The current limitation of this PR is that it won't necessarily work with js_of_ocaml... (I only tested it in batch mode with [autograde-ocaml](https://github.com/pfitaxel/autograde-ocaml), by using a `-timeout` option that is disabled by default.)

So I guess one could either refine this PR to make it work with js_of_ocaml as well, or merge this PR as-is and add some js_of_ocaml support of individual timeout in a separated PR?
But I'm afraid I couldn't do this extension myself since I'm not js_of_ocaml-savvy enough for the moment.

Kind regards,
Erik