### PR TITLE
Correction of behavior of the optional argument for the test_function…

### DIFF
--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -1196,7 +1196,7 @@ let run_timeout ~time v =
     test_value rf @@ fun rf ->
     let gen = match gen with
       | Some n -> n
-      | None -> 0 in
+      | None -> max 5 (10 - List.length tests) in
     let tests = match gen with
       | 0 -> List.map (fun x () -> x) tests
       | _ -> 

--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -1194,16 +1194,19 @@ let run_timeout ~time v =
       ?test ?test_stdout ?test_stderr
       ?(before_reference = fun _ -> ()) ?before_user ?after ?sampler ?ty prot uf rf tests =
     test_value rf @@ fun rf ->
-    let sampler =
-      match sampler with
-      | None -> get_sampler prot
-      | Some sampler -> sampler in
     let gen = match gen with
       | Some n -> n
-      | None -> max 5 (10 - List.length tests) in
-    let rec make i =
-      if i <= 0 then [] else sampler :: make (i - 1) in
-    let tests = List.map (fun x () -> x) tests @ make gen in
+      | None -> 0 in
+    let tests = match gen with
+      | 0 -> List.map (fun x () -> x) tests
+      | _ -> 
+         let sampler =
+           match sampler with
+           | None -> get_sampler prot
+           | Some sampler -> sampler in
+         let rec make i =
+           if i <= 0 then [] else sampler :: make (i - 1) in
+         List.map (fun x () -> x) tests @ make gen in
     let tests = List.map (fun a () -> let a = a () in (a, (fun () -> before_reference a ; apply rf a))) tests in
     test_function_generic
       ?test ?test_stdout ?test_stderr


### PR DESCRIPTION
The optional argument ~gen of the test_function had  a pretty bad default behavior : 
- if not defined the number of automatically generated tests was **NOT** 0
- if ~gen:0 :  the grader still checked if there was the right sampler to generate tests automatically which was ... pretty inconvenient.

Now : if ~gen is not defined, the number of generated tests is 0 and if not defined or if ~gen=0 there is no need to define a sampler for the inputs of the tested function.

NB: The change of the default value of ~gen will break the mooc exercises, so maybe we should discuss it!