### PR TITLE
Add a lightweight console client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,13 @@ install: static
 	@cp _obuild/*/learnocaml-toplevel-worker.js ${DEST_DIR}/js/
 	@cp _obuild/*/learnocaml-grader-worker.js ${DEST_DIR}/js/
 	@cp _obuild/*/learnocaml-simple-server.byte .
+	@cp _obuild/*/learnocaml-client.byte .
 
 .PHONY: learn-ocaml.install travis
 learn-ocaml.install: static
 	@echo 'bin: [' >$@
 	@echo '  "_obuild/learnocaml/learnocaml.byte" {"learn-ocaml"}' >>$@
+	@echo '  "_obuild/learnocaml-client/learnocaml-client.byte" {"learn-ocaml-client"}' >>$@
 	@echo ']' >>$@
 	@echo 'share: [' >>$@
 	@echo '  "scripts/complete.sh"' >>$@

--- a/src/app/learnocaml_sync.ml
+++ b/src/app/learnocaml_sync.ml
@@ -93,3 +93,56 @@ let sync
     sync_map sync_snapshot
       all_exercise_toplevel_histories_a
       all_exercise_toplevel_histories_b }
+
+module Token = struct
+
+  type t = string list
+
+  let to_string = String.concat "-"
+  let to_path = String.concat (Filename.dir_sep)
+
+  let alphabet =
+    "ABCDEFGH1JKLMNOPORSTUVWXYZO1Z34SG1B9"
+  let visually_equivalent_alphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+  let parse =
+    let table = Array.make 256 None in
+    String.iter
+      (fun c -> Array.set table (Char.code c) (Some c))
+      visually_equivalent_alphabet ;
+    let translate part =
+      String.map (fun c ->
+          match Array.get table (Char.code c) with
+          | None -> failwith "bad token character"
+          | Some c -> c)
+        part in
+    fun token ->
+      if String.length token <> 15 then
+        failwith "bad token length"
+      else if String.get token 3 <> '-'
+           || String.get token 7 <> '-'
+           || String.get token 11 <> '-' then
+        failwith "bad token format"
+      else
+        List.map translate
+          [ String.sub token 0 3 ;
+            String.sub token 4 3 ;
+            String.sub token 8 3 ;
+            String.sub token 12 3 ]
+
+  let check token =
+    try ignore (parse token) ; true
+    with _ -> false
+
+  let random ?(admin=false) () =
+    let rand () = String.get alphabet (Random.int (String.length alphabet)) in
+    let part () = String.init 3 (fun _ -> rand ()) in
+    (if admin then ["X"] else []) @
+    [ part () ; part () ; part () ; part () ]
+
+  let is_admin = function
+    | "X"::_ -> true
+    | _ -> false
+
+end

--- a/src/app/learnocaml_sync.mli
+++ b/src/app/learnocaml_sync.mli
@@ -26,3 +26,13 @@ type save_file =
 val save_file_enc : save_file Json_encoding.encoding
 
 val sync : save_file -> save_file -> save_file
+
+module Token: sig
+  type t
+  val to_path: t -> string
+  val to_string: t -> string
+  val parse: string -> t
+  val check: string -> bool
+  val random: ?admin:bool -> unit -> t
+  val is_admin: t -> bool
+end

--- a/src/main/build.ocp
+++ b/src/main/build.ocp
@@ -9,3 +9,17 @@ begin program "learnocaml"
     "learnocaml-simple-server-lib"
   ]
 end
+
+begin program "learnocaml-client"
+  has_asm = false
+  files = [
+    "learnocaml_client.ml"
+  ]
+  requires = [
+    "cmdliner"
+    "lwt.unix"
+    "cohttp.lwt"
+    "grading-cli"
+    "learnocaml-sync"
+  ]
+end

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -1,0 +1,477 @@
+(* This file is part of Learn-OCaml.
+ *
+ * Copyright (C) 2018 OCamlPro.
+ *
+ * Learn-OCaml is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Learn-OCaml is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *)
+
+open Lwt.Infix
+
+module Args = struct
+  open Cmdliner
+  open Arg
+
+  type t = {
+    server_url: Uri.t;
+    solution_file: string;
+    exercise_id: string;
+    output_format: [`Console|`Json|`Html|`Raw];
+    submit: bool;
+    color: bool;
+    verbosity: int;
+    token: string option;
+  }
+
+  let url_conv =
+    conv ~docv:"URL" (
+      (fun s ->
+         try Ok (Uri.of_string s)
+         with e -> Error (`Msg (Printexc.to_string e))),
+      Uri.pp_hum
+    )
+
+  let token_conv =
+    conv ~docv:"TOKEN" (
+      (fun s ->
+         if Learnocaml_sync.Token.check s then Ok s
+         else Error (`Msg ("Invalid token "^s))),
+      (fun fmt s -> Format.pp_print_string fmt s)
+    )
+
+  let server_url =
+    value & opt url_conv (Uri.of_string "https://learn-ocaml.org") &
+    info ["s";"server"] ~docv:"URL" ~doc:
+      "The URL of the learn-ocaml server"
+      ~env:(Cmdliner.Term.env_info "LEARNOCAML_SERVER" ~doc:
+            "Sets the learn-ocaml server URL. Overriden by $(b,--server).")
+
+  let solution_file =
+    required & pos 0 (some file) None & info [] ~docv:"FILE" ~doc:
+      "The file containing the user's solution to the exercise"
+
+  let exercise_id =
+    value & opt (some string) None & info ["id"] ~docv:"ID" ~doc:
+      "The exercise identifier. If unspecified, this is inferred from the file \
+       name"
+
+  let output_format =
+    value & vflag `Console & [
+      `Console, info ["console"] ~doc:
+        "output the results to the console. This is the default";
+      `Json, info ["json"] ~doc:
+        "output the results as JSON, to stdout";
+      `Html, info ["html"] ~doc:
+        "output the results as HTML, to the console";
+      `Raw, info ["raw"] ~doc:
+        "output the results as raw text";
+    ]
+
+  let dont_submit =
+    value & flag & info ["n";"dry-run"] ~doc:
+      "Perform the grading locally, but don't submit back to the server"
+
+  let color_when =
+    let when_enum = ["always", Some true; "never", Some false; "auto", None] in
+    value & opt (enum when_enum) None & info ["color"] ~docv:"WHEN" ~doc:
+      ("Colorise the output, and also allows use of UTF-8 characters. $(docv) \
+        must be "^doc_alts_enum when_enum)
+
+  let verbose =
+    value & flag_all & info ["v";"verbose"] ~doc:
+      "Be more verbose. Can be repeated"
+
+  let token =
+    value & opt (some token_conv) None & info ["token";"t"] ~docv:"TOKEN" ~doc:
+      "Your token on the learn-ocaml server. This is required to submit \
+       solutions"
+      ~env:(Cmdliner.Term.env_info "LEARNOCAML_TOKEN" ~doc:
+              "Sets the learn-ocaml user token on the sever. Overriden by \
+               $(b,--token).")
+
+  let term =
+    let apply
+        server_url solution_file exercise_id output_format dont_submit
+        color_when verbose token =
+      let exercise_id = match exercise_id with
+        | Some id -> id
+        | None -> Filename.(remove_extension (basename solution_file))
+      in
+      let color = match color_when with
+        | Some o -> o
+        | None -> Unix.(isatty stdout) && Sys.getenv_opt "TERM" <> Some "dumb"
+      in
+      {
+        server_url;
+        solution_file;
+        exercise_id;
+        output_format;
+        submit = not dont_submit;
+        color;
+        verbosity = List.length verbose;
+        token
+      }
+    in
+    Term.(const apply
+          $server_url $solution_file $exercise_id $output_format $dont_submit
+          $color_when $verbose $token)
+end
+
+module Console = struct
+
+  let enable_colors = ref false
+  let enable_utf8 = ref false
+
+  let color cols =
+    let code = function
+      | `Bold -> "1"
+      | `Underline -> "4"
+      | `Crossed -> "9"
+      | `Black -> "30"
+      | `Red -> "31"
+      | `Green -> "32"
+      | `Yellow -> "33"
+      | `Blue -> "34"
+      | `Magenta -> "35"
+      | `Cyan -> "36"
+      | `White -> "37"
+      | `Bg `Black -> "40;37"
+      | `Bg `Red -> "41;37"
+      | `Bg `Green -> "42;30"
+      | `Bg `Yellow -> "43;30"
+      | `Bg `Blue -> "44;37"
+      | `Bg `Magenta -> "45;30"
+      | `Bg `Cyan -> "46;30"
+      | `Bg `White -> "47;30"
+    in
+    if !enable_colors then
+      Printf.sprintf "\027[%sm%s\027[m"
+        (String.concat ";" @@ (List.map code cols))
+    else
+      fun s -> s
+
+  let status_line s =
+    if !enable_colors then
+      (flush stdout; Printf.eprintf "%s..%!\r\027[K" s)
+    else
+      Printf.eprintf "%s..\n" s
+
+  let utf default c = if !enable_utf8 then c else default
+
+  let block ?title ?border_color ?text_color ?(no_open=false) s =
+    let top = utf "+" "\xe2\x94\x8c\xe2\x94\x80" (*U+250C U+2500*) in
+    let left = utf "|" "\xe2\x94\x82" (*U+2502*) in
+    let bottom = utf "`" "\xe2\x94\x94\xe2\x94\x80" (*U+2514 U+2500*) in
+    let buf = Buffer.create (String.length s + String.length s / 10) in
+    let oc = function None -> (fun s -> s) | Some col -> color col in
+    if not no_open then
+      Buffer.add_string buf (oc border_color top);
+    (match title with
+     | None -> ()
+     | Some s ->
+         match String.split_on_char '\n' s with
+         | s1::r ->
+             if not no_open then
+               Buffer.add_string buf " ";
+             Buffer.add_string buf s1;
+             Buffer.add_char buf '\n';
+             List.iter
+               (fun si ->
+                  if not no_open then
+                    (Buffer.add_string buf left;
+                     Buffer.add_string buf "  ");
+                  Buffer.add_string buf si;
+                  Buffer.add_char buf '\n')
+               r;
+             if not no_open then
+               Buffer.add_string buf left;
+         | [] -> ());
+    if not no_open then
+      Buffer.add_char buf '\n';
+    List.iter
+      (fun s ->
+         Buffer.add_string buf (oc border_color left);
+         Buffer.add_string buf "  ";
+         Buffer.add_string buf (oc text_color s);
+         Buffer.add_char buf '\n')
+      (String.split_on_char '\n' s);
+    Buffer.add_string buf (oc border_color bottom);
+    Buffer.add_char buf '\n';
+    Buffer.contents buf
+
+  let button col s =
+    let left = utf "<" "\xe2\x9d\xb0" (*U+2770*) in
+    let right = utf ">" "\xe2\x9d\xb1" (*U+2771*) in
+    color [`Bg col] left ^ color [`Bg col] s ^ color [`Bg col] right
+
+  let hline ?(width=80) () =
+    let c = utf "-" "\xe2\x94\x80" (*U+2500*) in
+    let ln = String.length c in
+    let b = Bytes.create (width * ln + 1) in
+    for i = 0 to width - 1 do String.blit c 0 b (i * ln) ln done;
+    Bytes.set b (width * ln) '\n';
+    Bytes.to_string b
+end
+
+let get_score =
+  let open Learnocaml_report in
+  let rec get_score report =
+    List.fold_left (fun acc -> function
+        | Section (_text, report) -> get_score acc report
+        | Message (_text, status) -> match status with
+          | Success i -> acc + i
+          | _ -> acc)
+      report
+  in
+  get_score 0
+
+let max_score exercise =
+  Learnocaml_exercise.(get max_score) exercise
+
+let print_score ?(max=1) ?color i =
+  let color = match color with
+    | None -> if i <= 0 then `Red else if i >= max then `Green else `Yellow
+    | Some c -> c
+  in
+  if i <= 1 then
+    Console.button color (Printf.sprintf " %3d pt  " i)
+  else 
+    Console.button color (Printf.sprintf " %3d pts " i)
+
+let console_report ?(verbose=false) exercise report =
+  let open Console in
+  let open Learnocaml_report in
+  let score = get_score report in
+  let max_score = max_score exercise in
+  print_string (hline ());
+  Printf.printf
+    "## %-72s %s\n"
+    (color [`Bold]
+       (if score <= 0 then "Exercise failed"
+        else if score >= max_score then "Exercise complete"
+        else Printf.sprintf "Exercise incomplete (%02d%%)" (100 * score / max_score)))
+    (print_score ~max:max_score score);
+  print_string (hline ());
+  print_newline ();
+  let format_text t =
+    String.concat " " @@ List.map (function
+        | Text w -> w
+        | Break -> "\n"
+        | Code s when String.contains s '\n' -> block ~border_color:[`Cyan] s
+        | Code s -> color [`Cyan] s
+        | Output s -> block ~border_color:[`Yellow] s)
+      t
+  in
+  let rec all_good report =
+    (List.for_all @@ function
+      | Section (_, report) -> all_good report
+      | Message (_, (Success _ | Informative | Warning | Important)) -> true
+      | Message (_, Failure) -> false)
+      report
+  in
+  let rec format_item = function
+    | Section (text, report) ->
+        let good = all_good report in
+        let score = get_score report in
+        let title =
+          let color =
+            if good then `Green else if score = 0 then `Red else `Yellow
+          in
+          print_score ~color score ^ " " ^ format_text text
+        in
+        if not verbose && all_good report then
+          title
+        else
+          "\n" ^ block ~title ~no_open:true
+            (String.concat "\n" @@ List.map format_item report)
+    | Message (text, Success i) ->
+        print_score i ^ "   " ^ format_text text
+    | Message (text, Failure) ->
+        print_score 0 ^ "   " ^ format_text text
+    | Message (text, Warning) ->
+        color [`Bg `Yellow] "[ warning ]" ^ "   " ^ format_text text
+    | Message (text, Informative) ->
+        format_text text
+    | Message (text, Important) ->
+        color [`Bg `Cyan]   "[important]" ^ "   " ^ format_text text
+  in
+  List.iter (fun i -> print_endline (format_item i)) report;
+  print_newline ()
+
+
+let fetch url =
+  let open Cohttp in
+  let open Cohttp_lwt_unix in
+  Client.get url >>= fun (resp, body) ->
+  match Response.status resp with
+  | `OK -> Cohttp_lwt.Body.to_string body
+  | status ->
+      Cohttp_lwt.Body.to_string body >>= fun body_str ->
+      Printf.ksprintf Lwt.fail_with
+        "Could not fetch data from server: code %d\n        %s"
+        (Code.code_of_status status)
+        body_str
+
+let fetch_exercise server_url id =
+  let exercise_json_url =
+    Uri.with_path server_url
+      (Printf.sprintf "%s/exercises/%s.json" (Uri.path server_url) id)
+  in
+  fetch exercise_json_url >|=
+  Ezjsonm.from_string >|=
+  Json_encoding.destruct Learnocaml_exercise.enc
+
+let fetch_save server_url token =
+  let sync_url =
+    Uri.with_path server_url
+      (Printf.sprintf "%s/sync/%s" (Uri.path server_url) token)
+  in
+  fetch sync_url >|= fun s ->
+  let s = if s = "" then "{}" else s in
+  Ezjsonm.from_string s |>
+  Json_encoding.destruct Learnocaml_sync.save_file_enc
+
+let upload_save server_url token save =
+  let sync_url =
+    Uri.with_path server_url
+      (Printf.sprintf "%s/sync/%s" (Uri.path server_url) token)
+  in
+  let json =
+    match Json_encoding.construct Learnocaml_sync.save_file_enc save with
+    | `A _ | `O _ as d -> d
+    | v -> `A [ v ]
+  in
+  let body = `String (Ezjsonm.to_string json) in
+  let open Cohttp in
+  let open Cohttp_lwt_unix in
+  Client.post ~body sync_url >>= fun (resp, _body) ->
+  match Response.status resp with
+  | `OK -> Lwt.return_unit
+  | status ->
+      Printf.ksprintf Lwt.fail_with
+        "Could not upload the results to the server: code %d"
+        (Code.code_of_status status)
+
+
+let upload_report server token exercise solution report =
+  let module M = Map.Make(String) in
+  let score = get_score report in
+  let max_score = max_score exercise in
+  let exercise_state =
+    { Learnocaml_exercise_state.
+      solution;
+      grade = Some (score * 100 / max_score);
+      report = Some report;
+      mtime = Unix.gettimeofday ();
+    }
+  in
+  let new_save =
+    { Learnocaml_sync.
+      all_exercise_states =
+        M.singleton (Learnocaml_exercise.(get id) exercise)
+          exercise_state;
+      all_toplevel_histories = M.empty;
+      all_exercise_toplevel_histories = M.empty;
+    }
+  in
+  fetch_save server token >>= fun save ->
+  upload_save server token (Learnocaml_sync.sync save new_save)
+
+open Args
+
+let main o =
+  Console.enable_colors := o.color;
+  Console.enable_utf8 := o.color;
+  let status_line =
+    if o.verbosity >= 2 then Printf.eprintf "%s..\n" else Console.status_line
+  in
+  status_line "Reading solution.";
+  Lwt_io.with_file ~mode:Lwt_io.Input o.solution_file Lwt_io.read
+  >>= fun solution ->
+  status_line "Fetching exercise data from server.";
+  fetch_exercise o.server_url o.exercise_id
+  >>= fun exercise ->
+  Grading_cli.get_grade ~callback:status_line ?timeout:None
+    exercise solution
+  >>= fun (report, ex_stdout, ex_stderr, ex_outcome) ->
+  flush stderr;
+  let pr col title s =
+    if o.verbosity >= 1 then
+      let s = String.trim s in
+      if s <> "" then
+        prerr_string (Console.block ~title ~border_color:[col] s)
+  in
+  pr `Green "stdout" ex_stdout;
+  pr `Red "stderr" ex_stderr;
+  pr `Cyan "outcome" ex_outcome;
+  if o.verbosity >= 1 then prerr_newline ();
+  match report with
+  | Error e ->
+      Printf.eprintf "[ERROR] Could not do the grading: %s"
+        (Printexc.to_string e);
+      Lwt.return 10
+  | Ok report ->
+      (match o.output_format with
+       | `Console -> console_report ~verbose:(o.verbosity > 0) exercise report
+       | `Raw ->
+           Learnocaml_report.print_report Format.std_formatter report
+       | `Html ->
+           Learnocaml_report.output_html_of_report Format.std_formatter report
+       | `Json ->
+           match Json_encoding.construct Learnocaml_report.report_enc report
+           with
+           | `O _ | `A _ as json -> Ezjsonm.to_channel stdout json
+           | _ -> assert false);
+      match o.token with
+      | None ->
+          Printf.eprintf
+            "[ERROR] No token specified, can not submit results to server.\n\
+            \        Get one from the web service and define %s.\n"
+            (Console.color [`Bold] "LEARNOCAML_TOKEN");
+          Lwt.return 11
+      | Some tok ->
+          upload_report o.server_url tok exercise solution report >>= fun () ->
+          Printf.eprintf "Results saved to server\n";
+          Lwt.return 0
+
+let man = [
+  `S "DESCRIPTION";
+  `P "Grades an OCaml exercise using a learn-ocaml server, and submits \
+      solutions.";
+  `S "OPTIONS";
+  `S "AUTHORS";
+  `P "Learn OCaml is written by OCamlPro. Its main authors are Benjamin Canou, \
+      Çağdaş Bozman and Grégoire Henry. It is licensed under the GNU Affero \
+      General Public License version 3: any instance of the app must provide \
+      its source code to its users.";
+  `S "BUGS";
+  `P "Bugs should be reported to \
+      $(i,https://github.com/ocaml-sf/learn-ocaml/issues)";
+]
+
+let main_cmd =
+  Cmdliner.Term.(
+    const (fun o -> Pervasives.exit (Lwt_main.run (main o)))
+    $ term),
+  Cmdliner.Term.info
+    ~man
+    ~doc:"Learn-ocaml grading client"
+    "learn-ocaml-client"
+
+let () =
+  match Cmdliner.Term.eval ~catch:false main_cmd
+  with
+  | exception Failure msg ->
+      Printf.eprintf "[ERROR] %s\n" msg;
+      exit 1
+  | `Error _ -> exit 2
+  | _ -> exit 0

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -17,19 +17,26 @@
 
 open Lwt.Infix
 
+let version = "0.1"
+
 module Args = struct
   open Cmdliner
   open Arg
 
   type t = {
-    server_url: Uri.t;
-    solution_file: string;
-    exercise_id: string;
+    server_url: Uri.t option;
+    solution_file: string option;
+    exercise_id: string option;
     output_format: [`Console|`Json|`Html|`Raw];
     submit: bool;
     color: bool;
     verbosity: int;
-    token: string option;
+    token: Learnocaml_sync.Token.t option;
+    local: bool;
+    set_options: bool;
+    print_token: bool;
+    fetch: bool;
+    version: bool;
   }
 
   let url_conv =
@@ -43,20 +50,21 @@ module Args = struct
   let token_conv =
     conv ~docv:"TOKEN" (
       (fun s ->
-         if Learnocaml_sync.Token.check s then Ok s
-         else Error (`Msg ("Invalid token "^s))),
-      (fun fmt s -> Format.pp_print_string fmt s)
+         try Ok (Learnocaml_sync.Token.parse s)
+         with Failure msg ->
+           Error (`Msg (Printf.sprintf "Invalid token %s: %s" s msg))),
+      (fun fmt t -> Format.pp_print_string fmt (Learnocaml_sync.Token.to_string t))
     )
 
   let server_url =
-    value & opt url_conv (Uri.of_string "https://learn-ocaml.org") &
+    value & opt (some url_conv) None &
     info ["s";"server"] ~docv:"URL" ~doc:
       "The URL of the learn-ocaml server"
       ~env:(Cmdliner.Term.env_info "LEARNOCAML_SERVER" ~doc:
             "Sets the learn-ocaml server URL. Overriden by $(b,--server).")
 
   let solution_file =
-    required & pos 0 (some file) None & info [] ~docv:"FILE" ~doc:
+    value & pos 0 (some file) None & info [] ~docv:"FILE" ~doc:
       "The file containing the user's solution to the exercise"
 
   let exercise_id =
@@ -98,14 +106,32 @@ module Args = struct
               "Sets the learn-ocaml user token on the sever. Overriden by \
                $(b,--token).")
 
+  let local =
+    value & flag & info ["local"] ~doc:
+      "Generate a configuration file local to the current directory, rather \
+       than user-wide"
+
+  let set_options =
+    value & flag & info ["set-options"] ~doc:
+      "Overwrite the configuration file with the command-line options \
+       ($(b,--server), $(b,--token)), and exit"
+
+  let print_token =
+    value & flag & info ["print-token"] ~doc:
+      "Just print the configured user token and exit"
+
+  let fetch =
+    value & flag & info ["fetch"] ~doc:
+      "Fetch the user's solutions on the server to the current directory and exit"
+
+  let version =
+    value & flag & info ["version"] ~doc:
+      "Print the version of this program and exit"
+
   let term =
     let apply
         server_url solution_file exercise_id output_format dont_submit
-        color_when verbose token =
-      let exercise_id = match exercise_id with
-        | Some id -> id
-        | None -> Filename.(remove_extension (basename solution_file))
-      in
+        color_when verbose token local set_options print_token fetch version =
       let color = match color_when with
         | Some o -> o
         | None -> Unix.(isatty stdout) && Sys.getenv_opt "TERM" <> Some "dumb"
@@ -118,12 +144,60 @@ module Args = struct
         submit = not dont_submit;
         color;
         verbosity = List.length verbose;
-        token
+        token;
+        local;
+        set_options;
+        print_token;
+        fetch;
+        version;
       }
     in
     Term.(const apply
           $server_url $solution_file $exercise_id $output_format $dont_submit
-          $color_when $verbose $token)
+          $color_when $verbose $token $local $set_options $print_token $fetch
+          $version)
+end
+
+module ConfigFile = struct
+
+  type t = {
+    server: Uri.t;
+    token: Learnocaml_sync.Token.t;
+  }
+
+  let local_path, user_path =
+    let ( / ) = Filename.concat in
+    Sys.getcwd () / ".learnocaml-client",
+    (try Sys.getenv "HOME" with Not_found -> ".")
+    / ".config" / "learnocaml" / "client.json"
+
+  let path ?(local=false) () =
+    if local then
+      if Sys.file_exists local_path then Some local_path else None
+    else
+      List.find_opt Sys.file_exists [local_path; user_path]
+
+  let enc =
+    let open Json_encoding in
+    conv
+      (fun {server; token} -> server, token)
+      (fun (server, token) -> {server; token}) @@
+    obj2
+      (req "server" (conv Uri.to_string Uri.of_string string))
+      (req "token" Learnocaml_sync.Token.(conv to_string parse string))
+
+  let read file =
+    Lwt_io.with_file ~mode:Lwt_io.Input file Lwt_io.read >|=
+    Ezjsonm.from_string >|=
+    Json_encoding.destruct enc
+
+  let write path t =
+    Lwt_utils.mkdir_p (Filename.dirname path) >>= fun () ->
+    Lwt_io.(with_file ~mode:Output ~perm:0o600 path) @@ fun oc ->
+    Json_encoding.construct enc t |> function
+    | `O _ | `A _ as json -> Lwt_io.write oc (Ezjsonm.to_string json)
+    | _ -> assert false
+
 end
 
 module Console = struct
@@ -220,6 +294,32 @@ module Console = struct
     for i = 0 to width - 1 do String.blit c 0 b (i * ln) ln done;
     Bytes.set b (width * ln) '\n';
     Bytes.to_string b
+
+  let rec input ?default parse =
+    flush stderr;
+    let on_empty () =
+      match default with
+      | Some d -> d
+      | None ->
+          Printf.eprintf "I beg you pardon? %!";
+          input ?default parse
+    in
+    try match read_line () with
+      | "" -> on_empty ()
+      | s ->
+          try parse s with Failure msg ->
+            Printf.eprintf "Invalid input: %s\nPlease try again: %!" msg;
+            input ?default parse
+    with
+    | End_of_file -> prerr_newline (); on_empty ()
+    | Sys.Break as e -> prerr_newline (); raise e
+
+  let yesno ?(default=false) () =
+    input ~default (fun s -> match String.lowercase_ascii s with
+        | "y" | "yes" -> true
+        | "n" | "no" -> false
+        | _ -> failwith "please answer 'y' or 'n'.")
+
 end
 
 let get_score =
@@ -244,7 +344,7 @@ let print_score ?(max=1) ?color i =
   in
   if i <= 1 then
     Console.button color (Printf.sprintf " %3d pt  " i)
-  else 
+  else
     Console.button color (Printf.sprintf " %3d pts " i)
 
 let console_report ?(verbose=false) exercise report =
@@ -315,16 +415,17 @@ let fetch url =
   match Response.status resp with
   | `OK -> Cohttp_lwt.Body.to_string body
   | status ->
-      Cohttp_lwt.Body.to_string body >>= fun body_str ->
       Printf.ksprintf Lwt.fail_with
-        "Could not fetch data from server: code %d\n        %s"
+        "Error contacting learn-ocaml server: code %d"
         (Code.code_of_status status)
-        body_str
+
+let server_path server_url path =
+  Uri.with_path server_url @@
+  String.concat "/" (Uri.path server_url :: path)
 
 let fetch_exercise server_url id =
   let exercise_json_url =
-    Uri.with_path server_url
-      (Printf.sprintf "%s/exercises/%s.json" (Uri.path server_url) id)
+    server_path server_url ["exercises"; id ^ ".json"]
   in
   fetch exercise_json_url >|=
   Ezjsonm.from_string >|=
@@ -332,8 +433,7 @@ let fetch_exercise server_url id =
 
 let fetch_save server_url token =
   let sync_url =
-    Uri.with_path server_url
-      (Printf.sprintf "%s/sync/%s" (Uri.path server_url) token)
+    server_path server_url ["sync"; Learnocaml_sync.Token.to_string token]
   in
   fetch sync_url >|= fun s ->
   let s = if s = "" then "{}" else s in
@@ -342,8 +442,7 @@ let fetch_save server_url token =
 
 let upload_save server_url token save =
   let sync_url =
-    Uri.with_path server_url
-      (Printf.sprintf "%s/sync/%s" (Uri.path server_url) token)
+    server_path server_url ["sync"; Learnocaml_sync.Token.to_string token]
   in
   let json =
     match Json_encoding.construct Learnocaml_sync.save_file_enc save with
@@ -361,9 +460,21 @@ let upload_save server_url token save =
         "Could not upload the results to the server: code %d"
         (Code.code_of_status status)
 
+module StringMap = Map.Make(String)
+
+let write_save_files save =
+  Lwt_list.iter_s (fun (id, st) ->
+      let f = Filename.concat (Sys.getcwd ()) (id ^ ".ml") in
+      if Sys.file_exists f then
+        (Printf.eprintf "File %s already exists, not overwriting.\n" f;
+         Lwt.return_unit)
+      else
+        Lwt_io.(with_file ~mode:Output ~perm:0o600 f) @@ fun oc ->
+        Lwt_io.write oc st.Learnocaml_exercise_state.solution >|= fun () ->
+        Printf.eprintf "Wrote file %s\n%!" f)
+    (StringMap.bindings (save.Learnocaml_sync.all_exercise_states))
 
 let upload_report server token exercise solution report =
-  let module M = Map.Make(String) in
   let score = get_score report in
   let max_score = max_score exercise in
   let exercise_state =
@@ -377,28 +488,114 @@ let upload_report server token exercise solution report =
   let new_save =
     { Learnocaml_sync.
       all_exercise_states =
-        M.singleton (Learnocaml_exercise.(get id) exercise)
+        StringMap.singleton (Learnocaml_exercise.(get id) exercise)
           exercise_state;
-      all_toplevel_histories = M.empty;
-      all_exercise_toplevel_histories = M.empty;
+      all_toplevel_histories = StringMap.empty;
+      all_exercise_toplevel_histories = StringMap.empty;
     }
   in
   fetch_save server token >>= fun save ->
   upload_save server token (Learnocaml_sync.sync save new_save)
 
-open Args
+let init ?(local=false) ?server ?token () =
+  let path = if local then ConfigFile.local_path else ConfigFile.user_path in
+  let default_server = Uri.of_string "http://learn-ocaml.org" in
+  let server =
+    match server with
+    | Some s -> s
+    | None ->
+        Printf.eprintf
+          "Please specify the address of the learn-ocaml server to use \
+           [default: %s]: " (Uri.to_string default_server);
+        let uri s =
+          let u = Uri.of_string s in
+          match Uri.scheme u with
+          | None -> Uri.with_scheme u (Some "http")
+          | Some ("http" (* | "https" *)) -> u
+          | Some s ->
+              failwith (Printf.sprintf
+                          "unsupported scheme %S, please use http://."
+                          s)
+        in
+        Console.input ~default:default_server uri
+  in
+  let get_new_token () =
+    let url = server_path server ["sync"; "gimme"] in
+    fetch url >|=
+    Ezjsonm.from_string >|=
+    Json_encoding.(
+      destruct @@ conv
+        Learnocaml_sync.Token.to_string Learnocaml_sync.Token.parse
+        (obj1 (req "token" string)))
+  in
+  let get_token () =
+    match token with
+    | Some t -> Lwt.return t
+    | None ->
+        Printf.eprintf
+          "Please provide your user token on %s (leave empty to generate one): "
+          (Uri.to_string server);
+        match
+          Console.input ~default:None
+            (fun s -> Some (Learnocaml_sync.Token.parse s))
+        with
+        | Some t -> Lwt.return t
+        | None -> get_new_token ()
+  in
+  get_token () >>= fun token ->
+  let config = { ConfigFile. server; token } in
+  ConfigFile.write path config >|= fun () ->
+  Printf.eprintf "Configuration written to %s\n%!" path;
+  config
+
+let get_config ?local ?(save_back=false) server_opt token_opt =
+  match ConfigFile.path ?local () with
+  | Some f ->
+      ConfigFile.read f >>= fun c ->
+      let c = match server_opt with
+        | None -> c
+        | Some server -> { c with ConfigFile.server }
+      in
+      let c = match token_opt with
+        | None -> c
+        | Some token -> { c with ConfigFile.token}
+      in
+      (if save_back then
+         ConfigFile.write f c >|= fun () ->
+         Printf.eprintf "Configuration written to %s\n%!" f;
+         exit 0
+       else Lwt.return_unit)
+      >|= fun () -> c
+  | None -> init ?local ?server:server_opt ?token:token_opt ()
 
 let main o =
-  Console.enable_colors := o.color;
-  Console.enable_utf8 := o.color;
+  Console.enable_colors := o.Args.color;
+  Console.enable_utf8 := o.Args.color;
+  if o.Args.version then
+    (print_endline version; exit 0);
+  let open Args in
+  get_config ~local:o.local ~save_back:o.set_options o.server_url o.token
+  >>= fun { ConfigFile.server; token } ->
+  if o.print_token then
+    (print_endline (Learnocaml_sync.Token.to_string token);
+     exit 0);
+  (if o.fetch then
+     (fetch_save server token >>= write_save_files >>= fun () -> exit 0)
+   else Lwt.return_unit) >>= fun () ->
   let status_line =
     if o.verbosity >= 2 then Printf.eprintf "%s..\n" else Console.status_line
   in
+  let solution, exercise_id =
+    match o.solution_file, o.exercise_id with
+    | None, _ -> Printf.eprintf "You must specify a file to grade.\n%!"; exit 2
+    | Some f, None -> f, Filename.(remove_extension (basename f))
+    | Some f, Some id -> f, id
+  in
   status_line "Reading solution.";
-  Lwt_io.with_file ~mode:Lwt_io.Input o.solution_file Lwt_io.read
+  Lwt_io.with_file ~mode:Lwt_io.Input solution Lwt_io.read
   >>= fun solution ->
   status_line "Fetching exercise data from server.";
-  fetch_exercise o.server_url o.exercise_id
+  fetch_exercise server exercise_id
   >>= fun exercise ->
   Grading_cli.get_grade ~callback:status_line ?timeout:None
     exercise solution
@@ -431,17 +628,9 @@ let main o =
            with
            | `O _ | `A _ as json -> Ezjsonm.to_channel stdout json
            | _ -> assert false);
-      match o.token with
-      | None ->
-          Printf.eprintf
-            "[ERROR] No token specified, can not submit results to server.\n\
-            \        Get one from the web service and define %s.\n"
-            (Console.color [`Bold] "LEARNOCAML_TOKEN");
-          Lwt.return 11
-      | Some tok ->
-          upload_report o.server_url tok exercise solution report >>= fun () ->
-          Printf.eprintf "Results saved to server\n";
-          Lwt.return 0
+      upload_report server token exercise solution report >>= fun () ->
+      Printf.eprintf "Results saved to server\n";
+      Lwt.return 0
 
 let man = [
   `S "DESCRIPTION";
@@ -461,7 +650,7 @@ let man = [
 let main_cmd =
   Cmdliner.Term.(
     const (fun o -> Pervasives.exit (Lwt_main.run (main o)))
-    $ term),
+    $ Args.term),
   Cmdliner.Term.info
     ~man
     ~doc:"Learn-ocaml grading client"

--- a/src/main/learnocaml_main.ml
+++ b/src/main/learnocaml_main.ml
@@ -193,24 +193,6 @@ module Args = struct
           $Grader.term $Builder.term $Server.term)
 end
 
-let copy_tree src dst =
-  Lwt.catch (fun () ->
-      Lwt_unix.file_exists dst >>= (function
-          | true -> Lwt.return_unit
-          | false -> Lwt_unix.mkdir dst 0o755) >>= fun () ->
-      let cmd =
-        Array.concat
-          [[|"cp"; "-PR"|];
-           Array.map (Filename.concat src) (Sys.readdir src);
-           [|dst|]]
-      in
-      Lwt_process.exec ("", cmd) >>= fun r ->
-      if r <> Unix.WEXITED 0 then Lwt.fail_with "copy_tree"
-      else Lwt.return_unit)
-    (function
-      | Sys_error _ | Unix.Unix_error _ -> Lwt.fail_with "copy_tree"
-      | e -> raise e)
-
 open Args
 
 let main o =
@@ -229,7 +211,7 @@ let main o =
     if List.mem Build o.commands then
       (Printf.printf "Updating app at %s\n%!" o.app_dir;
        Lwt.catch
-         (fun () -> copy_tree o.builder.Builder.contents_dir o.app_dir)
+         (fun () -> Lwt_utils.copy_tree o.builder.Builder.contents_dir o.app_dir)
          (function
            | Failure _ ->
                Lwt.fail_with @@ Printf.sprintf

--- a/src/repo/build.ocp
+++ b/src/repo/build.ocp
@@ -10,6 +10,7 @@ begin library "learnocaml-repository"
     "ocplib-json-typed"
     "xor"
     "lwt"
+    "lwt_utils"
   ]
 end
 

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -148,9 +148,7 @@ let main dest_dir =
     | Some exercises_index -> exercises_index
     | None -> !exercises_dir / "index.json" in
   let exercises_dest_dir = dest_dir / Learnocaml_index.exercises_dir in
-  Lwt_unix.file_exists exercises_dest_dir >>= fun exists ->
-  (if exists then Lwt.return_unit
-   else Lwt_unix.mkdir exercises_dest_dir 0o755) >>= fun () ->
+  Lwt_utils.mkdir_p exercises_dest_dir >>= fun () ->
   Lwt.catch
     (fun () ->
        (if Sys.file_exists exercises_index then

--- a/src/repo/learnocaml_process_tutorial_repository.ml
+++ b/src/repo/learnocaml_process_tutorial_repository.ml
@@ -65,9 +65,7 @@ let main dest_dir =
     | None -> !tutorials_dir / "index.json" in
   let tutorials_dest_dir =
     dest_dir / Learnocaml_index.tutorials_dir in
-  Lwt_unix.file_exists tutorials_dest_dir >>= fun exists ->
-  (if exists then Lwt.return_unit
-   else Lwt_unix.mkdir tutorials_dest_dir 0o755) >>= fun () ->
+  Lwt_utils.mkdir_p tutorials_dest_dir >>= fun () ->
   Lwt.catch
     (fun () ->
        (if Sys.file_exists tutorials_index then

--- a/src/simple-server/learnocaml_simple_server.ml
+++ b/src/simple-server/learnocaml_simple_server.ml
@@ -68,21 +68,9 @@ let check_save_file contents =
   with _ -> false
 
 let create_token_file token =
-  let rec mkdir_p dir =
-    Lwt_unix.file_exists dir >>= function
-    | true ->
-        if Sys.is_directory dir then
-          Lwt.return ()
-        else
-          Lwt.fail (Failure "bad sync directory structure")
-    | false ->
-        mkdir_p (Filename.dirname dir) >>= fun () ->
-        Lwt_unix.mkdir dir 0o750
-  in
   let path = Filename.concat !sync_dir (Learnocaml_sync.Token.to_path token) in
-  mkdir_p (Filename.dirname path) >>= fun () ->
-  Lwt_io.(with_file ~mode: Output path (fun chan -> write chan "")) >>= fun () ->
-  Lwt.return_unit
+  Lwt_utils.mkdir_p ~perm:0o700 (Filename.dirname path) >>= fun () ->
+  Lwt_io.(with_file ~mode: Output ~perm:0o700 path (fun chan -> write chan ""))
 
 let store token contents =
   let token = Learnocaml_sync.Token.parse token in

--- a/src/simple-server/learnocaml_simple_server.ml
+++ b/src/simple-server/learnocaml_simple_server.ml
@@ -32,7 +32,7 @@ let args = Arg.align @@
 open Lwt.Infix
 
 let read_static_file path =
-  let rec shorten path =
+  let shorten path =
     let rec resolve acc = function
       | [] -> List.rev acc
       | "." :: rest -> resolve acc rest
@@ -46,44 +46,11 @@ let read_static_file path =
     String.concat Filename.dir_sep (!static_dir :: shorten path) in
   Lwt_io.(with_file ~mode: Input path (fun chan -> read chan))
 
-let alphabet =
-  "ABCDEFGH1JKLMNOPORSTUVWXYZO1Z34SG1B9"
-let visually_equivalent_alphabet =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-let parse_token =
-  let table = Array.make 256 None in
-  String.iter
-    (fun c -> Array.set table (Char.code c) (Some c))
-    visually_equivalent_alphabet ;
-  let translate part =
-    String.map (fun c ->
-        match Array.get table (Char.code c) with
-        | None -> failwith "bad token character"
-        | Some c -> c)
-      part in
-  fun token ->
-    if String.length token <> 15 then
-      failwith "bad token length"
-    else if String.get token 3 <> '-'
-         || String.get token 7 <> '-'
-         || String.get token 11 <> '-' then
-      failwith "bad token format"
-    else
-      List.map translate
-        [ String.sub token 0 3 ;
-          String.sub token 4 3 ;
-          String.sub token 8 3 ;
-          String.sub token 12 3 ]
-
-let check_token token =
-  try ignore (parse_token token) ; true
-  with _ -> false
-
 let retrieve token =
   Lwt.catch (fun () ->
       let path =
-        String.concat Filename.dir_sep (!sync_dir :: parse_token token) in
+        Filename.concat !sync_dir
+          Learnocaml_sync.Token.(to_path (parse token)) in
       Lwt_io.(with_file ~mode: Input path (fun chan -> read chan)))
   @@ function
   | Unix.Unix_error (Unix.ENOENT, _, _) -> raise Not_found
@@ -101,45 +68,38 @@ let check_save_file contents =
   with _ -> false
 
 let create_token_file token =
-  let rec create acc path =
-    begin if Sys.file_exists acc then
-        if Sys.is_directory acc then
+  let rec mkdir_p dir =
+    Lwt_unix.file_exists dir >>= function
+    | true ->
+        if Sys.is_directory dir then
           Lwt.return ()
         else
           Lwt.fail (Failure "bad sync directory structure")
-      else
-        Lwt_unix.mkdir acc 0o750
-    end >>= fun () ->
-    match path with
-    | [] -> assert false
-    | [ file ] ->
-        let fn = (Filename.concat acc file) in
-        Lwt_io.(with_file ~mode: Output fn (fun chan -> write chan "")) >>= fun () ->
-        Lwt.return_unit
-    | dir :: path ->
-        create (Filename.concat acc dir) path
+    | false ->
+        mkdir_p (Filename.dirname dir) >>= fun () ->
+        Lwt_unix.mkdir dir 0o750
   in
-  create !sync_dir token
+  let path = Filename.concat !sync_dir (Learnocaml_sync.Token.to_path token) in
+  mkdir_p (Filename.dirname path) >>= fun () ->
+  Lwt_io.(with_file ~mode: Output path (fun chan -> write chan "")) >>= fun () ->
+  Lwt.return_unit
 
 let store token contents =
-  let token = parse_token token in
+  let token = Learnocaml_sync.Token.parse token in
   let path =
-    String.concat Filename.dir_sep (!sync_dir :: token) in
+    Filename.concat !sync_dir
+      (Learnocaml_sync.Token.to_path token) in
   (if not (Sys.file_exists path) then create_token_file token
    else Lwt.return_unit) >>= fun _ ->
   Lwt_io.(with_file ~mode: Output path (fun chan -> write chan contents))
 
-let gimme () =
-  let rec next () =
-    let rand () = String.get alphabet (Random.int (String.length alphabet)) in
-    let part () = String.init 3 (fun _ -> rand ()) in
-    let token = [ part () ; part () ; part () ; part () ] in
-    if Sys.file_exists (String.concat Filename.dir_sep (!sync_dir :: token)) then
-      next ()
-    else
-      create_token_file token >|= fun () -> String.concat "-" token
-  in
-  next ()
+let rec gimme () =
+  let token = Learnocaml_sync.Token.random () in
+  if Sys.file_exists (Learnocaml_sync.Token.to_path token) then
+    gimme ()
+  else
+    create_token_file token >|= fun () ->
+    Learnocaml_sync.Token.to_string token
 
 
 exception Too_long_body
@@ -192,7 +152,7 @@ let launch () =
         gimme () >>= fun token ->
         let body = Printf.sprintf "{\"token\":\"%s\"}" token in
         Server.respond_string ~status:`OK ~body ()
-    | `GET, [ "sync" ; token ] when check_token token ->
+    | `GET, [ "sync" ; token ] when Learnocaml_sync.Token.check token ->
         (Lwt.catch
            (fun () ->
               retrieve token >>= fun body ->
@@ -200,7 +160,7 @@ let launch () =
          @@ function
          | Not_found -> Server.respond_string ~status:`OK ~body:"" ()
          | e -> raise e)
-    | `POST, [ "sync" ; token ] when check_token token -> begin
+    | `POST, [ "sync" ; token ] when Learnocaml_sync.Token.check token -> begin
         string_of_stream (Cohttp_lwt.Body.to_stream body) >>= function
         | None ->
             Server.respond_string ~status:`Bad_request ~body: "Too much data" ()

--- a/src/state/learnocaml_report.ml
+++ b/src/state/learnocaml_report.ml
@@ -269,7 +269,7 @@ let format_report items =
             } else {\
             div.classList.add ('folded') ;\
             }" in
-  E ("div", [ "class", "folded" ; "id", "learnocaml-report" ],
+  E ("div", [ "id", "learnocaml-report" ],
      [E ("div", [ "class", " section " ^ result_class ],
          [ E ("span", [ "class", "title clickable" ; "onclick", js], score) ]) ;
       E ("div", [ "class", "main" ], report) ])

--- a/src/utils/build.ocp
+++ b/src/utils/build.ocp
@@ -31,6 +31,16 @@ begin library "ocplib_i18n"
   ]
 end
 
+begin library "lwt_utils"
+  has_asm = true
+  has_byte = true
+  requires = [
+    "lwt.unix"
+  ]
+  files = [
+    "lwt_utils.ml"
+  ]
+end
 
 begin library "xor"
   has_asm = true


### PR DESCRIPTION
Supported:
- documented CLI interface
- fetching an exercise data from the server
- grading an ml file for the given exercise
- reporting to the console, to json or HTML
- submitting the solution back to the server

To do:
- creation of a new token
- a conf file to memorise it (without relying on an env variable)
- fetching all the submitted exercises for a given token

Related but a different todo:
- keeping track of older versions on the server