### PR TITLE
Remove uses of Camlp4

### DIFF
--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -16,9 +16,8 @@ depends: [
   "ocp-build" {build}
   "base64"
   "ezjsonm"
-  "camlp4"
   "js_of_ocaml" {= "3.1.0" }
-  "js_of_ocaml-camlp4"
+  "js_of_ocaml-ppx"
   "js_of_ocaml-toplevel"
   "js_of_ocaml-compiler"
   "js_of_ocaml-lwt"
@@ -27,7 +26,6 @@ depends: [
   "ocp-indent-nlfork"
   "ocp-ocamlres" {= "0.4"}
   "ocplib-json-typed" {= "0.6"}
-  "optcomp"
   "pprint"
   "ppx_tools"
   "react"

--- a/learn-ocaml.opam.locked
+++ b/learn-ocaml.opam.locked
@@ -18,7 +18,6 @@ depends: [
   "cmdliner" {= "1.0.2"}
   "yojson" {= "1.4.1"}
   "js_of_ocaml-compiler" {= "3.1.0"}
-  "camlp4" {= "4.05+1"}
   "js_of_ocaml" {= "3.1.0"}
   "lwt" {= "3.1.0"}
   "uutf" {= "1.0.1"}
@@ -33,7 +32,7 @@ depends: [
   "pprint" {= "20171003"}
   "cohttp-lwt-unix" {= "1.0.2"}
   "ezjsonm" {= "0.5.0"}
-  "js_of_ocaml-camlp4" {= "3.1.0"}
+  "js_of_ocaml-ppx" {= "3.1.0"}
   "js_of_ocaml-lwt" {= "3.1.0"}
   "js_of_ocaml-toplevel" {= "3.1.0"}
   "js_of_ocaml-tyxml" {= "3.1.0"}
@@ -41,7 +40,6 @@ depends: [
   "ocp-ocamlres" {= "0.4"}
   "ocplib-json-typed" {= "0.6"}
   "omd" {= "1.3.1"}
-  "optcomp" {= "1.6"}
   "ppx_cstruct" {= "3.2.1"}
   "ppx_tools" {= "5.0+4.05.0"}
 ]

--- a/scripts/install-opam-deps.sh
+++ b/scripts/install-opam-deps.sh
@@ -7,7 +7,6 @@ opam pin add --yes --no-action ocp-ocamlres \
 	   "https://github.com/OCamlPro/ocp-ocamlres.git"
 opam pin add --yes --no-action ocplib-json-typed 0.6
 opam pin add --yes --no-action learn-ocaml-deps src
-opam install camlp4 --yes
 opam depext learn-ocaml-deps
 if opam list --installed learn-ocaml-deps
 then opam upgrade learn-ocaml-deps ocp-indent-nlfork ocplib-json-typed ocp-ocamlres

--- a/src/ace-lib/ace.ml
+++ b/src/ace-lib/ace.ml
@@ -31,72 +31,72 @@ type 'a editor = {
 }
 
 let ace : Ace_types.ace Js.t = Js.Unsafe.variable "ace"
-let edit el = ace##edit (el)
+let edit el = ace##(edit el)
 
 let create_position r c =
   let pos : position Js.t = Js.Unsafe.obj [||] in
-  pos##row <- r;
-  pos##column <- c;
+  pos##.row := r;
+  pos##.column := c;
   pos
 let greater_position p1 p2 =
-  p1##row > p2##row ||
-  (p1##row = p2##row && p1##column > p2##column)
+  p1##.row > p2##.row ||
+  (p1##.row = p2##.row && p1##.column > p2##.column)
 
 
 let create_range s e =
   let range : range Js.t = Js.Unsafe.obj [||] in
-  range##start <- s;
-  range##end_ <- e;
+  range##.start := s;
+  range##.end_ := e;
   range
 
-let read_position pos = (pos##row, pos##column)
+let read_position pos = (pos##.row, pos##.column)
 
 let read_range range =
-  ((range##start##row, range##start##column),
-   (range##end_##row, range##end_##column))
+  ((range##.start##.row, range##.start##.column),
+   (range##.end_##.row, range##.end_##.column))
 
 let get_contents ?range {editor} =
-  let document = editor##getSession()##getDocument() in
+  let document = (editor##getSession)##getDocument in
   match range with
   | None ->
-      Js.to_string @@ document##getValue()
+      Js.to_string @@ document##getValue
   | Some r ->
-      Js.to_string @@ document##getTextRange(r)
+      Js.to_string @@ document##(getTextRange r)
 
 let set_contents {editor} code =
-  let document = editor##getSession()##getDocument() in
-  document##setValue (Js.string code)
+  let document = (editor##getSession)##getDocument in
+  document##(setValue (Js.string code))
 
-let get_selection_range {editor} = editor##getSelectionRange()
+let get_selection_range {editor} = editor##getSelectionRange
 
 let get_selection {editor} =
-  let document = editor##getSession()##getDocument() in
-  let range = editor##getSelectionRange() in
-  Js.to_string @@ document##getTextRange(range)
+  let document = (editor##getSession)##getDocument in
+  let range = editor##getSelectionRange in
+  Js.to_string @@ document##(getTextRange range)
 
 let get_line {editor} line =
-  let document = editor##getSession()##getDocument() in
-  Js.to_string @@ document##getLine (line)
+  let document = (editor##getSession)##getDocument in
+  Js.to_string @@ document##(getLine line)
 
 let create_editor editor_div =
   let editor = edit editor_div in
   Js.Unsafe.set editor "$blockScrolling" (Js.Unsafe.variable "Infinity");
   let data =
     { editor; editor_div; marks = []; keybinding_menu = false; } in
-  editor##customData <- (data, None);
+  editor##.customData := (data, None);
   data
 
 let get_custom_data { editor } =
-  match snd editor##customData with
+  match snd editor##.customData with
   | None -> raise Not_found
   | Some x -> x
 
 let set_custom_data { editor } data =
-  let ed = fst editor##customData in
-  editor##customData <- (ed, Some data)
+  let ed = fst editor##.customData in
+  editor##.customData := (ed, Some data)
 
 let set_mode {editor} name =
-  editor##getSession()##setMode (Js.string name)
+  editor##getSession##(setMode (Js.string name))
 
 type mark_type = Error | Warning | Message
 
@@ -105,10 +105,10 @@ let string_of_make_type = function
   | Warning -> "warning"
   | Message -> "message"
 
-let require s = (Js.Unsafe.variable "ace")##require(Js.string s)
+let require s = (Js.Unsafe.variable "ace")##(require (Js.string s))
 
 type range = Ace_types.range Js.t
-let range_cstr = (require  "ace/range")##_Range
+let range_cstr = (require  "ace/range")##._Range
 let range sr sc er ec : range =
   Js.Unsafe.new_obj range_cstr
     [| Js.Unsafe.inject sr ; Js.Unsafe.inject sc ;
@@ -120,7 +120,7 @@ type loc = {
 }
 
 let set_mark editor ?loc ?(type_ = Message) msg =
-  let session = editor.editor##getSession() in
+  let session = (editor.editor)##getSession in
   let type_ = string_of_make_type type_ in
   let sr, sc, range =
     match loc with
@@ -130,39 +130,39 @@ let set_mark editor ?loc ?(type_ = Message) msg =
         let er = er - 1 in
       sr, sc, Some (range sr sc er ec) in
   let annot : annotation Js.t = Js.Unsafe.obj [||] in
-  annot##row <- sr;
-  annot##column <- sc;
-  annot##text <- Js.string msg;
-  annot##type_ <- Js.string type_;
+  annot##.row := sr;
+  annot##.column := sc;
+  annot##.text := Js.string msg;
+  annot##.type_ := Js.string type_;
   let annotations =
-    Array.concat [[| annot |]; Js.to_array (session##getAnnotations ())] in
-  session##setAnnotations(Js.array @@ annotations);
+    Array.concat [[| annot |]; Js.to_array (session##getAnnotations)] in
+  session##(setAnnotations (Js.array @@ annotations));
   match range with
   | None -> ()
   | Some range ->
     editor.marks <-
-      session##addMarker (range, Js.string type_, Js.string "text", Js._false) ::
+      session##(addMarker range (Js.string type_) (Js.string "text") (Js._false)) ::
       editor.marks
 
 let set_background_color editor color =
-  editor.editor_div##style##backgroundColor <- Js.string color
+  editor.editor_div##.style##.backgroundColor := Js.string color
 
 let add_class { editor_div } name =
-  editor_div##classList##add(Js.string name)
+  editor_div##.classList##(add (Js.string name))
 let remove_class { editor_div } name =
-  editor_div##classList##remove(Js.string name)
+  editor_div##.classList##(remove (Js.string name))
 
 let clear_marks editor =
-  let session = editor.editor##getSession() in
-  List.iter (fun i -> session##removeMarker (i)) editor.marks;
-  session##clearAnnotations();
+  let session = (editor.editor)##getSession in
+  List.iter (fun i -> session##(removeMarker i)) editor.marks;
+  session##clearAnnotations;
   editor.marks <- []
 
 let record_event_handler editor event handler =
-  editor.editor##on(Js.string event, handler)
+  editor.editor##(on (Js.string event) handler)
 
-let focus { editor } = editor##focus ()
-let resize { editor } force = editor##resize (Js.bool force)
+let focus { editor } = editor##focus
+let resize { editor } force = editor##(resize (Js.bool force))
 
 let get_keybinding_menu e =
   if e.keybinding_menu then
@@ -179,37 +179,37 @@ let get_keybinding_menu e =
 let show_keybindings e =
   match get_keybinding_menu e with
   | None ->
-      Firebug.console##log
-        (Js.string "You should load: 'ext-keybinding_menu.js'")
+      Firebug.console##(log
+        (Js.string "You should load: 'ext-keybinding_menu.js'"))
   | Some o ->
-      o##showKeyboardShortcuts()
+      o##showKeyboardShortcuts
 
 let add_keybinding { editor }
     ?ro ?scrollIntoView ?multiSelectAction
     name key exec =
   let command : _ command Js.t = Js.Unsafe.obj [||] in
   let binding : binding Js.t = Js.Unsafe.obj [||] in
-  command##name <- Js.string name;
-  command##exec <- Js.wrap_callback (fun ed _args -> exec (fst ed##customData));
-  iter_option (fun ro -> command##readOnly <- Js.bool ro) ro;
+  command##.name := Js.string name;
+  command##.exec := Js.wrap_callback (fun ed _args -> exec (fst ed##.customData));
+  iter_option (fun ro -> command##.readOnly := Js.bool ro) ro;
   iter_option
-    (fun s -> command##scrollIntoView <- Js.string s)
+    (fun s -> command##.scrollIntoView := Js.string s)
     scrollIntoView;
   iter_option
-    (fun s -> command##multiSelectAction <- Js.string s)
+    (fun s -> command##.multiSelectAction := Js.string s)
     multiSelectAction;
-  binding##win <- Js.string key;
-  binding##mac <- Js.string key;
-  command##bindKey <- binding;
-  editor##commands##addCommand (command)
+  binding##.win := Js.string key;
+  binding##.mac := Js.string key;
+  command##.bindKey := binding;
+  editor##.commands##(addCommand command)
 
 (** Mode *)
 
 type token = Ace_types.token Js.t
 let token ~type_ value =
   let obj : Ace_types.token Js.t = Js.Unsafe.obj [||] in
-  obj##value <- Js.string value;
-  obj##_type <- Js.string type_;
+  obj##.value := Js.string value;
+  obj##._type := Js.string type_;
   obj
 
 type doc = Ace_types.document Js.t
@@ -224,26 +224,26 @@ type 'state helpers = {
 
 let create_js_line_tokens (st, tokens) =
   let obj : _ Ace_types.line_tokens Js.t = Js.Unsafe.obj [||] in
-  obj##state <- st;
-  obj##tokens <- Js.array (Array.of_list tokens);
+  obj##.state := st;
+  obj##.tokens := Js.array (Array.of_list tokens);
   obj
 
 let define_mode name helpers =
   let js_helpers : _ ace_mode_helpers Js.t = Js.Unsafe.obj [||] in
-  js_helpers##initialState <- Js.wrap_callback helpers.initial_state;
-  js_helpers##getNextLineIndent <-
+  js_helpers##.initialState := Js.wrap_callback helpers.initial_state;
+  js_helpers##.getNextLineIndent :=
     (Js.wrap_callback @@ fun st line tab ->
      Js.string @@
      helpers.get_next_line_indent
        st ~line:(Js.to_string line) ~tab:(Js.to_string tab));
-  js_helpers##getLineTokens <-
+  js_helpers##.getLineTokens :=
     (Js.wrap_callback @@ fun line st row doc ->
      create_js_line_tokens @@
      helpers.get_line_tokens (Js.to_string line) st row doc);
   begin match helpers.check_outdent with
     | None -> ()
     | Some check_outdent ->
-        js_helpers##checkOutdent <-
+        js_helpers##.checkOutdent :=
           (Js.wrap_callback @@ fun st line input ->
            Js.bool @@
            check_outdent st (Js.to_string line) (Js.to_string input))
@@ -251,7 +251,7 @@ let define_mode name helpers =
   begin match helpers.auto_outdent with
     | None -> ()
     | Some auto_outdent ->
-        js_helpers##autoOutdent <- Js.wrap_callback auto_outdent
+        js_helpers##.autoOutdent := Js.wrap_callback auto_outdent
   end;
   Js.Unsafe.fun_call
     (Js.Unsafe.variable "define_ocaml_mode")
@@ -259,27 +259,27 @@ let define_mode name helpers =
        Js.Unsafe.inject js_helpers |]
 
 let set_font_size {editor} sz =
-  editor##setFontSize (sz)
+  editor##(setFontSize sz)
 let set_tab_size {editor} sz =
-  editor##getSession()##setTabSize (sz)
+  editor##getSession##(setTabSize sz)
 
 let get_state { editor } row =
-  editor##getSession()##getState(row)
+  editor##getSession##(getState row)
 
 let get_last { editor } =
-  let doc = editor##getSession()##getDocument () in
-  let lines = doc##getLength() in
-  let last = doc##getLine(lines - 1) in
-  create_position (lines - 1) last##length
+  let doc = (editor##getSession)##getDocument in
+  let lines = doc##getLength in
+  let last = doc##(getLine (lines - 1)) in
+  create_position (lines - 1) last##.length
 
 let document { editor } =
-  editor##getSession()##getDocument()
+  (editor##getSession)##getDocument
 
 let replace doc range text =
-  doc##replace (range, Js.string text)
+  doc##(replace range (Js.string text))
 
 let delete doc range =
-  doc##replace (range, Js.string "")
+  doc##(replace range (Js.string ""))
 
 let remove { editor } dir =
-  editor##remove(Js.string "left")
+  editor##(remove (Js.string "left"))

--- a/src/ace-lib/build.ocp
+++ b/src/ace-lib/build.ocp
@@ -2,8 +2,8 @@ begin library "ace"
   link += [ "-linkall" ]
   files = [
     "ace_types.mli"
-    "ace.ml"        ( pp = camlp4_optcomp_js )
-    "ocaml_mode.ml" ( pp = camlp4_optcomp_js )
+    "ace.ml" ( comp = ppx_js )
+    "ocaml_mode.ml"
   ]
   requires = [
     "jsutils"

--- a/src/ace-lib/ocaml_mode.ml
+++ b/src/ace-lib/ocaml_mode.ml
@@ -226,7 +226,7 @@ type config = {
 
 let config =
   ref {
-    indent = IndentConfig.(update_from_string default "match_clause=4");
+    indent = IndentConfig.({default with i_match_clause = 4});
     forced = true;
   }
 

--- a/src/app/build.ocp
+++ b/src/app/build.ocp
@@ -10,14 +10,14 @@ end
 
 begin library "learnocaml-app-common"
   files = [
-    "learnocaml_local_storage.ml" ( pp = camlp4_js )
-    "server_caller.ml" ( pp = camlp4_js )
-    "learnocaml_common.ml" ( pp = camlp4_js )
+    "learnocaml_local_storage.ml" ( comp = ppx_js )
+    "server_caller.ml" ( comp = ppx_js )
+    "learnocaml_common.ml" ( comp = ppx_js )
   ]
   requires = [
     "ocplib-json-typed.browser"
     "js_of_ocaml"
-    "js_of_ocaml.syntax"
+    "js_of_ocaml.ppx"
     "js_of_ocaml.tyxml"
     "jsutils"
     "learnocaml-toplevel"
@@ -34,9 +34,10 @@ begin program "learnocaml-main"
     "learnocaml-repository"
     "learnocaml-app-common"
     "learnocaml-toplevel"
+    "js_of_ocaml.ppx"
   ]
   files = [
-    "learnocaml_index_main.ml" ( pp = camlp4_js )
+    "learnocaml_index_main.ml" ( comp = ppx_js )
   ]
   build_rules = [
     "%{learnocaml-main_FULL_DST_DIR}%/learnocaml-main.js" (
@@ -61,9 +62,10 @@ begin program "learnocaml-exercise"
     "learnocaml-repository"
     "learnocaml-app-common"
     "learnocaml-toplevel"
+    "js_of_ocaml.ppx"
   ]
   files = [
-    "learnocaml_exercise_main.ml" ( pp = camlp4_js )
+    "learnocaml_exercise_main.ml" ( comp = ppx_js )
   ]
   build_rules = [
     "%{learnocaml-exercise_FULL_DST_DIR}%/learnocaml-exercise.js" (

--- a/src/app/learnocaml_common.ml
+++ b/src/app/learnocaml_common.ml
@@ -34,16 +34,16 @@ let find_component id =
 let fake_download ~name ~contents =
   (* TODO: add some primitives to jsoo and clean this up  *)
   let blob : (Js.js_string Js.t Js.js_array Js.t -> File.blob Js.t) Js.constr =
-    Js.Unsafe.global ## _Blob in
-  let blob = jsnew blob (Js.array [| contents |]) in
+    Js.Unsafe.global ##. _Blob in
+  let blob = new%js blob (Js.array [| contents |]) in
   let url =
-    Js.Unsafe.meth_call (Js.Unsafe.global##_URL) "createObjectURL" [| Js.Unsafe.inject blob |] in
+    Js.Unsafe.meth_call (Js.Unsafe.global##._URL) "createObjectURL" [| Js.Unsafe.inject blob |] in
   let link = Dom_html.createA Dom_html.document in
-  link##href <- url ;
+  link##.href := url ;
   Js.Unsafe.set link (Js.string "download") (Js.string name) ;
-  ignore (Dom_html.document##body##appendChild ((link :> Dom.node Js.t))) ;
+  ignore (Dom_html.document##.body##(appendChild ((link :> Dom.node Js.t)))) ;
   ignore (Js.Unsafe.meth_call link "click" [||]) ;
-  ignore (Dom_html.document##body##removeChild ((link :> Dom.node Js.t)))
+  ignore (Dom_html.document##.body##(removeChild ((link :> Dom.node Js.t))))
 
 let fake_upload () =
   let input_files_load =
@@ -53,19 +53,19 @@ let fake_upload () =
     Lwt.wakeup_exn result_wakener
       (Failure "file loading not implemented for this browser") ;
     Js._true in
-  input_files_load##onchange <- Dom.handler (fun ev ->
-      Js.Opt.case (ev##target) fail @@ fun target ->
+  input_files_load##.onchange := Dom.handler (fun ev ->
+      Js.Opt.case (ev##.target) fail @@ fun target ->
       Js.Opt.case (Dom_html.CoerceTo.input target) fail @@ fun input ->
-      Js.Optdef.case (input##files) fail @@ fun files ->
-      Js.Opt.case (files##item (0)) fail @@ fun file ->
-      let name = Js.to_string file##name in
-      let fileReader = jsnew File.fileReader() in
-      fileReader##onload <- Dom.handler (fun ev ->
-          Js.Opt.case (ev##target) fail @@ fun target ->
-          Js.Opt.case (File.CoerceTo.string (target##result)) fail @@ fun result ->
+      Js.Optdef.case (input##.files) fail @@ fun files ->
+      Js.Opt.case (files##(item (0))) fail @@ fun file ->
+      let name = Js.to_string file##.name in
+      let fileReader = new%js File.fileReader in
+      fileReader##.onload := Dom.handler (fun ev ->
+          Js.Opt.case (ev##.target) fail @@ fun target ->
+          Js.Opt.case (File.CoerceTo.string (target##.result)) fail @@ fun result ->
           Lwt.wakeup result_wakener (name, result) ;
           Js._true) ;
-      fileReader##readAsText (file) ;
+      fileReader##(readAsText file) ;
       Js._true) ;
   ignore (Js.Unsafe.meth_call input_files_load "click" [||]) ;
   result_t
@@ -166,7 +166,7 @@ let disable_button_group (buttons, _, cpt) =
   if !cpt = 1 then
     List.iter
       (fun (button, _) ->
-         button##disabled <- Js.bool true)
+         button##.disabled := Js.bool true)
       !buttons
 
 let enable_button_group (buttons, _, cpt) =
@@ -175,7 +175,7 @@ let enable_button_group (buttons, _, cpt) =
     List.iter
       (fun (button, state) ->
          if not !state then
-           button##disabled <- Js.bool false)
+           button##.disabled := Js.bool false)
       !buttons
 
 let disable_button (disabled, self) =
@@ -184,7 +184,7 @@ let disable_button (disabled, self) =
       disabled := true
   | Some (_, button) ->
       disabled := true ;
-      button##disabled <- Js.bool true
+      button##.disabled := Js.bool true
 
 let enable_button (disabled, self) =
   match !self with
@@ -193,7 +193,7 @@ let enable_button (disabled, self) =
   | Some ((_, _, cpt), button) ->
       disabled := false ;
       if !cpt = 0 then
-        button##disabled <- Js.bool false
+        button##.disabled := Js.bool false
 
 let button_group_disabled (_, _, cpt) =
   !cpt > 0
@@ -243,12 +243,12 @@ let button ~container ~theme ?group ?state ~icon lbl cb =
         disabled in
   others := (dom_button, self_disabled) :: !others ;
   if !self_disabled || !cnt > 0 then
-    dom_button##disabled <- Js.bool true ;
+    dom_button##.disabled := Js.bool true ;
   Manip.appendChild container button
 
 let gettimeofday () =
-  let now = jsnew Js.date_now () in
-  floor ((now ## getTime ()) *. 1000.) +. float (now ## getTimezoneOffset ())
+  let now = new%js Js.date_now in
+  floor ((now ## getTime) *. 1000.) +. float (now ## getTimezoneOffset)
 
 let render_rich_text ?on_runnable_clicked text =
   let open Learnocaml_index in

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -213,7 +213,7 @@ let () =
       Tyxml_js.Html5.[ prelude_title ; prelude_container ]
   end ;
   Js.Opt.case
-    (text_iframe##contentDocument)
+    (text_iframe##.contentDocument)
     (fun () -> failwith "cannot edit iframe document")
     (fun d ->
        let mathjax_url =
@@ -235,9 +235,9 @@ let () =
            (Learnocaml_exercise.(get title) exo)
            mathjax_url
            (Learnocaml_exercise.(get descr) exo) in
-       d##open_ ();
+       d##open_;
        d##write (Js.string html);
-       d##close ()) ;
+       d##close) ;
   (* ---- editor pane --------------------------------------------------- *)
   let editor_pane = find_component "learnocaml-exo-editor-pane" in
   let editor = Ocaml_mode.create_ocaml_editor (Tyxml_js.To_dom.of_div editor_pane) in
@@ -309,7 +309,7 @@ let () =
   let toolbar_button = button ~container: exo_toolbar ~theme: "light" in
   begin toolbar_button
       ~icon: "list" "Exercises" @@ fun () ->
-    Dom_html.window##location##assign
+    Dom_html.window##.location##assign
       (Js.string "index.html#activity=exercises") ;
     Lwt.return ()
   end ;

--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -139,7 +139,7 @@ let lessons_tab select (arg, set_arg, delete_arg) () =
   let next_button_state = button_state () in
   let load_lesson ~loading () =
     let selector = Tyxml_js.To_dom.of_select selector in
-    let id = Js.to_string selector##value in
+    let id = Js.to_string selector##.value in
     Server_caller.fetch_lesson id >>= fun { lesson_steps } ->
     Manip.removeChildren main_div ;
     if loading then begin
@@ -214,27 +214,27 @@ let lessons_tab select (arg, set_arg, delete_arg) () =
       ~group ~state: prev_button_state ~container: navigation_div
       ~theme: "black" ~icon: "left" "Prev" @@ fun () ->
     let selector = Tyxml_js.To_dom.of_select selector in
-    let id = Js.to_string selector##value in
+    let id = Js.to_string selector##.value in
     match prev_and_next id with
     | Some prev, _ ->
         let option = Tyxml_js.To_dom.of_option (List.assoc prev options) in
-        option##selected <- Js._true ;
+        option##.selected := Js._true ;
         load_lesson ~loading: true ()
     | _ -> Lwt.return ()
   end ;
   Manip.appendChild navigation_div selector ;
   disable_with_button_group (Tyxml_js.To_dom.of_select selector) group ;
-  (Tyxml_js.To_dom.of_select selector)##onchange <-
+  (Tyxml_js.To_dom.of_select selector)##.onchange :=
     Dom_html.handler (fun _ -> Lwt.async (load_lesson ~loading: true) ; Js._true) ;
   begin button
       ~group ~state: next_button_state ~container: navigation_div
       ~theme: "black" ~icon: "right" "Next" @@ fun () ->
     let selector = Tyxml_js.To_dom.of_select selector in
-    let id = Js.to_string selector##value in
+    let id = Js.to_string selector##.value in
     match prev_and_next id with
     | _, Some next ->
         let option = Tyxml_js.To_dom.of_option (List.assoc next options) in
-        option##selected <- Js._true ;
+        option##.selected := Js._true ;
         load_lesson ~loading: true ()
     | _ -> Lwt.return ()
   end ;
@@ -249,7 +249,7 @@ let lessons_tab select (arg, set_arg, delete_arg) () =
           | [] -> raise Not_found
           | (id, _) :: _ -> id in
       let option = Tyxml_js.To_dom.of_option (List.assoc id options) in
-      option##selected <- Js._true ;
+      option##.selected := Js._true ;
       load_lesson ~loading: false ()
     with Not_found -> failwith "lesson not found"
   end >>= fun () ->
@@ -375,7 +375,7 @@ let tryocaml_tab select (arg, set_arg, delete_arg) () =
     end ;
     let option =
       Tyxml_js.To_dom.of_option (List.assoc tutorial_name options) in
-    option##selected <- Js._true ;
+    option##.selected := Js._true ;
     let step = try
         List.nth tutorial_steps step_id
       with _ -> failwith "unknown step" in
@@ -438,9 +438,9 @@ let tryocaml_tab select (arg, set_arg, delete_arg) () =
   Manip.appendChild navigation_div selector ;
   disable_with_button_group (Tyxml_js.To_dom.of_select selector)
     toplevel_buttons_group ;
-  dom_selector##onchange <-
+  dom_selector##.onchange :=
     Dom_html.handler (fun _ ->
-        let id = Js.to_string (dom_selector##value) in
+        let id = Js.to_string (dom_selector##.value) in
         Lwt.async (load_tutorial id 0) ;
         Js._true) ;
   begin button
@@ -564,12 +564,12 @@ let init_sync_token button_state =
          with Not_found ->
            Lwt_request.get ~headers: [] ~url: "/sync/gimme" ~args: [] >>= fun token ->
            let token = Js.string token in
-           let json = Js._JSON##parse (token) in
+           let json = Js._JSON##(parse token) in
            let token = Json_repr_browser.Json_encoding.destruct token_format json in
            Learnocaml_local_storage.(store sync_token) token ;
            Lwt.return token
        end >>= fun token ->
-       input##value <- Js.string token ;
+       input##.value := Js.string token ;
        enable_button button_state ;
        Lwt.return ())
     (fun _ -> Lwt.return ())
@@ -598,7 +598,7 @@ let sync () =
     let id = "learnocaml-save-token-field" in
     let input = find_component id in
     let input = Tyxml_js.To_dom.of_input input in
-    Js.to_string input ## value in
+    Js.to_string input ##. value in
   let req = Server_caller.fetch_save_file ~token in
   let local_save_file = get_state_as_save_file () in
   req >>= fun server_save_file ->
@@ -629,7 +629,7 @@ let () =
         Json_repr_browser.Json_encoding.construct
           Learnocaml_sync.save_file_enc
           (get_state_as_save_file ()) in
-      Js._JSON##stringify (json) in
+      Js._JSON##(stringify json) in
     Learnocaml_common.fake_download ~name ~contents ;
     Lwt.return ()
   end ;
@@ -640,7 +640,7 @@ let () =
     let save_file =
       Json_repr_browser.Json_encoding.destruct
         Learnocaml_sync.save_file_enc
-        (Js._JSON##parse (contents)) in
+        (Js._JSON##(parse contents)) in
     set_state_from_save_file save_file ;
     Lwt.return ()
   end ;

--- a/src/app/learnocaml_local_storage.ml
+++ b/src/app/learnocaml_local_storage.ml
@@ -65,7 +65,7 @@ let init () =
   Dom_html.addEventListener
     Dom_html.window storage_event_typ
     (Dom_html.handler (fun evt ->
-         Js.Opt.case (evt##key)
+         Js.Opt.case (evt##.key)
            (fun () -> Js._false)
            (fun name ->
               let name = Js.to_string name in
@@ -102,19 +102,19 @@ let demangle str =
 
 let store_single name enc value =
   Js.Optdef.case
-    (Dom_html.window##localStorage)
+    (Dom_html.window##.localStorage)
     (fun () -> failwith "local storage support required")
     (fun localStorage ->
        let json = Json_repr_browser.Json_encoding.construct enc value in
-       localStorage##setItem (Js.string name, Js._JSON##stringify (json)))
+       localStorage##(setItem (Js.string name) (Js._JSON##(stringify json))))
 
 let retrieve_single ?default name enc () =
   Js.Optdef.case
-    (Dom_html.window##localStorage)
+    (Dom_html.window##.localStorage)
     (fun () -> failwith "local storage support required")
     (fun localStorage ->
        Js.Opt.case
-         (localStorage##getItem (Js.string name))
+         (localStorage##(getItem (Js.string name)))
          (fun () ->
             match default with
             | Some default -> default
@@ -122,17 +122,17 @@ let retrieve_single ?default name enc () =
          (fun v ->
             let open Json_repr_browser.Json_encoding in
             try
-              destruct enc (Js._JSON##parse (v))
+              destruct enc (Js._JSON##(parse v))
             with exn ->
               raise (Json_encoding.Cannot_destruct
                        ([ `Field "localStorage" ; `Field name ], exn))))
 
 let delete_single name enc () =
   Js.Optdef.case
-    (Dom_html.window##localStorage)
+    (Dom_html.window##.localStorage)
     (fun () -> failwith "local storage support required")
     (fun localStorage ->
-       localStorage##removeItem (Js.string name))
+       localStorage##(removeItem (Js.string name)))
 
 let sync_token =
   let key = mangle [ "sync-token" ] in

--- a/src/app/server_caller.ml
+++ b/src/app/server_caller.ml
@@ -42,10 +42,10 @@ let fetch ?message filename =
 
 let fetch_json filename =
   fetch filename >>= fun text ->
-  try Lwt.return (Js._JSON##parse (Js.string text)) with Js.Error err ->
+  try Lwt.return (Js._JSON##(parse (Js.string text))) with Js.Error err ->
     let msg =
       Format.asprintf "bad format for %s\n%s"
-        filename (Js.to_string err ## message) in
+        filename (Js.to_string err ##. message) in
     Lwt.fail (Cannot_fetch msg)
 
 let fetch_and_decode_json enc filename =
@@ -94,10 +94,10 @@ let fetch_save_file ~token =
   let message = "cannot download server data" in
   fetch ~message ("/sync/" ^ token) >>= fun text ->
   let text = if text = "" then "{}" else text in
-  (try Lwt.return (Js._JSON##parse (Js.string text)) with Js.Error err ->
+  (try Lwt.return (Js._JSON##(parse (Js.string text))) with Js.Error err ->
      let msg =
        Format.asprintf "bad format for server data\n%s"
-         (Js.to_string err ## message) in
+         (Js.to_string err ##. message) in
      Lwt.fail (Cannot_fetch msg)) >>= fun json ->
   try Lwt.return @@
     Json_repr_browser.Json_encoding.destruct Learnocaml_sync.save_file_enc json
@@ -113,7 +113,7 @@ let upload_save_file ~token save_file =
       Learnocaml_sync.save_file_enc
       save_file in
   let body =
-    Some (Js.to_string (Js._JSON##stringify (json))) in
+    Some (Js.to_string (Js._JSON##(stringify json))) in
   Lwt.catch
     (fun () -> Lwt_request.post ~headers: [] ~get_args: []
         ~url: ("/sync/" ^ token) ~body)

--- a/src/grader/build.ocp
+++ b/src/grader/build.ocp
@@ -106,10 +106,11 @@ begin library "grading-jsoo"
     "ocplib-json-typed.browser"
     "learnocaml-repository"
     "learnocaml-state"
+    "js_of_ocaml.ppx"
   ]
   files = [
     "grader_jsoo_messages.ml"
-    "grading_jsoo.ml" ( pp = camlp4_js )
+    "grading_jsoo.ml" ( comp = ppx_js )
   ]
 end
 
@@ -123,10 +124,11 @@ begin program "learnocaml-grader-worker"
     "js_of_ocaml.syntax"
     "learnocaml-repository"
     "learnocaml-state"
+    "js_of_ocaml.ppx"
   ]
   files = [
     "grader_jsoo_messages.ml"
-    "grader_jsoo_worker.ml" ( pp = camlp4_js )
+    "grader_jsoo_worker.ml" ( comp = ppx_js )
   ]
   build_rules = [
     "%{learnocaml-grader-worker_FULL_DST_DIR}%/learnocaml-grader-worker.js" (

--- a/src/opam
+++ b/src/opam
@@ -12,7 +12,7 @@ depends: [
   "base64"
   "ezjsonm"
   "js_of_ocaml" {= "3.1.0" }
-  "js_of_ocaml-camlp4"
+  "js_of_ocaml-ppx"
   "js_of_ocaml-toplevel"
   "js_of_ocaml-compiler"
   "js_of_ocaml-lwt"

--- a/src/syntax.ocp
+++ b/src/syntax.ocp
@@ -1,24 +1,3 @@
+ppx_js = [ "-ppx" "%{js_of_ocaml-ppx_FULL_DST_DIR}%/ppx.exe --as-ppx" ]
 
-optcomp_opt = %string(strings = [
-  "-let ocaml_full_version=("
-    ocaml_major_version ","
-    ocaml_minor_version ","
-    ocaml_point_version
-  ")"
-])
-
-camlp4_optcomp_js = [
-  "camlp4o"
-  "%{optcomp_FULL_DST_DIR}%/optcomp.cma" optcomp_opt
-  "%{js_of_ocaml-camlp4_FULL_DST_DIR}%/pa_js.cma"
-]
-
-camlp4_js = [
-  "camlp4o"
-  "%{js_of_ocaml-camlp4_FULL_DST_DIR}%/pa_js.cma"
-]
-
-camlp4_optcomp = [
-  "camlp4o"
-  "%{optcomp_FULL_DST_DIR}%/optcomp.cma" optcomp_opt
-]
+ppx_lang = [ "-ppx" %asm_exe( p = "ppx_lang" ) ]

--- a/src/toplevel/build.ocp
+++ b/src/toplevel/build.ocp
@@ -3,6 +3,7 @@ begin program "learnocaml-toplevel-worker"
   requires = [
     "jsutils"
     "js_of_ocaml"
+    "js_of_ocaml.ppx"
     "toploop_jsoo"
     "toploop_results"
     "ocplib-ocamlres.runtime"
@@ -10,7 +11,7 @@ begin program "learnocaml-toplevel-worker"
   ]
   files = [
     "learnocaml_toplevel_worker_messages.mli"
-    "learnocaml_toplevel_worker_main.ml" ( pp = camlp4_js )
+    "learnocaml_toplevel_worker_main.ml" ( comp = ppx_js )
   ]
   build_rules = [
     "%{learnocaml-toplevel-worker_FULL_DST_DIR}%/learnocaml-toplevel-worker.js" (
@@ -32,9 +33,10 @@ end
 begin library "learnocaml-toplevel-history"
   requires = [
     "ocplib-json-typed"
+    "js_of_ocaml.ppx"
   ]
   files = [
-    "learnocaml_toplevel_history.ml" ( pp = camlp4_js )
+    "learnocaml_toplevel_history.ml" ( comp = ppx_js )
   ]
 end
 
@@ -43,6 +45,7 @@ begin library "learnocaml-toplevel"
     "toploop_results"
     "jsutils"
     "js_of_ocaml"
+    "js_of_ocaml.ppx"
     "ocp-indent-nlfork.lib"
     "ace"
     "ocplib-json-typed"
@@ -50,9 +53,9 @@ begin library "learnocaml-toplevel"
   ]
   files = [
     "learnocaml_toplevel_worker_messages.mli"
-    "learnocaml_toplevel_worker_caller.ml" ( pp = camlp4_js )
-    "learnocaml_toplevel_output.ml" ( pp = camlp4_js )
-    "learnocaml_toplevel_input.ml" ( pp = camlp4_js )
-    "learnocaml_toplevel.ml" ( pp = camlp4_optcomp_js )
+    "learnocaml_toplevel_worker_caller.ml" ( comp = ppx_js )
+    "learnocaml_toplevel_output.ml" ( comp = ppx_js )
+    "learnocaml_toplevel_input.ml" ( comp = ppx_js )
+    "learnocaml_toplevel.ml"
   ]
 end

--- a/src/toplevel/learnocaml_toplevel_output.ml
+++ b/src/toplevel/learnocaml_toplevel_output.ml
@@ -50,18 +50,18 @@ let setup
 
 let enforce_limit { limit ; container } =
   let container = Tyxml_js.To_dom.of_div container in
-  while container##childNodes##length > limit do
+  while container##.childNodes##.length > limit do
     Js.Opt.case
-      (container##firstChild)
+      (container##.firstChild)
       (fun () -> ())
-      (fun child -> ignore (container##removeChild (child)))
+      (fun child -> ignore (container##(removeChild child)))
   done
 
 let scroll { container ; on_resize } =
   let container = Tyxml_js.To_dom.of_div container in
   Lwt.async @@ fun () ->
   Lwt.bind (Lwt_js.yield ()) @@ fun () ->
-  container##scrollTop <- container##scrollHeight - container##clientHeight ;
+  container##.scrollTop := container##.scrollHeight - container##.clientHeight ;
   on_resize () ;
   Lwt.return_unit
 

--- a/src/toploop/build.ocp
+++ b/src/toploop/build.ocp
@@ -10,7 +10,7 @@ begin library "toploop"
     "toploop_results"
   ]
   files = [
-    "toploop_ext.ml" ( pp = camlp4_optcomp )
+    "toploop_ext.ml"
   ]
 end
 
@@ -20,7 +20,7 @@ begin library "toploop_jsoo"
     "toploop"
   ]
   files = [
-    "toploop_jsoo.ml" ( pp = camlp4_js )
+    "toploop_jsoo.ml" ( comp = ppx_js )
   ]
 end
 

--- a/src/toploop/toploop_ext.ml
+++ b/src/toploop/toploop_ext.ml
@@ -73,7 +73,6 @@ let convert_loc loc =
   let _file2,line2,col2 = Location.get_pos_info (loc.Location.loc_end) in
   { loc_start = (line1, col1) ; loc_end = (line2, col2) }
 
-#if ocaml_full_version >= (4,02,2)
 let () =
   Location.warning_printer :=
     (fun loc _fmt w ->
@@ -89,7 +88,6 @@ let () =
          let loc = convert_loc loc in
          warnings := { msg; locs = [loc]; if_highlight } :: !warnings
        end)
-#endif
 
 let return_success e = Ok (e, !warnings)
 let return_error e = Error (e, !warnings)

--- a/src/toploop/toploop_jsoo.ml
+++ b/src/toploop/toploop_jsoo.ml
@@ -68,10 +68,10 @@ let setup = lazy (
     flush stdout; flush stderr;
     let res = Buffer.contents b in
     let res = String.concat "" !stubs ^ res in
-    Js.Unsafe.global##toplevelEval(res)
+    Js.Unsafe.global##(toplevelEval res)
   in
-  Js.Unsafe.global##toplevelCompile <- compile (*XXX HACK!*);
-  Js.Unsafe.global##toplevelEval <- (fun x ->
+  Js.Unsafe.global##.toplevelCompile := compile (*XXX HACK!*);
+  Js.Unsafe.global##.toplevelEval := (fun x ->
       let f : < .. > Js.t -> < .. > Js.t = Js.Unsafe.eval_string x in
       (fun () ->
          let res = f Js.Unsafe.global in
@@ -124,7 +124,7 @@ let stop_channel_redirection redir =
         redirections :=
           List.filter (fun (ch, _) -> ch != redir.channel) !redirections ;
         let append text =
-          Firebug.console##log (Js.string text) in
+          Firebug.console##(log (Js.string text)) in
         Sys_js.set_channel_flusher redir.channel append ;
   with Not_found ->
     fail ()

--- a/src/utils/build.ocp
+++ b/src/utils/build.ocp
@@ -1,10 +1,11 @@
 begin library "jsutils"
   files = [
-    "js_utils.ml"    ( pp = camlp4_optcomp_js )
-    "lwt_request.ml" ( pp = camlp4_optcomp_js )
+    "js_utils.ml" ( comp = ppx_js )
+    "lwt_request.ml" ( comp = ppx_js )
   ]
   requires = [
     "lwt"
+    "js_of_ocaml.ppx"
     "js_of_ocaml.tyxml"
   ]
 end

--- a/src/utils/js_utils.ml
+++ b/src/utils/js_utils.ml
@@ -20,39 +20,39 @@ let doc = Dom_html.document
 let window = Dom_html.window
 let loc = Js.Unsafe.variable "location"
 
-let alert s = window##alert (Js.string s)
-let confirm s = Js.to_bool (window##confirm (Js.string s))
+let alert s = window##(alert (Js.string s))
+let confirm s = Js.to_bool (window##(confirm (Js.string s)))
 
-let js_log obj = Firebug.console##log (obj)
-let js_debug obj = Firebug.console##debug (obj)
-let js_warn obj = Firebug.console##warn (obj)
-let js_error obj = Firebug.console##error (obj)
+let js_log obj = Firebug.console##(log obj)
+let js_debug obj = Firebug.console##(debug obj)
+let js_warn obj = Firebug.console##(warn obj)
+let js_error obj = Firebug.console##(error obj)
 
 let log fmt =
   Format.kfprintf
-    (fun s -> Firebug.console##log (Js.string (Format.flush_str_formatter ())))
+    (fun s -> Firebug.console##(log (Js.string (Format.flush_str_formatter ()))))
     Format.str_formatter
     fmt
 let debug fmt =
   Format.kfprintf
-    (fun s -> Firebug.console##debug (Js.string (Format.flush_str_formatter ())))
+    (fun s -> Firebug.console##(debug (Js.string (Format.flush_str_formatter ()))))
     Format.str_formatter
     fmt
 let warn fmt =
   Format.kfprintf
-    (fun s -> Firebug.console##warn (Js.string (Format.flush_str_formatter ())))
+    (fun s -> Firebug.console##(warn (Js.string (Format.flush_str_formatter ()))))
     Format.str_formatter
     fmt
 let error fmt =
   Format.kfprintf
-    (fun s -> Firebug.console##error (Js.string (Format.flush_str_formatter ())))
+    (fun s -> Firebug.console##(error (Js.string (Format.flush_str_formatter ()))))
     Format.str_formatter
     fmt
 
 let is_hidden div =
-  div##style##display = Js.string "none"
+  div##.style##.display = Js.string "none"
 
-let reload () = window##location##reload ()
+let reload () = window##.location##reload
 
 module Manip = struct
 
@@ -80,7 +80,7 @@ module Manip = struct
            name)
       id
   let html_doc_constr : Dom_html.document Js.constr =
-    Js.Unsafe.global##_HTMLDocument
+    Js.Unsafe.global##._HTMLDocument
 
   let document elt =
     let elt = get_elt "document" elt in
@@ -89,7 +89,7 @@ module Manip = struct
       then (Obj.magic elt : Dom_html.document Js.t)
       else
         Js.Opt.case
-          (elt##parentNode)
+          (elt##.parentNode)
           (fun () -> (Obj.magic elt : Dom_html.document Js.t))
           loop
     in
@@ -97,76 +97,76 @@ module Manip = struct
 
   let window elt =
     let doc = document elt in
-    (Obj.magic doc)##defaultView
+    (Obj.magic doc)##.defaultView
 
   let clone ?(deep=false) elt =
     let elt = get_elt "clone" elt in
-    Obj.magic (elt##cloneNode (Js.bool deep))
+    Obj.magic (elt##(cloneNode (Js.bool deep)))
 
   let setInnerHtml elt s =
     let elt = get_elt "setInnerHtml" elt in
-    elt##innerHTML <- Js.string s
+    elt##.innerHTML := Js.string s
 
   let addClass elt s =
     let elt = get_elt "addClass" elt in
-    elt##classList##add(Js.string s)
+    elt##.classList##(add (Js.string s))
   let removeClass elt s =
     let elt = get_elt "removeClass" elt in
-    elt##classList##remove(Js.string s)
+    elt##.classList##(remove (Js.string s))
 
   let raw_appendChild ?before node elt2 =
     match before with
-    | None -> ignore(node##appendChild(get_node elt2))
+    | None -> ignore(node##(appendChild (get_node elt2)))
     | Some elt3 ->
       let node3 = get_node elt3 in
-      ignore(node##insertBefore(get_node elt2, Js.some node3))
+      ignore(node##(insertBefore (get_node elt2) (Js.some node3)))
 
   let raw_appendChildren ?before node elts =
     match before with
     | None ->
-      List.iter (fun elt2 -> ignore(node##appendChild(get_node elt2))) elts
+      List.iter (fun elt2 -> ignore(node##(appendChild (get_node elt2)))) elts
     | Some elt3 ->
       let node3 = get_node elt3 in
-      List.iter (fun elt2 -> ignore(node##insertBefore(get_node elt2, Js.some node3))) elts
+      List.iter (fun elt2 -> ignore(node##(insertBefore (get_node elt2) (Js.some node3)))) elts
 
   let raw_insertChildAfter node1 node2 elt3 =
     Js.Opt.case
-      (node2##nextSibling)
+      (node2##.nextSibling)
       (fun () ->
-         ignore(node1##appendChild (get_node elt3)))
+         ignore(node1##(appendChild (get_node elt3))))
       (fun node2 ->
-         ignore(node1##insertBefore (get_node elt3, Js.some node2)))
+         ignore(node1##(insertBefore (get_node elt3) (Js.some node2))))
 
   let raw_insertChildrenAfter node1 node2 elts =
     Js.Opt.case
-      (node2##nextSibling)
+      (node2##.nextSibling)
       (fun () ->
          List.iter (fun elt3 ->
-             ignore(node1##appendChild (get_node elt3))))
+             ignore(node1##(appendChild (get_node elt3)))))
       (fun node2 ->
          List.iter (fun elt3 ->
-             ignore(node1##insertBefore (get_node elt3, Js.some node2))))
+             ignore(node1##(insertBefore (get_node elt3) (Js.some node2)))))
       elts
 
   let raw_removeChild node1 elt2 =
     let node2 = get_node elt2 in
-    ignore(node1##removeChild(node2))
+    ignore(node1##(removeChild node2))
 
   let raw_replaceChild node1 elt2 elt3 =
     let node2 = get_node elt2 in
-    ignore(node1##replaceChild(node2, get_node elt3))
+    ignore(node1##(replaceChild node2 (get_node elt3)))
 
   let raw_removeChildren node =
-    let childrens = Dom.list_of_nodeList (node##childNodes) in
-    List.iter (fun c -> ignore(node##removeChild(c))) childrens
+    let childrens = Dom.list_of_nodeList (node##.childNodes) in
+    List.iter (fun c -> ignore(node##(removeChild c))) childrens
 
   let raw_replaceChildren node elts =
     raw_removeChildren node;
-    List.iter (fun elt -> ignore(node##appendChild(get_node elt))) elts
+    List.iter (fun elt -> ignore(node##(appendChild (get_node elt)))) elts
 
   let nth elt n =
     let node = get_node elt in
-    let res = Js.Opt.bind (node##childNodes##item (n)) (fun node ->
+    let res = Js.Opt.bind (node##.childNodes##(item n)) (fun node ->
         Js.Opt.map (Dom.CoerceTo.element node) (fun node ->
             Of_dom.of_element (Dom_html.element node)
           )
@@ -174,7 +174,7 @@ module Manip = struct
     Js.Opt.to_option res
 
   let by_id n =
-    let res = Js.Opt.bind (Dom_html.window##document##getElementById (Js.string n)) (fun node ->
+    let res = Js.Opt.bind (Dom_html.window##.document##(getElementById (Js.string n))) (fun node ->
         Js.Opt.map (Dom.CoerceTo.element node) (fun node ->
             Of_dom.of_element (Dom_html.element node)
           )
@@ -183,7 +183,7 @@ module Manip = struct
 
   let childLength elt =
     let node = get_node elt in
-    node##childNodes##length
+    node##.childNodes##.length
 
   let appendChild ?before elt1 elt2 =
     let node = get_node elt1 in
@@ -209,7 +209,7 @@ module Manip = struct
 
   let removeSelf elt =
     let node = get_node elt in
-    let res = Js.Opt.bind (node##parentNode) (fun node ->
+    let res = Js.Opt.bind (node##.parentNode) (fun node ->
         Js.Opt.map (Dom.CoerceTo.element node) (fun node ->
             Of_dom.of_element (Dom_html.element node)
           )
@@ -243,14 +243,14 @@ module Manip = struct
 
   let childElements elt =
     let node = get_node elt in
-    filterElements (Dom.list_of_nodeList (node##childNodes))
+    filterElements (Dom.list_of_nodeList (node##.childNodes))
 
   let children elt =
     let node = get_node elt in
-    List.map Html5.tot (Dom.list_of_nodeList (node##childNodes))
+    List.map Html5.tot (Dom.list_of_nodeList (node##.childNodes))
 
   let appendToBody ?before elt2 =
-    let body = (Of_dom.of_body Dom_html.window##document##body) in
+    let body = (Of_dom.of_body Dom_html.window##.document##.body) in
     appendChild ?before body elt2
 
   let get_elt_input name elt : Dom_html.inputElement Js.t =
@@ -279,11 +279,11 @@ module Manip = struct
 
   let scrollIntoView ?(bottom = false) elt =
     let elt = get_elt "Css.background" elt in
-    elt##scrollIntoView(Js.bool (not bottom))
+    elt##(scrollIntoView (Js.bool (not bottom)))
 
   type disable = < disabled: bool Js.t Js.prop >
   let get_disable_elt name elt : disable Js.t =
-    if Js.undefined == (Js.Unsafe.coerce @@ Html5.toelt elt)##disabled then
+    if Js.undefined == (Js.Unsafe.coerce @@ Html5.toelt elt)##.disabled then
       manip_error
         "Cannot call %s on a node without a 'disable' property"
         name;
@@ -291,36 +291,36 @@ module Manip = struct
 
   let disable elt =
     let elt = get_disable_elt "disable" elt in
-    elt##disabled <- Js._true
+    elt##.disabled := Js._true
   let enable elt =
     let elt = get_disable_elt "enable" elt in
-    elt##disabled <- Js._false
+    elt##.disabled := Js._false
 
   type focus = < focus: unit Js.meth >
   let get_focus_elt name elt : focus Js.t =
-    if Js.undefined == (Js.Unsafe.coerce @@ Html5.toelt elt)##focus then
+    if Js.undefined == (Js.Unsafe.coerce @@ Html5.toelt elt)##.focus then
       manip_error
         "Cannot call %s on a node without a 'focus' property"
         name;
     Js.Unsafe.coerce @@ Html5.toelt elt
   let focus elt =
     let elt = get_focus_elt "focus" elt in
-    elt##focus()
+    elt##focus
 
   type blur = < blur: unit Js.meth >
   let get_blur_elt name elt : blur Js.t =
-    if Js.undefined == (Js.Unsafe.coerce @@ Html5.toelt elt)##blur then
+    if Js.undefined == (Js.Unsafe.coerce @@ Html5.toelt elt)##.blur then
       manip_error
         "Cannot call %s on a node without a 'blur' property"
         name;
     Js.Unsafe.coerce @@ Html5.toelt elt
   let blur elt =
     let elt = get_blur_elt "blur" elt in
-    elt##blur()
+    elt##blur
 
   type value = < value: Js.js_string Js.t Js.prop >
   let get_value_elt name elt : value Js.t =
-    if Js.undefined == (Js.Unsafe.coerce @@ Html5.toelt elt)##value then
+    if Js.undefined == (Js.Unsafe.coerce @@ Html5.toelt elt)##.value then
       manip_error
         "Cannot call %s on a node without a 'value' property"
         name;
@@ -328,14 +328,14 @@ module Manip = struct
 
   let value elt =
     let elt = get_value_elt "value" elt in
-    Js.to_string elt##value
+    Js.to_string elt##.value
 
   module Elt = struct
     let body =
-      try Of_dom.of_body (Dom_html.window##document##body)
+      try Of_dom.of_body (Dom_html.window##.document##.body)
       with _ -> Obj.magic Js.undefined (* For workers... *)
     let active () =
-      (Js.Unsafe.coerce Dom_html.window##document)##activeElement
+      (Js.Unsafe.coerce Dom_html.window##.document)##.activeElement
   end
 
   module Ev = struct
@@ -344,749 +344,749 @@ module Manip = struct
     let bool_cb f = Dom_html.handler (fun e -> Js.bool (f e))
     let onkeyup elt f =
       let elt = get_elt "Ev.onkeyup" elt in
-      elt##onkeyup <- (bool_cb f)
+      elt##.onkeyup := (bool_cb f)
     let onkeydown elt f =
       let elt = get_elt "Ev.onkeydown" elt in
-      elt##onkeydown <- (bool_cb f)
+      elt##.onkeydown := (bool_cb f)
     let onmouseup elt f =
       let elt = get_elt "Ev.onmouseup" elt in
-      elt##onmouseup <- (bool_cb f)
+      elt##.onmouseup := (bool_cb f)
     let onmousedown elt f =
       let elt = get_elt "Ev.onmousedown" elt in
-      elt##onmousedown <- (bool_cb f)
+      elt##.onmousedown := (bool_cb f)
     let onmouseout elt f =
       let elt = get_elt "Ev.onmouseout" elt in
-      elt##onmouseout <- (bool_cb f)
+      elt##.onmouseout := (bool_cb f)
     let onmouseover elt f =
       let elt = get_elt "Ev.onmouseover" elt in
-      elt##onmouseover <- (bool_cb f)
+      elt##.onmouseover := (bool_cb f)
     let onclick elt f =
       let elt = get_elt "Ev.onclick" elt in
-      elt##onclick <- (bool_cb f)
+      elt##.onclick := (bool_cb f)
     let ondblclick elt f =
       let elt = get_elt "Ev.ondblclick" elt in
-      elt##ondblclick <- (bool_cb f)
+      elt##.ondblclick := (bool_cb f)
     let onload elt f =
       let elt = get_elt_img "Ev.onload" elt in
-      elt##onload <- (bool_cb f)
+      elt##.onload := (bool_cb f)
     let onerror elt f =
       let elt = get_elt_img "Ev.onerror" elt in
-      elt##onerror <- (bool_cb f)
+      elt##.onerror := (bool_cb f)
     let onabort elt f =
       let elt = get_elt_img "Ev.onabort" elt in
-      elt##onabort <- (bool_cb f)
+      elt##.onabort := (bool_cb f)
     let onfocus elt f =
       let elt = get_elt_input "Ev.onfocus" elt in
-      elt##onfocus <- (bool_cb f)
+      elt##.onfocus := (bool_cb f)
     let onblur elt f =
       let elt = get_elt_input "Ev.onblur" elt in
-      elt##onblur <- (bool_cb f)
+      elt##.onblur := (bool_cb f)
     let onfocus_textarea elt f =
       let elt = get_elt_textarea "Ev.onfocus" elt in
-      elt##onfocus <- (bool_cb f)
+      elt##.onfocus := (bool_cb f)
     let onblur_textarea elt f =
       let elt = get_elt_textarea "Ev.onblur" elt in
-      elt##onblur <- (bool_cb f)
+      elt##.onblur := (bool_cb f)
     let onscroll elt f =
       let elt = get_elt "Ev.onscroll" elt in
-      elt##onscroll <- (bool_cb f)
+      elt##.onscroll := (bool_cb f)
     let onreturn elt f =
       let f ev =
-	let key = ev##keyCode in
+	let key = ev##.keyCode in
 	if key = 13 then f ev;
 	true in
       onkeydown elt f
     let onchange elt f =
       let elt = get_elt_input "Ev.onchange" elt in
-      elt##onchange <- (bool_cb f)
+      elt##.onchange := (bool_cb f)
     let onchange_select elt f =
       let elt = get_elt_select "Ev.onchange_select" elt in
-      elt##onchange <- (bool_cb f)
+      elt##.onchange := (bool_cb f)
   end
 
   module Attr = struct
     let clientWidth elt =
       let elt = get_elt "Attr.clientWidth" elt in
-      elt##clientWidth
+      elt##.clientWidth
     let clientHeight elt =
       let elt = get_elt "Attr.clientHeight" elt in
-      elt##clientHeight
+      elt##.clientHeight
     let offsetWidth elt =
       let elt = get_elt "Attr.offsetWidth" elt in
-      elt##offsetWidth
+      elt##.offsetWidth
     let offsetHeight elt =
       let elt = get_elt "Attr.offsetHeight" elt in
-      elt##offsetHeight
+      elt##.offsetHeight
     let clientLeft elt =
       let elt = get_elt "Attr.clientLeft" elt in
-      elt##clientLeft
+      elt##.clientLeft
     let clientTop elt =
       let elt = get_elt "Attr.clientTop" elt in
-      elt##clientTop
+      elt##.clientTop
   end
 
   module Css = struct
     let background elt =
       let elt = get_elt "Css.background" elt in
-      Js.to_bytestring (elt##style##background)
+      Js.to_bytestring (elt##.style##.background)
     let backgroundAttachment elt =
       let elt = get_elt "Css.backgroundAttachment" elt in
-      Js.to_bytestring (elt##style##backgroundAttachment)
+      Js.to_bytestring (elt##.style##.backgroundAttachment)
     let backgroundColor elt =
       let elt = get_elt "Css.backgroundColor" elt in
-      Js.to_bytestring (elt##style##backgroundColor)
+      Js.to_bytestring (elt##.style##.backgroundColor)
     let backgroundImage elt =
       let elt = get_elt "Css.backgroundImage" elt in
-      Js.to_bytestring (elt##style##backgroundImage)
+      Js.to_bytestring (elt##.style##.backgroundImage)
     let backgroundPosition elt =
       let elt = get_elt "Css.backgroundPosition" elt in
-      Js.to_bytestring (elt##style##backgroundPosition)
+      Js.to_bytestring (elt##.style##.backgroundPosition)
     let backgroundRepeat elt =
       let elt = get_elt "Css.backgroundRepeat" elt in
-      Js.to_bytestring (elt##style##backgroundRepeat)
+      Js.to_bytestring (elt##.style##.backgroundRepeat)
     let border elt =
       let elt = get_elt "Css.border" elt in
-      Js.to_bytestring (elt##style##border)
+      Js.to_bytestring (elt##.style##.border)
     let borderBottom elt =
       let elt = get_elt "Css.borderBottom" elt in
-      Js.to_bytestring (elt##style##borderBottom)
+      Js.to_bytestring (elt##.style##.borderBottom)
     let borderBottomColor elt =
       let elt = get_elt "Css.borderBottomColor" elt in
-      Js.to_bytestring (elt##style##borderBottomColor)
+      Js.to_bytestring (elt##.style##.borderBottomColor)
     let borderBottomStyle elt =
       let elt = get_elt "Css.borderBottomStyle" elt in
-      Js.to_bytestring (elt##style##borderBottomStyle)
+      Js.to_bytestring (elt##.style##.borderBottomStyle)
     let borderBottomWidth elt =
       let elt = get_elt "Css.borderBottomWidth" elt in
-      Js.to_bytestring (elt##style##borderBottomWidth)
+      Js.to_bytestring (elt##.style##.borderBottomWidth)
     let borderBottomWidthPx elt =
       let elt = get_elt "Css.borderBottomWidthPx" elt in
-      Js.parseInt (elt##style##borderBottomWidth)
+      Js.parseInt (elt##.style##.borderBottomWidth)
     let borderCollapse elt =
       let elt = get_elt "Css.borderCollapse" elt in
-      Js.to_bytestring (elt##style##borderCollapse)
+      Js.to_bytestring (elt##.style##.borderCollapse)
     let borderColor elt =
       let elt = get_elt "Css.borderColor" elt in
-      Js.to_bytestring (elt##style##borderColor)
+      Js.to_bytestring (elt##.style##.borderColor)
     let borderLeft elt =
       let elt = get_elt "Css.borderLeft" elt in
-      Js.to_bytestring (elt##style##borderLeft)
+      Js.to_bytestring (elt##.style##.borderLeft)
     let borderLeftColor elt =
       let elt = get_elt "Css.borderLeftColor" elt in
-      Js.to_bytestring (elt##style##borderLeftColor)
+      Js.to_bytestring (elt##.style##.borderLeftColor)
     let borderLeftStyle elt =
       let elt = get_elt "Css.borderLeftStyle" elt in
-      Js.to_bytestring (elt##style##borderLeftStyle)
+      Js.to_bytestring (elt##.style##.borderLeftStyle)
     let borderLeftWidth elt =
       let elt = get_elt "Css.borderLeftWidth" elt in
-      Js.to_bytestring (elt##style##borderLeftWidth)
+      Js.to_bytestring (elt##.style##.borderLeftWidth)
     let borderLeftWidthPx elt =
       let elt = get_elt "Css.borderLeftWidthPx" elt in
-      Js.parseInt (elt##style##borderLeftWidth)
+      Js.parseInt (elt##.style##.borderLeftWidth)
     let borderRight elt =
       let elt = get_elt "Css.borderRight" elt in
-      Js.to_bytestring (elt##style##borderRight)
+      Js.to_bytestring (elt##.style##.borderRight)
     let borderRightColor elt =
       let elt = get_elt "Css.borderRightColor" elt in
-      Js.to_bytestring (elt##style##borderRightColor)
+      Js.to_bytestring (elt##.style##.borderRightColor)
     let borderRightStyle elt =
       let elt = get_elt "Css.borderRightStyle" elt in
-      Js.to_bytestring (elt##style##borderRightStyle)
+      Js.to_bytestring (elt##.style##.borderRightStyle)
     let borderRightWidth elt =
       let elt = get_elt "Css.borderRightWidth" elt in
-      Js.to_bytestring (elt##style##borderRightWidth)
+      Js.to_bytestring (elt##.style##.borderRightWidth)
     let borderRightWidthPx elt =
       let elt = get_elt "Css.borderRightWidthPx" elt in
-      Js.parseInt (elt##style##borderRightWidth)
+      Js.parseInt (elt##.style##.borderRightWidth)
     let borderSpacing elt =
       let elt = get_elt "Css.borderSpacing" elt in
-      Js.to_bytestring (elt##style##borderSpacing)
+      Js.to_bytestring (elt##.style##.borderSpacing)
     let borderStyle elt =
       let elt = get_elt "Css.borderStyle" elt in
-      Js.to_bytestring (elt##style##borderStyle)
+      Js.to_bytestring (elt##.style##.borderStyle)
     let borderTop elt =
       let elt = get_elt "Css.borderTop" elt in
-      Js.to_bytestring (elt##style##borderTop)
+      Js.to_bytestring (elt##.style##.borderTop)
     let borderTopColor elt =
       let elt = get_elt "Css.borderTopColor" elt in
-      Js.to_bytestring (elt##style##borderTopColor)
+      Js.to_bytestring (elt##.style##.borderTopColor)
     let borderTopStyle elt =
       let elt = get_elt "Css.borderTopStyle" elt in
-      Js.to_bytestring (elt##style##borderTopStyle)
+      Js.to_bytestring (elt##.style##.borderTopStyle)
     let borderTopWidth elt =
       let elt = get_elt "Css.borderTopWidth" elt in
-      Js.to_bytestring (elt##style##borderTopWidth)
+      Js.to_bytestring (elt##.style##.borderTopWidth)
     let borderTopWidthPx elt =
       let elt = get_elt "Css.borderTopWidthPx" elt in
-      Js.parseInt (elt##style##borderTopWidth)
+      Js.parseInt (elt##.style##.borderTopWidth)
     let borderWidth elt =
       let elt = get_elt "Css.borderWidth" elt in
-      Js.to_bytestring (elt##style##borderWidth)
+      Js.to_bytestring (elt##.style##.borderWidth)
     let borderWidthPx elt =
       let elt = get_elt "Css.borderWidthPx" elt in
-      Js.parseInt (elt##style##borderWidth)
+      Js.parseInt (elt##.style##.borderWidth)
     let bottom elt =
       let elt = get_elt "Css.bottom" elt in
-      Js.to_bytestring (elt##style##bottom)
+      Js.to_bytestring (elt##.style##.bottom)
     let captionSide elt =
       let elt = get_elt "Css.captionSide" elt in
-      Js.to_bytestring (elt##style##captionSide)
+      Js.to_bytestring (elt##.style##.captionSide)
     let clear elt =
       let elt = get_elt "Css.clear" elt in
-      Js.to_bytestring (elt##style##clear)
+      Js.to_bytestring (elt##.style##.clear)
     let clip elt =
       let elt = get_elt "Css.clip" elt in
-      Js.to_bytestring (elt##style##clip)
+      Js.to_bytestring (elt##.style##.clip)
     let color elt =
       let elt = get_elt "Css.color" elt in
-      Js.to_bytestring (elt##style##color)
+      Js.to_bytestring (elt##.style##.color)
     let content elt =
       let elt = get_elt "Css.content" elt in
-      Js.to_bytestring (elt##style##content)
+      Js.to_bytestring (elt##.style##.content)
     let counterIncrement elt =
       let elt = get_elt "Css.counterIncrement" elt in
-      Js.to_bytestring (elt##style##counterIncrement)
+      Js.to_bytestring (elt##.style##.counterIncrement)
     let counterReset elt =
       let elt = get_elt "Css.counterReset" elt in
-      Js.to_bytestring (elt##style##counterReset)
+      Js.to_bytestring (elt##.style##.counterReset)
     let cssFloat elt =
       let elt = get_elt "Css.cssFloat" elt in
-      Js.to_bytestring (elt##style##cssFloat)
+      Js.to_bytestring (elt##.style##.cssFloat)
     let cssText elt =
       let elt = get_elt "Css.cssText" elt in
-      Js.to_bytestring (elt##style##cssText)
+      Js.to_bytestring (elt##.style##.cssText)
     let cursor elt =
       let elt = get_elt "Css.cursor" elt in
-      Js.to_bytestring (elt##style##cursor)
+      Js.to_bytestring (elt##.style##.cursor)
     let direction elt =
       let elt = get_elt "Css.direction" elt in
-      Js.to_bytestring (elt##style##direction)
+      Js.to_bytestring (elt##.style##.direction)
     let display elt =
       let elt = get_elt "Css.display" elt in
-      Js.to_bytestring (elt##style##display)
+      Js.to_bytestring (elt##.style##.display)
     let emptyCells elt =
       let elt = get_elt "Css.emptyCells" elt in
-      Js.to_bytestring (elt##style##emptyCells)
+      Js.to_bytestring (elt##.style##.emptyCells)
     let font elt =
       let elt = get_elt "Css.font" elt in
-      Js.to_bytestring (elt##style##font)
+      Js.to_bytestring (elt##.style##.font)
     let fontFamily elt =
       let elt = get_elt "Css.fontFamily" elt in
-      Js.to_bytestring (elt##style##fontFamily)
+      Js.to_bytestring (elt##.style##.fontFamily)
     let fontSize elt =
       let elt = get_elt "Css.fontSize" elt in
-      Js.to_bytestring (elt##style##fontSize)
+      Js.to_bytestring (elt##.style##.fontSize)
     let fontStyle elt =
       let elt = get_elt "Css.fontStyle" elt in
-      Js.to_bytestring (elt##style##fontStyle)
+      Js.to_bytestring (elt##.style##.fontStyle)
     let fontVariant elt =
       let elt = get_elt "Css.fontVariant" elt in
-      Js.to_bytestring (elt##style##fontVariant)
+      Js.to_bytestring (elt##.style##.fontVariant)
     let fontWeight elt =
       let elt = get_elt "Css.fontWeight" elt in
-      Js.to_bytestring (elt##style##fontWeight)
+      Js.to_bytestring (elt##.style##.fontWeight)
     let height elt =
       let elt = get_elt "Css.height" elt in
-      Js.to_bytestring (elt##style##height)
+      Js.to_bytestring (elt##.style##.height)
     let heightPx elt =
       let elt = get_elt "Css.heightPx" elt in
-      Js.parseInt (elt##style##height)
+      Js.parseInt (elt##.style##.height)
     let left elt =
       let elt = get_elt "Css.left" elt in
-      Js.to_bytestring (elt##style##left)
+      Js.to_bytestring (elt##.style##.left)
     let leftPx elt =
       let elt = get_elt "Css.leftPx" elt in
-      Js.parseInt (elt##style##left)
+      Js.parseInt (elt##.style##.left)
     let letterSpacing elt =
       let elt = get_elt "Css.letterSpacing" elt in
-      Js.to_bytestring (elt##style##letterSpacing)
+      Js.to_bytestring (elt##.style##.letterSpacing)
     let lineHeight elt =
       let elt = get_elt "Css.lineHeight" elt in
-      Js.to_bytestring (elt##style##lineHeight)
+      Js.to_bytestring (elt##.style##.lineHeight)
     let listStyle elt =
       let elt = get_elt "Css.listStyle" elt in
-      Js.to_bytestring (elt##style##listStyle)
+      Js.to_bytestring (elt##.style##.listStyle)
     let listStyleImage elt =
       let elt = get_elt "Css.listStyleImage" elt in
-      Js.to_bytestring (elt##style##listStyleImage)
+      Js.to_bytestring (elt##.style##.listStyleImage)
     let listStylePosition elt =
       let elt = get_elt "Css.listStylePosition" elt in
-      Js.to_bytestring (elt##style##listStylePosition)
+      Js.to_bytestring (elt##.style##.listStylePosition)
     let listStyleType elt =
       let elt = get_elt "Css.listStyleType" elt in
-      Js.to_bytestring (elt##style##listStyleType)
+      Js.to_bytestring (elt##.style##.listStyleType)
     let margin elt =
       let elt = get_elt "Css.margin" elt in
-      Js.to_bytestring (elt##style##margin)
+      Js.to_bytestring (elt##.style##.margin)
     let marginBottom elt =
       let elt = get_elt "Css.marginBottom" elt in
-      Js.to_bytestring (elt##style##marginBottom)
+      Js.to_bytestring (elt##.style##.marginBottom)
     let marginBottomPx elt =
       let elt = get_elt "Css.marginBottomPx" elt in
-      Js.parseInt (elt##style##marginBottom)
+      Js.parseInt (elt##.style##.marginBottom)
     let marginLeft elt =
       let elt = get_elt "Css.marginLeft" elt in
-      Js.to_bytestring (elt##style##marginLeft)
+      Js.to_bytestring (elt##.style##.marginLeft)
     let marginLeftPx elt =
       let elt = get_elt "Css.marginLeftPx" elt in
-      Js.parseInt (elt##style##marginLeft)
+      Js.parseInt (elt##.style##.marginLeft)
     let marginRight elt =
       let elt = get_elt "Css.marginRight" elt in
-      Js.to_bytestring (elt##style##marginRight)
+      Js.to_bytestring (elt##.style##.marginRight)
     let marginRightPx elt =
       let elt = get_elt "Css.marginRightPx" elt in
-      Js.parseInt (elt##style##marginRight)
+      Js.parseInt (elt##.style##.marginRight)
     let marginTop elt =
       let elt = get_elt "Css.marginTop" elt in
-      Js.to_bytestring (elt##style##marginTop)
+      Js.to_bytestring (elt##.style##.marginTop)
     let marginTopPx elt =
       let elt = get_elt "Css.marginTopPx" elt in
-      Js.parseInt (elt##style##marginTop)
+      Js.parseInt (elt##.style##.marginTop)
     let maxHeight elt =
       let elt = get_elt "Css.maxHeight" elt in
-      Js.to_bytestring (elt##style##maxHeight)
+      Js.to_bytestring (elt##.style##.maxHeight)
     let maxHeightPx elt =
       let elt = get_elt "Css.maxHeightPx" elt in
-      Js.parseInt (elt##style##maxHeight)
+      Js.parseInt (elt##.style##.maxHeight)
     let maxWidth elt =
       let elt = get_elt "Css.maxWidth" elt in
-      Js.to_bytestring (elt##style##maxWidth)
+      Js.to_bytestring (elt##.style##.maxWidth)
     let maxWidthPx elt =
       let elt = get_elt "Css.maxWidthPx" elt in
-      Js.parseInt (elt##style##maxWidth)
+      Js.parseInt (elt##.style##.maxWidth)
     let minHeight elt =
       let elt = get_elt "Css.minHeight" elt in
-      Js.to_bytestring (elt##style##minHeight)
+      Js.to_bytestring (elt##.style##.minHeight)
     let minHeightPx elt =
       let elt = get_elt "Css.minHeightPx" elt in
-      Js.parseInt (elt##style##minHeight)
+      Js.parseInt (elt##.style##.minHeight)
     let minWidth elt =
       let elt = get_elt "Css.minWidth" elt in
-      Js.to_bytestring (elt##style##minWidth)
+      Js.to_bytestring (elt##.style##.minWidth)
     let minWidthPx elt =
       let elt = get_elt "Css.minWidthPx" elt in
-      Js.parseInt (elt##style##minWidth)
+      Js.parseInt (elt##.style##.minWidth)
     let opacity elt =
       let elt = get_elt "Css.opacity" elt in
-      option_map Js.to_bytestring (Js.Optdef.to_option (elt##style##opacity))
+      option_map Js.to_bytestring (Js.Optdef.to_option (elt##.style##.opacity))
     let outline elt =
       let elt = get_elt "Css.outline" elt in
-      Js.to_bytestring (elt##style##outline)
+      Js.to_bytestring (elt##.style##.outline)
     let outlineColor elt =
       let elt = get_elt "Css.outlineColor" elt in
-      Js.to_bytestring (elt##style##outlineColor)
+      Js.to_bytestring (elt##.style##.outlineColor)
     let outlineOffset elt =
       let elt = get_elt "Css.outlineOffset" elt in
-      Js.to_bytestring (elt##style##outlineOffset)
+      Js.to_bytestring (elt##.style##.outlineOffset)
     let outlineStyle elt =
       let elt = get_elt "Css.outlineStyle" elt in
-      Js.to_bytestring (elt##style##outlineStyle)
+      Js.to_bytestring (elt##.style##.outlineStyle)
     let outlineWidth elt =
       let elt = get_elt "Css.outlineWidth" elt in
-      Js.to_bytestring (elt##style##outlineWidth)
+      Js.to_bytestring (elt##.style##.outlineWidth)
     let overflow elt =
       let elt = get_elt "Css.overflow" elt in
-      Js.to_bytestring (elt##style##overflow)
+      Js.to_bytestring (elt##.style##.overflow)
     let overflowX elt =
       let elt = get_elt "Css.overflowX" elt in
-      Js.to_bytestring (elt##style##overflowX)
+      Js.to_bytestring (elt##.style##.overflowX)
     let overflowY elt =
       let elt = get_elt "Css.overflowY" elt in
-      Js.to_bytestring (elt##style##overflowY)
+      Js.to_bytestring (elt##.style##.overflowY)
     let padding elt =
       let elt = get_elt "Css.padding" elt in
-      Js.to_bytestring (elt##style##padding)
+      Js.to_bytestring (elt##.style##.padding)
     let paddingBottom elt =
       let elt = get_elt "Css.paddingBottom" elt in
-      Js.to_bytestring (elt##style##paddingBottom)
+      Js.to_bytestring (elt##.style##.paddingBottom)
     let paddingBottomPx elt =
       let elt = get_elt "Css.paddingBottomPx" elt in
-      Js.parseInt (elt##style##paddingBottom)
+      Js.parseInt (elt##.style##.paddingBottom)
     let paddingLeft elt =
       let elt = get_elt "Css.paddingLeft" elt in
-      Js.to_bytestring (elt##style##paddingLeft)
+      Js.to_bytestring (elt##.style##.paddingLeft)
     let paddingLeftPx elt =
       let elt = get_elt "Css.paddingLeftPx" elt in
-      Js.parseInt (elt##style##paddingLeft)
+      Js.parseInt (elt##.style##.paddingLeft)
     let paddingRight elt =
       let elt = get_elt "Css.paddingRight" elt in
-      Js.to_bytestring (elt##style##paddingRight)
+      Js.to_bytestring (elt##.style##.paddingRight)
     let paddingRightPx elt =
       let elt = get_elt "Css.paddingRightPx" elt in
-      Js.parseInt (elt##style##paddingRight)
+      Js.parseInt (elt##.style##.paddingRight)
     let paddingTop elt =
       let elt = get_elt "Css.paddingTop" elt in
-      Js.to_bytestring (elt##style##paddingTop)
+      Js.to_bytestring (elt##.style##.paddingTop)
     let paddingTopPx elt =
       let elt = get_elt "Css.paddingTopPx" elt in
-      Js.parseInt (elt##style##paddingTop)
+      Js.parseInt (elt##.style##.paddingTop)
     let pageBreakAfter elt =
       let elt = get_elt "Css.pageBreakAfter" elt in
-      Js.to_bytestring (elt##style##pageBreakAfter)
+      Js.to_bytestring (elt##.style##.pageBreakAfter)
     let pageBreakBefore elt =
       let elt = get_elt "Css.pageBreakBefore" elt in
-      Js.to_bytestring (elt##style##pageBreakBefore)
+      Js.to_bytestring (elt##.style##.pageBreakBefore)
     let position elt =
       let elt = get_elt "Css.position" elt in
-      Js.to_bytestring (elt##style##position)
+      Js.to_bytestring (elt##.style##.position)
     let right elt =
       let elt = get_elt "Css.right" elt in
-      Js.to_bytestring (elt##style##right)
+      Js.to_bytestring (elt##.style##.right)
     let rightPx elt =
       let elt = get_elt "Css.rightPx" elt in
-      Js.parseInt (elt##style##right)
+      Js.parseInt (elt##.style##.right)
     let tableLayout elt =
       let elt = get_elt "Css.tableLayout" elt in
-      Js.to_bytestring (elt##style##tableLayout)
+      Js.to_bytestring (elt##.style##.tableLayout)
     let textAlign elt =
       let elt = get_elt "Css.textAlign" elt in
-      Js.to_bytestring (elt##style##textAlign)
+      Js.to_bytestring (elt##.style##.textAlign)
     let textDecoration elt =
       let elt = get_elt "Css.textDecoration" elt in
-      Js.to_bytestring (elt##style##textDecoration)
+      Js.to_bytestring (elt##.style##.textDecoration)
     let textIndent elt =
       let elt = get_elt "Css.textIndent" elt in
-      Js.to_bytestring (elt##style##textIndent)
+      Js.to_bytestring (elt##.style##.textIndent)
     let textTransform elt =
       let elt = get_elt "Css.textTransform" elt in
-      Js.to_bytestring (elt##style##textTransform)
+      Js.to_bytestring (elt##.style##.textTransform)
     let top elt =
       let elt = get_elt "Css.top" elt in
-      Js.to_bytestring (elt##style##top)
+      Js.to_bytestring (elt##.style##.top)
     let topPx elt =
       let elt = get_elt "Css.topPx" elt in
-      Js.parseInt (elt##style##top)
+      Js.parseInt (elt##.style##.top)
     let verticalAlign elt =
       let elt = get_elt "Css.verticalAlign" elt in
-      Js.to_bytestring (elt##style##verticalAlign)
+      Js.to_bytestring (elt##.style##.verticalAlign)
     let visibility elt =
       let elt = get_elt "Css.visibility" elt in
-      Js.to_bytestring (elt##style##visibility)
+      Js.to_bytestring (elt##.style##.visibility)
     let whiteSpace elt =
       let elt = get_elt "Css.whiteSpace" elt in
-      Js.to_bytestring (elt##style##whiteSpace)
+      Js.to_bytestring (elt##.style##.whiteSpace)
     let width elt =
       let elt = get_elt "Css.width" elt in
-      Js.to_bytestring (elt##style##width)
+      Js.to_bytestring (elt##.style##.width)
     let widthPx elt =
       let elt = get_elt "Css.widthPx" elt in
-      Js.parseInt (elt##style##width)
+      Js.parseInt (elt##.style##.width)
     let wordSpacing elt =
       let elt = get_elt "Css.wordSpacing" elt in
-      Js.to_bytestring (elt##style##wordSpacing)
+      Js.to_bytestring (elt##.style##.wordSpacing)
     let zIndex elt =
       let elt = get_elt "Css.zIndex" elt in
-      Js.to_bytestring (elt##style##zIndex)
+      Js.to_bytestring (elt##.style##.zIndex)
   end
 
   module SetCss = struct
     let background elt v =
       let elt = get_elt "SetCss.background" elt in
-      elt##style##background <- Js.bytestring v
+      elt##.style##.background := Js.bytestring v
     let backgroundAttachment elt v =
       let elt = get_elt "SetCss.backgroundAttachment" elt in
-      elt##style##backgroundAttachment <- Js.bytestring v
+      elt##.style##.backgroundAttachment := Js.bytestring v
     let backgroundColor elt v =
       let elt = get_elt "SetCss.backgroundColor" elt in
-      elt##style##backgroundColor <- Js.bytestring v
+      elt##.style##.backgroundColor := Js.bytestring v
     let backgroundImage elt v =
       let elt = get_elt "SetCss.backgroundImage" elt in
-      elt##style##backgroundImage <- Js.bytestring v
+      elt##.style##.backgroundImage := Js.bytestring v
     let backgroundPosition elt v =
       let elt = get_elt "SetCss.backgroundPosition" elt in
-      elt##style##backgroundPosition <- Js.bytestring v
+      elt##.style##.backgroundPosition := Js.bytestring v
     let backgroundRepeat elt v =
       let elt = get_elt "SetCss.backgroundRepeat" elt in
-      elt##style##backgroundRepeat <- Js.bytestring v
+      elt##.style##.backgroundRepeat := Js.bytestring v
     let border elt v =
       let elt = get_elt "SetCss.border" elt in
-      elt##style##border <- Js.bytestring v
+      elt##.style##.border := Js.bytestring v
     let borderBottom elt v =
       let elt = get_elt "SetCss.borderBottom" elt in
-      elt##style##borderBottom <- Js.bytestring v
+      elt##.style##.borderBottom := Js.bytestring v
     let borderBottomColor elt v =
       let elt = get_elt "SetCss.borderBottomColor" elt in
-      elt##style##borderBottomColor <- Js.bytestring v
+      elt##.style##.borderBottomColor := Js.bytestring v
     let borderBottomStyle elt v =
       let elt = get_elt "SetCss.borderBottomStyle" elt in
-      elt##style##borderBottomStyle <- Js.bytestring v
+      elt##.style##.borderBottomStyle := Js.bytestring v
     let borderBottomWidth elt v =
       let elt = get_elt "SetCss.borderBottomWidth" elt in
-      elt##style##borderBottomWidth <- Js.bytestring v
+      elt##.style##.borderBottomWidth := Js.bytestring v
     let borderBottomWidthPx elt v = borderBottomWidth elt (Printf.sprintf "%dpx" v)
     let borderCollapse elt v =
       let elt = get_elt "SetCss.borderCollapse" elt in
-      elt##style##borderCollapse <- Js.bytestring v
+      elt##.style##.borderCollapse := Js.bytestring v
     let borderColor elt v =
       let elt = get_elt "SetCss.borderColor" elt in
-      elt##style##borderColor <- Js.bytestring v
+      elt##.style##.borderColor := Js.bytestring v
     let borderLeft elt v =
       let elt = get_elt "SetCss.borderLeft" elt in
-      elt##style##borderLeft <- Js.bytestring v
+      elt##.style##.borderLeft := Js.bytestring v
     let borderLeftColor elt v =
       let elt = get_elt "SetCss.borderLeftColor" elt in
-      elt##style##borderLeftColor <- Js.bytestring v
+      elt##.style##.borderLeftColor := Js.bytestring v
     let borderLeftStyle elt v =
       let elt = get_elt "SetCss.borderLeftStyle" elt in
-      elt##style##borderLeftStyle <- Js.bytestring v
+      elt##.style##.borderLeftStyle := Js.bytestring v
     let borderLeftWidth elt v =
       let elt = get_elt "SetCss.borderLeftWidth" elt in
-      elt##style##borderLeftWidth <- Js.bytestring v
+      elt##.style##.borderLeftWidth := Js.bytestring v
     let borderLeftWidthPx elt v = borderLeftWidth elt (Printf.sprintf "%dpx" v)
     let borderRight elt v =
       let elt = get_elt "SetCss.borderRight" elt in
-      elt##style##borderRight <- Js.bytestring v
+      elt##.style##.borderRight := Js.bytestring v
     let borderRightColor elt v =
       let elt = get_elt "SetCss.borderRightColor" elt in
-      elt##style##borderRightColor <- Js.bytestring v
+      elt##.style##.borderRightColor := Js.bytestring v
     let borderRightStyle elt v =
       let elt = get_elt "SetCss.borderRightStyle" elt in
-      elt##style##borderRightStyle <- Js.bytestring v
+      elt##.style##.borderRightStyle := Js.bytestring v
     let borderRightWidth elt v =
       let elt = get_elt "SetCss.borderRightWidth" elt in
-      elt##style##borderRightWidth <- Js.bytestring v
+      elt##.style##.borderRightWidth := Js.bytestring v
     let borderRightWidthPx elt v = borderRightWidth elt (Printf.sprintf "%dpx" v)
     let borderSpacing elt v =
       let elt = get_elt "SetCss.borderSpacing" elt in
-      elt##style##borderSpacing <- Js.bytestring v
+      elt##.style##.borderSpacing := Js.bytestring v
     let borderStyle elt v =
       let elt = get_elt "SetCss.borderStyle" elt in
-      elt##style##borderStyle <- Js.bytestring v
+      elt##.style##.borderStyle := Js.bytestring v
     let borderTop elt v =
       let elt = get_elt "SetCss.borderTop" elt in
-      elt##style##borderTop <- Js.bytestring v
+      elt##.style##.borderTop := Js.bytestring v
     let borderTopColor elt v =
       let elt = get_elt "SetCss.borderTopColor" elt in
-      elt##style##borderTopColor <- Js.bytestring v
+      elt##.style##.borderTopColor := Js.bytestring v
     let borderTopStyle elt v =
       let elt = get_elt "SetCss.borderTopStyle" elt in
-      elt##style##borderTopStyle <- Js.bytestring v
+      elt##.style##.borderTopStyle := Js.bytestring v
     let borderTopWidth elt v =
       let elt = get_elt "SetCss.borderTopWidth" elt in
-      elt##style##borderTopWidth <- Js.bytestring v
+      elt##.style##.borderTopWidth := Js.bytestring v
     let borderTopWidthPx elt v = borderTopWidth elt (Printf.sprintf "%dpx" v)
     let borderWidth elt v =
       let elt = get_elt "SetCss.borderWidth" elt in
-      elt##style##borderWidth <- Js.bytestring v
+      elt##.style##.borderWidth := Js.bytestring v
     let bottom elt v =
       let elt = get_elt "SetCss.bottom" elt in
-      elt##style##bottom <- Js.bytestring v
+      elt##.style##.bottom := Js.bytestring v
     let bottomPx elt v = bottom elt (Printf.sprintf "%dpx" v)
     let captionSide elt v =
       let elt = get_elt "SetCss.captionSide" elt in
-      elt##style##captionSide <- Js.bytestring v
+      elt##.style##.captionSide := Js.bytestring v
     let clear elt v =
       let elt = get_elt "SetCss.clear" elt in
-      elt##style##clear <- Js.bytestring v
+      elt##.style##.clear := Js.bytestring v
     let clip elt v =
       let elt = get_elt "SetCss.clip" elt in
-      elt##style##clip <- Js.bytestring v
+      elt##.style##.clip := Js.bytestring v
     let color elt v =
       let elt = get_elt "SetCss.color" elt in
-      elt##style##color <- Js.bytestring v
+      elt##.style##.color := Js.bytestring v
     let content elt v =
       let elt = get_elt "SetCss.content" elt in
-      elt##style##content <- Js.bytestring v
+      elt##.style##.content := Js.bytestring v
     let counterIncrement elt v =
       let elt = get_elt "SetCss.counterIncrement" elt in
-      elt##style##counterIncrement <- Js.bytestring v
+      elt##.style##.counterIncrement := Js.bytestring v
     let counterReset elt v =
       let elt = get_elt "SetCss.counterReset" elt in
-      elt##style##counterReset <- Js.bytestring v
+      elt##.style##.counterReset := Js.bytestring v
     let cssFloat elt v =
       let elt = get_elt "SetCss.cssFloat" elt in
-      elt##style##cssFloat <- Js.bytestring v
+      elt##.style##.cssFloat := Js.bytestring v
     let cssText elt v =
       let elt = get_elt "SetCss.cssText" elt in
-      elt##style##cssText <- Js.bytestring v
+      elt##.style##.cssText := Js.bytestring v
     let cursor elt v =
       let elt = get_elt "SetCss.cursor" elt in
-      elt##style##cursor <- Js.bytestring v
+      elt##.style##.cursor := Js.bytestring v
     let direction elt v =
       let elt = get_elt "SetCss.direction" elt in
-      elt##style##direction <- Js.bytestring v
+      elt##.style##.direction := Js.bytestring v
     let display elt v =
       let elt = get_elt "SetCss.display" elt in
-      elt##style##display <- Js.bytestring v
+      elt##.style##.display := Js.bytestring v
     let emptyCells elt v =
       let elt = get_elt "SetCss.emptyCells" elt in
-      elt##style##emptyCells <- Js.bytestring v
+      elt##.style##.emptyCells := Js.bytestring v
     let font elt v =
       let elt = get_elt "SetCss.font" elt in
-      elt##style##font <- Js.bytestring v
+      elt##.style##.font := Js.bytestring v
     let fontFamily elt v =
       let elt = get_elt "SetCss.fontFamily" elt in
-      elt##style##fontFamily <- Js.bytestring v
+      elt##.style##.fontFamily := Js.bytestring v
     let fontSize elt v =
       let elt = get_elt "SetCss.fontSize" elt in
-      elt##style##fontSize <- Js.bytestring v
+      elt##.style##.fontSize := Js.bytestring v
     let fontStyle elt v =
       let elt = get_elt "SetCss.fontStyle" elt in
-      elt##style##fontStyle <- Js.bytestring v
+      elt##.style##.fontStyle := Js.bytestring v
     let fontVariant elt v =
       let elt = get_elt "SetCss.fontVariant" elt in
-      elt##style##fontVariant <- Js.bytestring v
+      elt##.style##.fontVariant := Js.bytestring v
     let fontWeight elt v =
       let elt = get_elt "SetCss.fontWeight" elt in
-      elt##style##fontWeight <- Js.bytestring v
+      elt##.style##.fontWeight := Js.bytestring v
     let height elt v =
       let elt = get_elt "SetCss.height" elt in
-      elt##style##height <- Js.bytestring v
+      elt##.style##.height := Js.bytestring v
     let heightPx elt v = height elt (Printf.sprintf "%dpx" v)
     let left elt v =
       let elt = get_elt "SetCss.left" elt in
-      elt##style##left <- Js.bytestring v
+      elt##.style##.left := Js.bytestring v
     let leftPx elt v = left elt (Printf.sprintf "%dpx" v)
     let letterSpacing elt v =
       let elt = get_elt "SetCss.letterSpacing" elt in
-      elt##style##letterSpacing <- Js.bytestring v
+      elt##.style##.letterSpacing := Js.bytestring v
     let lineHeight elt v =
       let elt = get_elt "SetCss.lineHeight" elt in
-      elt##style##lineHeight <- Js.bytestring v
+      elt##.style##.lineHeight := Js.bytestring v
     let listStyle elt v =
       let elt = get_elt "SetCss.listStyle" elt in
-      elt##style##listStyle <- Js.bytestring v
+      elt##.style##.listStyle := Js.bytestring v
     let listStyleImage elt v =
       let elt = get_elt "SetCss.listStyleImage" elt in
-      elt##style##listStyleImage <- Js.bytestring v
+      elt##.style##.listStyleImage := Js.bytestring v
     let listStylePosition elt v =
       let elt = get_elt "SetCss.listStylePosition" elt in
-      elt##style##listStylePosition <- Js.bytestring v
+      elt##.style##.listStylePosition := Js.bytestring v
     let listStyleType elt v =
       let elt = get_elt "SetCss.listStyleType" elt in
-      elt##style##listStyleType <- Js.bytestring v
+      elt##.style##.listStyleType := Js.bytestring v
     let margin elt v =
       let elt = get_elt "SetCss.margin" elt in
-      elt##style##margin <- Js.bytestring v
+      elt##.style##.margin := Js.bytestring v
     let marginBottom elt v =
       let elt = get_elt "SetCss.marginBottom" elt in
-      elt##style##marginBottom <- Js.bytestring v
+      elt##.style##.marginBottom := Js.bytestring v
     let marginBottomPx elt v = marginBottom elt (Printf.sprintf "%dpx" v)
     let marginLeft elt v =
       let elt = get_elt "SetCss.marginLeft" elt in
-      elt##style##marginLeft <- Js.bytestring v
+      elt##.style##.marginLeft := Js.bytestring v
     let marginLeftPx elt v = marginLeft elt (Printf.sprintf "%dpx" v)
     let marginRight elt v =
       let elt = get_elt "SetCss.marginRight" elt in
-      elt##style##marginRight <- Js.bytestring v
+      elt##.style##.marginRight := Js.bytestring v
     let marginRightPx elt v = marginRight elt (Printf.sprintf "%dpx" v)
     let marginTop elt v =
       let elt = get_elt "SetCss.marginTop" elt in
-      elt##style##marginTop <- Js.bytestring v
+      elt##.style##.marginTop := Js.bytestring v
     let marginTopPx elt v = marginTop elt (Printf.sprintf "%dpx" v)
     let maxHeight elt v =
       let elt = get_elt "SetCss.maxHeight" elt in
-      elt##style##maxHeight <- Js.bytestring v
+      elt##.style##.maxHeight := Js.bytestring v
     let maxHeightPx elt v = maxHeight elt (Printf.sprintf "%dpx" v)
     let maxWidth elt v =
       let elt = get_elt "SetCss.maxWidth" elt in
-      elt##style##maxWidth <- Js.bytestring v
+      elt##.style##.maxWidth := Js.bytestring v
     let maxWidthPx elt v = maxWidth elt (Printf.sprintf "%dpx" v)
     let minHeight elt v =
       let elt = get_elt "SetCss.minHeight" elt in
-      elt##style##minHeight <- Js.bytestring v
+      elt##.style##.minHeight := Js.bytestring v
     let minHeightPx elt v = minHeight elt (Printf.sprintf "%dpx" v)
     let minWidth elt v =
       let elt = get_elt "SetCss.minWidth" elt in
-      elt##style##minWidth <- Js.bytestring v
+      elt##.style##.minWidth := Js.bytestring v
     let minWidthPx elt v = minWidth elt (Printf.sprintf "%dpx" v)
     let opacity elt v =
       let elt = get_elt "SetCss.opacity" elt in
-      elt##style##opacity <- match v with None -> Js.undefined | Some v -> Js.def (Js.bytestring v)
+      elt##.style##.opacity := match v with None -> Js.undefined | Some v -> Js.def (Js.bytestring v)
     let outline elt v =
       let elt = get_elt "SetCss.outline" elt in
-      elt##style##outline <- Js.bytestring v
+      elt##.style##.outline := Js.bytestring v
     let outlineColor elt v =
       let elt = get_elt "SetCss.outlineColor" elt in
-      elt##style##outlineColor <- Js.bytestring v
+      elt##.style##.outlineColor := Js.bytestring v
     let outlineOffset elt v =
       let elt = get_elt "SetCss.outlineOffset" elt in
-      elt##style##outlineOffset <- Js.bytestring v
+      elt##.style##.outlineOffset := Js.bytestring v
     let outlineStyle elt v =
       let elt = get_elt "SetCss.outlineStyle" elt in
-      elt##style##outlineStyle <- Js.bytestring v
+      elt##.style##.outlineStyle := Js.bytestring v
     let outlineWidth elt v =
       let elt = get_elt "SetCss.outlineWidth" elt in
-      elt##style##outlineWidth <- Js.bytestring v
+      elt##.style##.outlineWidth := Js.bytestring v
     let overflow elt v =
       let elt = get_elt "SetCss.overflow" elt in
-      elt##style##overflow <- Js.bytestring v
+      elt##.style##.overflow := Js.bytestring v
     let overflowX elt v =
       let elt = get_elt "SetCss.overflowX" elt in
-      elt##style##overflowX <- Js.bytestring v
+      elt##.style##.overflowX := Js.bytestring v
     let overflowY elt v =
       let elt = get_elt "SetCss.overflowY" elt in
-      elt##style##overflowY <- Js.bytestring v
+      elt##.style##.overflowY := Js.bytestring v
     let padding elt v =
       let elt = get_elt "SetCss.padding" elt in
-      elt##style##padding <- Js.bytestring v
+      elt##.style##.padding := Js.bytestring v
     let paddingBottom elt v =
       let elt = get_elt "SetCss.paddingBottom" elt in
-      elt##style##paddingBottom <- Js.bytestring v
+      elt##.style##.paddingBottom := Js.bytestring v
     let paddingBottomPx elt v = paddingBottom elt (Printf.sprintf "%dpx" v)
     let paddingLeft elt v =
       let elt = get_elt "SetCss.paddingLeft" elt in
-      elt##style##paddingLeft <- Js.bytestring v
+      elt##.style##.paddingLeft := Js.bytestring v
     let paddingLeftPx elt v = paddingLeft elt (Printf.sprintf "%dpx" v)
     let paddingRight elt v =
       let elt = get_elt "SetCss.paddingRight" elt in
-      elt##style##paddingRight <- Js.bytestring v
+      elt##.style##.paddingRight := Js.bytestring v
     let paddingRightPx elt v = paddingRight elt (Printf.sprintf "%dpx" v)
     let paddingTop elt v =
       let elt = get_elt "SetCss.paddingTop" elt in
-      elt##style##paddingTop <- Js.bytestring v
+      elt##.style##.paddingTop := Js.bytestring v
     let paddingTopPx elt v = paddingTop elt (Printf.sprintf "%dpx" v)
     let pageBreakAfter elt v =
       let elt = get_elt "SetCss.pageBreakAfter" elt in
-      elt##style##pageBreakAfter <- Js.bytestring v
+      elt##.style##.pageBreakAfter := Js.bytestring v
     let pageBreakBefore elt v =
       let elt = get_elt "SetCss.pageBreakBefore" elt in
-      elt##style##pageBreakBefore <- Js.bytestring v
+      elt##.style##.pageBreakBefore := Js.bytestring v
     let position elt v =
       let elt = get_elt "SetCss.position" elt in
-      elt##style##position <- Js.bytestring v
+      elt##.style##.position := Js.bytestring v
     let right elt v =
       let elt = get_elt "SetCss.right" elt in
-      elt##style##right <- Js.bytestring v
+      elt##.style##.right := Js.bytestring v
     let rightPx elt v = right elt (Printf.sprintf "%dpx" v)
     let tableLayout elt v =
       let elt = get_elt "SetCss.tableLayout" elt in
-      elt##style##tableLayout <- Js.bytestring v
+      elt##.style##.tableLayout := Js.bytestring v
     let textAlign elt v =
       let elt = get_elt "SetCss.textAlign" elt in
-      elt##style##textAlign <- Js.bytestring v
+      elt##.style##.textAlign := Js.bytestring v
     let textDecoration elt v =
       let elt = get_elt "SetCss.textDecoration" elt in
-      elt##style##textDecoration <- Js.bytestring v
+      elt##.style##.textDecoration := Js.bytestring v
     let textIndent elt v =
       let elt = get_elt "SetCss.textIndent" elt in
-      elt##style##textIndent <- Js.bytestring v
+      elt##.style##.textIndent := Js.bytestring v
     let textTransform elt v =
       let elt = get_elt "SetCss.textTransform" elt in
-      elt##style##textTransform <- Js.bytestring v
+      elt##.style##.textTransform := Js.bytestring v
     let top elt v =
       let elt = get_elt "SetCss.top" elt in
-      elt##style##top <- Js.bytestring v
+      elt##.style##.top := Js.bytestring v
     let topPx elt v = top elt (Printf.sprintf "%dpx" v)
     let verticalAlign elt v =
       let elt = get_elt "SetCss.verticalAlign" elt in
-      elt##style##verticalAlign <- Js.bytestring v
+      elt##.style##.verticalAlign := Js.bytestring v
     let visibility elt v =
       let elt = get_elt "SetCss.visibility" elt in
-      elt##style##visibility <- Js.bytestring v
+      elt##.style##.visibility := Js.bytestring v
     let whiteSpace elt v =
       let elt = get_elt "SetCss.whiteSpace" elt in
-      elt##style##whiteSpace <- Js.bytestring v
+      elt##.style##.whiteSpace := Js.bytestring v
     let width elt v =
       let elt = get_elt "SetCss.width" elt in
-      elt##style##width <- Js.bytestring v
+      elt##.style##.width := Js.bytestring v
     let widthPx elt v = width elt (Printf.sprintf "%dpx" v)
     let wordSpacing elt v =
       let elt = get_elt "SetCss.wordSpacing" elt in
-      elt##style##wordSpacing <- Js.bytestring v
+      elt##.style##.wordSpacing := Js.bytestring v
     let zIndex elt v =
       let elt = get_elt "SetCss.zIndex" elt in
-      elt##style##zIndex <- Js.bytestring v
+      elt##.style##.zIndex := Js.bytestring v
   end
 
 end
@@ -1099,28 +1099,28 @@ let window_open ?features url name =
   let features = match features with
     | None -> Js.null
     | Some s -> Js.some @@ Js.string s in
-  window##open_ (Js.string url, Js.string name, features)
+  window##(open_ (Js.string url) (Js.string name) features)
 
 module Window = struct
-  let close win = win##close ()
-  let body win = Tyxml_js.Of_dom.of_body win##document##body
-  let head win = Tyxml_js.Of_dom.of_head win##document##head
+  let close win = win##close
+  let body win = Tyxml_js.Of_dom.of_body win##.document##.body
+  let head win = Tyxml_js.Of_dom.of_head win##.document##.head
   let onunload ?(win = Dom_html.window) f =
-    win##onunload <- Dom_html.handler (fun ev -> Js.bool (f ev))
+    win##.onunload := Dom_html.handler (fun ev -> Js.bool (f ev))
   let onresize ?(win = Dom_html.window) f =
-    win##onresize <- Dom_html.handler (fun ev -> Js.bool (f ev))
+    win##.onresize := Dom_html.handler (fun ev -> Js.bool (f ev))
   let prompt ?(win = Dom_html.window) ?(value = "") msg =
     Js.Opt.case
-      (win##prompt(Js.string msg, Js.string value))
+      (win##(prompt (Js.string msg) (Js.string value)))
       (fun () -> "")
       Js.to_string
   let onhashchange ?(win = Dom_html.window) f =
-    win##onhashchange <- Dom_html.handler (fun ev -> Js.bool (f ev))
+    win##.onhashchange := Dom_html.handler (fun ev -> Js.bool (f ev))
   end
 
 
 module Document = struct
-  let uri () = Js.to_string (doc##_URL)
+  let uri () = Js.to_string (doc##._URL)
 end
 
 let parse_fragment () =
@@ -1152,7 +1152,7 @@ module MakeLocal(V: sig type t val name: string end) = struct
 
   let get_storage () =
     try
-      match Js.Optdef.to_option Dom_html.window##localStorage with
+      match Js.Optdef.to_option Dom_html.window##.localStorage with
       | None -> raise Not_found
       | Some t -> t
     with exn ->
@@ -1160,7 +1160,7 @@ module MakeLocal(V: sig type t val name: string end) = struct
         Format.sprintf
           "Warning: can't access to localStorage.\n%s@."
           (Printexc.to_string exn) in
-      Firebug.console##log (Js.string msg);
+      Firebug.console##(log (Js.string msg));
       raise Not_found
 
   let name = Js.string V.name
@@ -1168,7 +1168,7 @@ module MakeLocal(V: sig type t val name: string end) = struct
   let get () =
     try
       let s = get_storage () in
-      match Js.Opt.to_option (s##getItem(name)) with
+      match Js.Opt.to_option (s##(getItem name)) with
       | None -> None
       | Some s -> Some (Json.unsafe_input s)
     with Not_found -> None
@@ -1177,7 +1177,7 @@ module MakeLocal(V: sig type t val name: string end) = struct
     try
       let s = get_storage () in
       let str = Json.output v in
-      s##setItem(name, str)
+      s##(setItem name str)
     with Not_found -> ()
 
 end

--- a/src/utils/lwt_request.ml
+++ b/src/utils/lwt_request.ml
@@ -30,24 +30,24 @@ let get ?(headers=[]) ~url ~args =
   let url = match args with
     | [] -> url
     | _ -> url ^ "?" ^ (url_encode_list args) in
-  req##_open (Js.string "GET", Js.string url, Js._true);
-  req##setRequestHeader (Js.string "Content-type",
-			 Js.string "application/x-www-form-urlencoded");
-  List.iter (fun (n, v) -> req##setRequestHeader (Js.string n, Js.string v))
+  req##(_open (Js.string "GET") (Js.string url) (Js._true));
+  req##(setRequestHeader (Js.string "Content-type")
+			 (Js.string "application/x-www-form-urlencoded"));
+  List.iter (fun (n, v) -> req##(setRequestHeader (Js.string n) (Js.string v)))
     headers;
   let callback () =
-    match req##status with
-    | 200 -> Lwt.wakeup w (Js.to_string req##responseText)
+    match req##.status with
+    | 200 -> Lwt.wakeup w (Js.to_string req##.responseText)
     | 204 -> Lwt.wakeup w ""
     | code (* including 0 *) ->
         Lwt.wakeup_exn w
-	        (Request_failed (code, Js.to_string req##responseText)) in
-  req##onreadystatechange <- Js.wrap_callback
-      (fun _ -> (match req##readyState with
+	        (Request_failed (code, Js.to_string req##.responseText)) in
+  req##.onreadystatechange := Js.wrap_callback
+      (fun _ -> (match req##.readyState with
 	     XmlHttpRequest.DONE -> callback ()
 	   | _ -> ()));
-  req##send(Js.null);
-  Lwt.on_cancel res (fun () -> req##abort ());
+  req##(send (Js.null));
+  Lwt.on_cancel res (fun () -> req##abort);
   res
 
 let post ?(headers=[]) ?(get_args=[]) ~url ~body =
@@ -56,23 +56,23 @@ let post ?(headers=[]) ?(get_args=[]) ~url ~body =
   let url = match get_args with
     | [] -> url
     | _ -> url ^ "?" ^ (url_encode_list get_args) in
-  req##_open (Js.string "POST", Js.string url, Js._true);
-  req##setRequestHeader (Js.string "Content-type",
-			 Js.string "application/x-www-form-urlencoded");
-  List.iter (fun (n, v) -> req##setRequestHeader (Js.string n, Js.string v))
+  req##(_open (Js.string "POST") (Js.string url) (Js._true));
+  req##(setRequestHeader (Js.string "Content-type")
+			 (Js.string "application/x-www-form-urlencoded"));
+  List.iter (fun (n, v) -> req##(setRequestHeader (Js.string n) (Js.string v)))
     headers;
   let callback () =
-    match req##status with
-    | 200 -> Lwt.wakeup w (Js.to_string req##responseText)
+    match req##.status with
+    | 200 -> Lwt.wakeup w (Js.to_string req##.responseText)
     | 204 -> Lwt.wakeup w ""
     | code (* including 0 *) -> Lwt.wakeup_exn w
-	  (Request_failed (code, Js.to_string req##responseText))
+	  (Request_failed (code, Js.to_string req##.responseText))
   in
-  req##onreadystatechange <- Js.wrap_callback
-      (fun _ -> (match req##readyState with
+  req##.onreadystatechange := Js.wrap_callback
+      (fun _ -> (match req##.readyState with
 	     XmlHttpRequest.DONE -> callback ()
 	   | _ -> ()));
   let body = Js.Opt.map (Js.Opt.option body) Js.string in
-  req##send(body);
-  Lwt.on_cancel res (fun () -> req##abort ());
+  req##(send body);
+  Lwt.on_cancel res (fun () -> req##abort);
   res


### PR DESCRIPTION
and rely on js_of_ocaml.ppx instead. One reason to do this is to make the
use of a PPX for internaltionalisation easier (combining PPX and camlp4 is
problematic).