### PR TITLE
A few, mainly build-related fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,12 @@ process-repo: install
           -dump-outputs ${EXERCISES_DIR} \
           -dump-reports ${EXERCISES_DIR}
 
-install:
+.PHONY: static
+static:
+	@${MAKE} -C static
+
+install: static
 	@mkdir -p ${DEST_DIR}
-	@${MAKE} -C  static
 	cp -r static/* ${DEST_DIR}
 	cp ${LESSONS_DIR}/* ${DEST_DIR}
 	@cp _obuild/*/learnocaml-main.js ${DEST_DIR}/js/
@@ -44,7 +47,7 @@ install:
 	@cp _obuild/*/learnocaml-simple-server.byte .
 
 .PHONY: learn-ocaml.install
-learn-ocaml.install:
+learn-ocaml.install: static
 	@echo 'bin: [' >$@
 	@echo '  "_obuild/learnocaml/learnocaml.byte" {"learn-ocaml"}' >>$@
 	@echo ']' >>$@

--- a/docs/exercises_tests.md
+++ b/docs/exercises_tests.md
@@ -4,7 +4,7 @@ Technical documentation about the grading infrastructure
 If you are a beginner, please read the tutorial
 `howto-write-exercises.md` first.
 
-This section explains how to write tests for exercices, using the modules
+This section explains how to write tests for exercises, using the modules
 `Test_lib`, `Introspection` and `Report` of the grader.
 
 # `test.ml` format
@@ -34,7 +34,7 @@ let () =
 
 ```
 
-The values `exercice_x` are values of type `Learnocaml_report.report`, which is
+The values `exercise_x` are values of type `Learnocaml_report.report`, which is
 a representation of the report given by the grader. In this example, each of
 these values are refering to a specific question from the exercise. Their
 content is detailed in the next section. These reports are then given to the

--- a/src/ace-lib/ace.ml
+++ b/src/ace-lib/ace.ml
@@ -84,6 +84,7 @@ let create_editor editor_div =
   let data =
     { editor; editor_div; marks = []; keybinding_menu = false; } in
   editor##.customData := (data, None);
+  editor##setOption (Js.string "displayIndentGuides") (Js.bool false);
   data
 
 let get_custom_data { editor } =

--- a/src/ace-lib/ace_types.mli
+++ b/src/ace-lib/ace_types.mli
@@ -99,6 +99,7 @@ class type ['a] editor = object
   method setSession : editSession Js.t -> unit Js.meth
   method setTheme : Js.js_string Js.t -> unit Js.meth
   method setValue : Js.js_string Js.t -> unit Js.meth
+  method setOption : Js.js_string Js.t -> 'b Js.t -> unit Js.meth
   method toggleCommentLines : unit Js.meth
   method focus : unit Js.meth
   method setFontSize : int -> unit Js.meth

--- a/src/app/build.ocp
+++ b/src/app/build.ocp
@@ -49,7 +49,6 @@ begin program "learnocaml-main"
       sources = %byte_exe( p = "learnocaml-main" )
       commands = [ {
         "js_of_ocaml"
-           "+weak.js"
            "+cstruct/cstruct.js"
            "%{ace_FULL_SRC_DIR}%/ace_bindings.js"
            %byte_exe( p = "learnocaml-main" )
@@ -79,7 +78,6 @@ begin program "learnocaml-exercise"
       sources = %byte_exe( p = "learnocaml-exercise" )
       commands = [ {
         "js_of_ocaml"
-           "+weak.js"
            "+cstruct/cstruct.js"
            "%{ace_FULL_SRC_DIR}%/ace_bindings.js"
            %byte_exe( p = "learnocaml-exercise" )

--- a/src/grader/build.ocp
+++ b/src/grader/build.ocp
@@ -138,7 +138,6 @@ begin program "learnocaml-grader-worker"
       sources = %byte_exe( p = "learnocaml-grader-worker" )
       commands = [ {
         "js_of_ocaml"
-           "+weak.js"
            "+cstruct/cstruct.js"
            "+dynlink.js"
            "+toplevel.js"

--- a/src/main/learnocaml_main.ml
+++ b/src/main/learnocaml_main.ml
@@ -128,7 +128,7 @@ module Args = struct
 
     let contents_dir =
       let default =
-        readlink (Filename.dirname (Filename.dirname (Sys.argv.(0)))
+        readlink (Filename.dirname (Filename.dirname (Sys.executable_name))
                   /"share"/"learn-ocaml"/"www")
       in
       value & opt dir default & info ["contents-dir"] ~docv:"DIR" ~doc:

--- a/src/toplevel/build.ocp
+++ b/src/toplevel/build.ocp
@@ -19,7 +19,6 @@ begin program "learnocaml-toplevel-worker"
       sources = %byte_exe( p = "learnocaml-toplevel-worker" )
       commands = [ {
         "js_of_ocaml"
-           "+weak.js"
            "+dynlink.js"
            "+toplevel.js"
            "--toplevel"


### PR DESCRIPTION
* generate the required icons
* remove double link to weak.js causing warnings
* disable the indent guides in Ace
etc.