### PR TITLE
Use staged docker containers

### DIFF
--- a/docs/howto-setup-exercise-development-environment.md
+++ b/docs/howto-setup-exercise-development-environment.md
@@ -62,13 +62,19 @@ If you do not have a GitHub account, do instead:
 git clone https://github.com/ocaml-sf/learn-ocaml.git && cd learn-ocaml
 ```
 
-Second, compile and install the platform:
+Get an opam environment (a.k.a "switch") with the learn-ocaml dependencies
+ready:
 ```
-opam install . --deps && make && make opaminstall
+opam switch create . --deps-only --locked
+eval $(opam env)
 ```
+(Alternatively, use `opam install . --deps-only` to install the dependencies in
+your current opam switch, without creating a dedicated one)
 
-Notice that the `make build-deps` command will probably ask for the
-installation of required opam packages.
+Then, compile and install the platform:
+```
+make && make opaminstall
+```
 
 At this point, you should get a working `learn-ocaml` program in
 your path. Try:


### PR DESCRIPTION
this refactors the Docker files to use multi-stage (still based on opam
2)

- run `make docker-images` to generate the images. I'll make them
  available in the docker hub for easy access

- move to the (more) stable opam2 containers for the
  `learn-ocaml-compilation` container, that is used to build the app

- use a barebones alpine container to actually run the app, which
  divides its size by 100 (~2GB to ~20MB). This is the main
  `learn-ocaml` image

- a secondary `Dockerfile.app` is provided, deriving from the
  `learn-ocaml` image, and it can be used to pre-build an instance from
  an exercise repository, and have an image that serves it
  directly (without containing the plaintext solutions).

- since most commands are now one-liners, I am not sure if the docker
  scripts in scripts/ are still useful and should be ported ?

- a few bits have also been improved, including
  - management of the `sync/` dir: use Docker "named volumes", so that it's
    persistent (and doesn't run into permission issues like binding a
    local dir directly). It's also not too difficult to recover the
    data.
  - Ctrl-c is properly handled to stop the server (using `dumb-init`)

You can already test the results of this PR using:
```
docker run --rm -v REPOSITORY:/repository -v learn-ocaml-sync:/sync -p 80:8080 --name learn-ocaml-server altgr/learn-ocaml
```

Or this server for the demo-repository, generated just by running
`docker build -f ../Dockerfile.app .` from the `demo-repository`
directory:
```
docker run --rm -v learn-ocaml-sync:/sync -p 80:8080 --name learn-ocaml-server altgr/learn-ocaml-demo
```

The servers will run on port 80 (ignore the '8080' message). If you get
an error: `cannot bind mount volume: learn-ocaml-sync volume paths must
be absolute.`, your version of Docker is too old, but you can work
around it by replacing the `-v` argument with `$PWD/sync:/sync`.
Synching the user data to the server probably won't work due to
permission issues in that case, though.