### PR TITLE
Update `meta.json` encoding

### DIFF
--- a/docs/exercises_format.md
+++ b/docs/exercises_format.md
@@ -72,6 +72,8 @@ Json description in version "2" contains more metadata:
   "learnocaml_version" : "2",
   "kind"               : "exercise" | "problem" | "project",
   "stars"              : [1 .. 5],
+  /* Exercise title, falls back to 'title.txt' if the field is not present. */
+  "title"              : "Title of the exercise",
   /* In an exercise repository, each exercise must have a unique identifier. */
   "identifier"         : "some_unique_identifier",
   /* Authors with their emails. */
@@ -84,12 +86,15 @@ Json description in version "2" contains more metadata:
   "forward_exercises"  : [ "exercise1", "exercise2", ... ],
   /* The suggested exercises in case of difficulty */
   "backward_exercises" : [ "exercise1", "exercise2", ... ],
+  /* Maximum score for the exercise. */
+  "max_score" : [ 0 .. n ],
 }
 ```
 
 ### title.txt
 
-Text file containing the title of the exercise.
+Text file containing the title of the exercise. Overridden by the field `title`
+in `meta.json` if present.
 
 ### descr.html
 
@@ -126,3 +131,8 @@ the user's code by comparing its results with a code reference.
 OCaml file containing the test program that is used to check and grade the user's code and
 the solution. It has access to many functions allowing the introspection of the
 code, which will be described and detailed in another section.
+
+### max_score.txt
+
+Maximum score that is possible to get for this exercise, even if the grader
+grades more. Overridden by the field `max_score`, if present in `meta.json`.

--- a/src/repo/learnocaml_index.ml
+++ b/src/repo/learnocaml_index.ml
@@ -35,6 +35,7 @@ type exercise =
     exercise_requirements : string list ;
     exercise_forward : identifier list ;
     exercise_backward : identifier list ;
+    exercise_max_score : int option ;
   }
 
 and group =
@@ -84,6 +85,23 @@ let exercise_kind_enc =
       "project", Project ;
       "exercise", Learnocaml_exercise ]
 
+let exercise_enc_v1 =
+  (obj10
+     (req "kind" exercise_kind_enc)
+     (req "title" string)
+     (opt "shortDescription" string)
+     (req "stars" float)
+     (opt "identifier" string)
+     (req "author" (list (tup2 string string)))
+     (req "focus" (list string))
+     (req "requirements" (list string))
+     (req "forward" (list string))
+     (req "backward" (list string)))
+
+let exercise_enc_v2 =
+  obj1
+    (opt "max_score" int)
+
 let exercise_enc =
   conv
     (fun { exercise_kind = kind ;
@@ -96,11 +114,14 @@ let exercise_enc =
            exercise_requirements = requirements ;
            exercise_forward = forward ;
            exercise_backward = backward ;
+           exercise_max_score = max_score ;
          } ->
-      (kind, title, short, stars, identifier,
-       author, focus, requirements, forward, backward))
-    (fun (kind, title, short, stars, identifier,
-       author, focus, requirements, forward, backward) ->
+      ((kind, title, short, stars, identifier,
+        author, focus, requirements, forward, backward),
+       max_score))
+    (fun ((kind, title, short, stars, identifier,
+           author, focus, requirements, forward, backward),
+          max_score) ->
        { exercise_kind = kind ;
          exercise_title = title ;
          exercise_short_description = short ;
@@ -111,18 +132,11 @@ let exercise_enc =
          exercise_requirements = requirements ;
          exercise_forward = forward ;
          exercise_backward = backward ;
+         exercise_max_score = max_score ;
        })
-    (obj10
-       (req "kind" exercise_kind_enc)
-       (req "title" string)
-       (opt "shortDescription" string)
-       (req "stars" float)
-       (opt "identifier" string)
-       (req "author" (list (tup2 string string)))
-       (req "focus" (list string))
-       (req "requirements" (list string))
-       (req "forward" (list string))
-       (req "backward" (list string)))
+    (merge_objs
+       exercise_enc_v1
+       exercise_enc_v2)
 
 let server_exercise_meta_enc =
   check_version_2 exercise_enc

--- a/src/repo/learnocaml_index.ml
+++ b/src/repo/learnocaml_index.ml
@@ -22,11 +22,20 @@ type exercise_kind =
   | Problem
   | Learnocaml_exercise
 
+type identifier = string
+
 type exercise =
   { exercise_kind : exercise_kind ;
     exercise_title : string ;
     exercise_short_description : string option ;
-    exercise_stars : float (* \in [0.,4.] *) }
+    exercise_stars : float (* \in [0.,4.] *);
+    exercise_identifier : identifier option ;
+    exercise_author : (string * string) list ;
+    exercise_focus : string list ;
+    exercise_requirements : string list ;
+    exercise_forward : identifier list ;
+    exercise_backward : identifier list ;
+  }
 
 and group =
   { group_title : string ;
@@ -77,21 +86,43 @@ let exercise_enc =
     (fun { exercise_kind = kind ;
            exercise_title = title ;
            exercise_short_description = short ;
-           exercise_stars = stars } ->
-      (kind, title, short, stars))
-    (fun (kind, title, short, stars) ->
+           exercise_stars = stars ;
+           exercise_identifier = identifier ;
+           exercise_author = author ;
+           exercise_focus = focus ;
+           exercise_requirements = requirements ;
+           exercise_forward = forward ;
+           exercise_backward = backward ;
+         } ->
+      (kind, title, short, stars, identifier,
+       author, focus, requirements, forward, backward))
+    (fun (kind, title, short, stars, identifier,
+       author, focus, requirements, forward, backward) ->
        { exercise_kind = kind ;
          exercise_title = title ;
          exercise_short_description = short ;
-         exercise_stars = stars })
-    (obj4
+         exercise_stars = stars;
+         exercise_identifier = identifier ;
+         exercise_author = author ;
+         exercise_focus = focus ;
+         exercise_requirements = requirements ;
+         exercise_forward = forward ;
+         exercise_backward = backward ;
+       })
+    (obj10
        (req "kind" exercise_kind_enc)
        (req "title" string)
        (opt "shortDescription" string)
-       (req "stars" float))
+       (req "stars" float)
+       (opt "identifier" string)
+       (req "author" (list (tup2 string string)))
+       (req "focus" (list string))
+       (req "requirements" (list string))
+       (req "forward" (list string))
+       (req "backward" (list string)))
 
 let server_exercise_meta_enc =
-  check_version_1 exercise_enc
+  check_version_2 exercise_enc
 
 let group_enc =
   mu "group" @@ fun group_enc ->
@@ -117,7 +148,7 @@ let group_enc =
         (fun (title, map) -> (title, Groups map)) ]
 
 let exercise_index_enc =
-  check_version_1 @@
+  check_version_2 @@
   union
     [ case
         (obj1 (req "exercises" (map_enc exercise_enc)))

--- a/src/repo/learnocaml_index.ml
+++ b/src/repo/learnocaml_index.ml
@@ -62,9 +62,12 @@ let check_version_2 enc =
   conv
     (fun exercise -> ("2", exercise))
     (fun (version, exercise) ->
-       if version <> "2" || version <> "1" then begin
-         let msg = Format.asprintf "unknown version %s" version in
-         raise (Cannot_destruct ([], Failure msg))
+       begin
+         match version with
+           "1" | "2" -> ()
+         | _ ->
+           let msg = Format.asprintf "unknown version %s" version in
+           raise (Cannot_destruct ([], Failure msg))
        end ;
        exercise)
     (merge_objs (obj1 (req "learnocaml_version" string)) enc)
@@ -164,7 +167,7 @@ let exercise_index_enc =
         (fun map -> Groups map) ]
 
 let lesson_index_enc =
-  check_version_1 @@
+  check_version_2 @@
   obj1 (req "lessons" (list @@ tup2 string string))
 
 type word =

--- a/src/repo/learnocaml_index.ml
+++ b/src/repo/learnocaml_index.ml
@@ -49,6 +49,17 @@ let check_version_1 enc =
        exercise)
     (merge_objs (obj1 (req "learnocaml_version" string)) enc)
 
+let check_version_2 enc =
+  conv
+    (fun exercise -> ("2", exercise))
+    (fun (version, exercise) ->
+       if version <> "2" || version <> "1" then begin
+         let msg = Format.asprintf "unknown version %s" version in
+         raise (Cannot_destruct ([], Failure msg))
+       end ;
+       exercise)
+    (merge_objs (obj1 (req "learnocaml_version" string)) enc)
+
 let map_enc enc =
   conv
     StringMap.bindings

--- a/src/repo/learnocaml_index.mli
+++ b/src/repo/learnocaml_index.mli
@@ -63,6 +63,8 @@ val tutorial_index_enc : series Map.Make (String).t Json_encoding.encoding
 
 val check_version_1 : 'a Json_encoding.encoding -> 'a Json_encoding.encoding
 
+val check_version_2 : 'a Json_encoding.encoding -> 'a Json_encoding.encoding
+
 (** the following are relative paths to the www root, using [/] as path
     separator *)
 val exercise_index_path : string

--- a/src/repo/learnocaml_index.mli
+++ b/src/repo/learnocaml_index.mli
@@ -20,11 +20,20 @@ type exercise_kind =
   | Problem
   | Learnocaml_exercise
 
+type identifier = string
+
 type exercise =
   { exercise_kind : exercise_kind ;
     exercise_title : string ;
     exercise_short_description : string option ;
-    exercise_stars : float (* \in [0.,4.] *) }
+    exercise_stars : float (* \in [0.,4.] *) ;
+    exercise_identifier : identifier option ;
+    exercise_author : (string * string) list ;
+    exercise_focus : string list ;
+    exercise_requirements : string list ;
+    exercise_forward : identifier list ;
+    exercise_backward : identifier list ;
+  }
 
 and group =
   { group_title : string ;

--- a/src/repo/learnocaml_index.mli
+++ b/src/repo/learnocaml_index.mli
@@ -33,6 +33,7 @@ type exercise =
     exercise_requirements : string list ;
     exercise_forward : identifier list ;
     exercise_backward : identifier list ;
+    exercise_max_score : int option ;
   }
 
 and group =

--- a/src/repo/learnocaml_lesson.ml
+++ b/src/repo/learnocaml_lesson.ml
@@ -28,7 +28,7 @@ and phrase =
 open Json_encoding
 
 let lesson_enc =
-  Learnocaml_index.check_version_1 @@
+  Learnocaml_index.check_version_2 @@
   conv
     (fun { lesson_title ; lesson_steps } -> (lesson_title, lesson_steps))
     (fun (lesson_title, lesson_steps) -> { lesson_title ; lesson_steps }) @@

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -73,7 +73,7 @@ let exercise_meta_enc =
           (opt "requirements" (list string))
           (opt "forward" (list string))
           (opt "backward" (list string)))
-       unit)
+       unit) (* FIXME: temporary parameter, that allows unknown fields *)
 
 let opt_to_list_enc = function
     None -> []

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -42,7 +42,7 @@ let index_enc =
           (fun (title, map) -> (title, `Groups map)) ] in
   let open Json_encoding in
   mu "group" @@ fun group_enc ->
-  check_version_1 @@
+  check_version_2 @@
   union
     [ case
         (obj1 (req "exercises" (list string)))
@@ -203,7 +203,14 @@ let main dest_dir =
                   let exercise =
                     { exercise_kind ; exercise_stars ;
                       exercise_title = Learnocaml_exercise.(get title) exercise ;
-                      exercise_short_description} in
+                      exercise_short_description;
+                      exercise_identifier ;
+                      exercise_author = opt_to_list_enc author ;
+                      exercise_focus = opt_to_list_enc focus ;
+                      exercise_requirements = opt_to_list_enc requirements ;
+                      exercise_forward = opt_to_list_enc forward ;
+                      exercise_backward = opt_to_list_enc backward ;
+                    } in
                   acc >>= fun acc ->
                   Lwt.return (StringMap.add id exercise acc))
                (Lwt.return StringMap.empty) ids >>= fun exercises ->

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -222,6 +222,13 @@ let main dest_dir =
                     | Some title -> title
                     | None -> Learnocaml_exercise.(get title) exercise
                   in
+                  let exercise_max_score =
+                    match max_score with
+                    | Some max_score -> Some max_score
+                    | None ->
+                        try Some (Learnocaml_exercise.(get max_score) exercise)
+                        with Learnocaml_exercise.Missing_field _ -> None
+                  in
                   let exercise =
                     { exercise_kind ; exercise_stars ;
                       exercise_title ;
@@ -232,6 +239,7 @@ let main dest_dir =
                       exercise_requirements = opt_to_list_enc requirements ;
                       exercise_forward = opt_to_list_enc forward ;
                       exercise_backward = opt_to_list_enc backward ;
+                      exercise_max_score ;
                     } in
                   acc >>= fun acc ->
                   Lwt.return (StringMap.add id exercise acc))

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -62,14 +62,12 @@ let exercise_kind_enc =
 
 let exercise_meta_enc_v1 =
   let open Json_encoding in
-  check_version_2 @@
   obj2
     (req "kind" exercise_kind_enc)
     (req "stars" float)
 
 let exercise_meta_enc_v2 =
   let open Json_encoding in
-  check_version_2 @@
   obj9
      (opt "title" string)
      (opt "short_description" string)

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -64,9 +64,10 @@ let exercise_meta_enc =
   let open Json_encoding in
   check_version_2
     (merge_objs
-       (obj8
+       (obj9
           (req "kind" exercise_kind_enc)
           (req "stars" float)
+          (opt "short_description" string)
           (opt "identifier" string)
           (opt "author" (list (tup2 string string)))
           (opt "focus" (list string))
@@ -194,10 +195,11 @@ let main dest_dir =
                (fun acc id ->
                   all_exercises := id :: !all_exercises ;
                   from_file exercise_meta_enc (!exercises_dir / id / "meta.json")
-                  >>= fun ((exercise_kind, exercise_stars, exercise_identifier,
+                  >>= fun ((exercise_kind, exercise_stars,
+                            exercise_short_description,
+                            exercise_identifier,
                             author, focus, requirements,
                             forward, backward), _) ->
-                  let exercise_short_description = None in
                   let exercise =
                     read_exercise (!exercises_dir / id) in
                   let exercise =

--- a/src/repo/learnocaml_process_tutorial_repository.ml
+++ b/src/repo/learnocaml_process_tutorial_repository.ml
@@ -36,7 +36,7 @@ let index_enc =
     obj2
       (req "title" string)
       (req "tutorials" (list string)) in
-  check_version_1 @@
+  check_version_2 @@
   obj1 (req "series" (assoc series_enc))
 
 let to_file encoding fn value =

--- a/src/repo/learnocaml_tutorial.ml
+++ b/src/repo/learnocaml_tutorial.ml
@@ -51,7 +51,7 @@ let phrase_enc =
         (fun phrase -> Paragraph phrase) ]
 
 let tutorial_enc =
-  Learnocaml_index.check_version_1 @@
+  Learnocaml_index.check_version_2 @@
   conv
     (fun { tutorial_title ; tutorial_steps } ->
        (tutorial_title, tutorial_steps))


### PR DESCRIPTION
Follows #40. 

However, this encoding is temporary. It allows to use any field in `meta.json` which is obviously not robust. This means that it will not warn for errors if a field is declared as optional and written with a typo.