### PR TITLE
test_lib.mli: Add another way to build ['a Ty.ty] terms

### DIFF
--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -257,6 +257,8 @@ module type S = sig
 
   (*----------------------------------------------------------------------------*)
 
+  val ty_of : string -> 'a Ty.ty
+
   (* Usage: arg 3 @@ arg "word" @@ last false *)
   type ('arrow, 'uarrow, 'ret) args
   val last :
@@ -1102,6 +1104,8 @@ let run_timeout ~time v =
     | Last_ty (a, b) -> Ty.curry a b
     | Arg_ty (x, Last_ty (l, r)) -> Ty.curry x (Ty.curry l r)
     | Arg_ty (x, Arg_ty (y, r)) -> Ty.curry x (ty_of_prot (Arg_ty (y, r)))
+
+  let ty_of str = Ty.repr (Parse.core_type (Lexing.from_string str))
 
   let rec apply : type p a c r. (p -> a) -> (p -> a, p -> c, r) args -> r = fun f x ->
     match x with

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -257,6 +257,13 @@ module type S = sig
 
   (*----------------------------------------------------------------------------*)
 
+  (** Parsing function.
+
+      [ty_of "string"] is very similar to the ppx expr [[%ty: string]]
+      but [ty_of "Code.t"] won't trigger a syntax error if the type t
+      is undefined in student's Code. *)
+  val ty_of : string -> 'a Ty.ty
+
   (** The type of arguments, represented as heterogeneous lists.
 
   Usage: [arg 3 @@ arg "word" @@ last false] *)


### PR DESCRIPTION
Dear learn-ocaml developers,

To follow-up our latest discussion, I'm opening this PR to propose another way to construct `'a Ty.ty` terms so that the grader fails more gracefully in case there is an undefined type.

This corresponds to the following use case: the type of a function to grade depends on a type `t` that
should be defined in the student's Code itself.

If that type is undefined, `[%ty: Code.t]` will trigger a syntax error (cf. the first screenshot below) while `(ty_of "Code.t")` will fail locally only, and let the other tests pass (cf. the second screenshot below).

Kind regards, Erik

### Using `[%ty: Code.t]`
![screenshot_learn-ocaml-editor_ty_ppx](https://user-images.githubusercontent.com/10367254/42509856-8154d296-844d-11e8-8bb3-f92e2931e773.png)

### Using `(ty_of "Code.t")`
![screenshot_learn-ocaml-editor_ty_of](https://user-images.githubusercontent.com/10367254/42509873-8990c35c-844d-11e8-963a-6c50684e414e.png)
