### PR TITLE
Fix `make build-deps` for opam 1.2

### DIFF
--- a/scripts/install-opam-deps.sh
+++ b/scripts/install-opam-deps.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 opam list --installed depext || opam install depext
-opam pin add --yes --no-action ocp-indent-nlfork \
-     "https://github.com/OCamlPro/ocp-indent.git#master"
-opam pin add --yes --no-action ocp-ocamlres \
-	   "https://github.com/OCamlPro/ocp-ocamlres.git"
-opam pin add --yes --no-action ocplib-json-typed 0.6
+#opam pin add --yes --no-action ocp-indent-nlfork \
+#     "https://github.com/OCamlPro/ocp-indent.git#master"
+#opam pin add --yes --no-action ocp-ocamlres \
+#	   "https://github.com/OCamlPro/ocp-ocamlres.git"
+#opam pin add --yes --no-action ocplib-json-typed 0.6
 opam pin add --yes --no-action learn-ocaml-deps src
 opam depext learn-ocaml-deps
 if opam list --installed learn-ocaml-deps

--- a/src/opam
+++ b/src/opam
@@ -20,7 +20,7 @@ depends: [
   "lwt" {= "3.1.0"}
   "ocp-indent-nlfork"
   "ocp-ocamlres"
-  "ocplib-json-typed"
+  "ocplib-json-typed" {= "0.6"}
   "optcomp"
   "pprint"
   "ppx_tools"


### PR DESCRIPTION
Removing obsolete pins that are no longer needed