### PR TITLE
test_lib.mli: Fix the comments documenting args & prot functions

### DIFF
--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -259,7 +259,7 @@ module type S = sig
 
   (*----------------------------------------------------------------------------*)
 
-  (* Usage: (arg 3 @@ arg "word" @@ last false *)
+  (* Usage: arg 3 @@ arg "word" @@ last false *)
   type ('arrow, 'uarrow, 'ret) args
   val last :
     'a ->
@@ -271,7 +271,7 @@ module type S = sig
 
   val apply : ('ar -> 'row) -> ('ar -> 'row, 'ar -> 'urow, 'ret) args -> 'ret
 
-  (* Usage: (arg [%ty: int] @@ arg [%ty: string] @@ last [%ty: bool] *)
+  (* Usage: arg_ty [%ty: int] @@ arg_ty [%ty: string] @@ last_ty [%ty: bool] [%ty: unit] *)
   type ('arrow, 'uarrow, 'ret) prot
   val last_ty :
     'a Ty.ty ->

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -259,7 +259,9 @@ module type S = sig
 
   (*----------------------------------------------------------------------------*)
 
-  (* Usage: (arg 3 @@ arg "word" @@ last false *)
+  (** The type of arguments, represented as heterogeneous lists.
+
+  Usage: [arg 3 @@ arg "word" @@ last false] *)
   type ('arrow, 'uarrow, 'ret) args
   val last :
     'a ->
@@ -271,7 +273,9 @@ module type S = sig
 
   val apply : ('ar -> 'row) -> ('ar -> 'row, 'ar -> 'urow, 'ret) args -> 'ret
 
-  (* Usage: (arg [%ty: int] @@ arg [%ty: string] @@ last [%ty: bool] *)
+  (** The type of function prototypes.
+
+  Usage: [arg_ty [%ty: int] @@ arg_ty [%ty: string] @@ last_ty [%ty: bool] [%ty: unit]] *)
   type ('arrow, 'uarrow, 'ret) prot
   val last_ty :
     'a Ty.ty ->


### PR DESCRIPTION
Just a small bugfix for test_lib's doc.