### PR TITLE
Refactoring of exercises processing

### DIFF
--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -258,6 +258,16 @@ let () =
             },\n"
          *)
        in
+       (* Looking for the description in the correct language. *)
+       let descr =
+         let lang = "" in
+         try
+           List.assoc lang (Learnocaml_exercise.(access File.descr exo))
+         with
+           Not_found ->
+             try List.assoc "" (Learnocaml_exercise.(access File.descr exo))
+             with Not_found -> [%i "No description available for this exercise." ]
+         in
        let html = Format.asprintf
            "<!DOCTYPE html>\
             <html><head>\
@@ -274,7 +284,7 @@ let () =
            (Learnocaml_exercise.(access File.title exo))
            mathjax_config
            mathjax_url
-           (Learnocaml_exercise.(access File.descr exo)) in
+           descr in
        d##open_;
        d##write (Js.string html);
        d##close) ;

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -69,7 +69,7 @@ let display_report exo report =
   Manip.removeClass report_button "failure" ;
   Manip.removeClass report_button "partial" ;
   let grade =
-    let max = Learnocaml_exercise.(get max_score) exo in
+    let max = Learnocaml_exercise.(access File.max_score) exo in
     if max = 0 then 999 else score * 100 / max
   in
   if grade >= 100 then begin
@@ -128,7 +128,7 @@ let () =
   let exercise_fetch = Server_caller.fetch_exercise id in
   let after_init top =
     exercise_fetch >>= fun exo ->
-    begin match Learnocaml_exercise.(get prelude) exo with
+    begin match Learnocaml_exercise.(access File.prelude exo) with
       | "" -> Lwt.return true
       | prelude ->
           Learnocaml_toplevel.load ~print_outcome:true top
@@ -136,7 +136,7 @@ let () =
             prelude
     end >>= fun r1 ->
     Learnocaml_toplevel.load ~print_outcome:false top
-      (Learnocaml_exercise.(get prepare) exo) >>= fun r2 ->
+      (Learnocaml_exercise.(access File.prepare exo)) >>= fun r2 ->
     if not r1 || not r2 then failwith [%i"error in prelude"] ;
     Learnocaml_toplevel.set_checking_environment top >>= fun () ->
     Lwt.return () in
@@ -200,9 +200,9 @@ let () =
   let text_container = find_component "learnocaml-exo-tab-text" in
   let text_iframe = Dom_html.createIframe Dom_html.document in
   Manip.replaceChildren text_container
-    Tyxml_js.Html5.[ h1 [ pcdata (Learnocaml_exercise.(get title) exo) ] ;
+    Tyxml_js.Html5.[ h1 [ pcdata (Learnocaml_exercise.(access File.title exo)) ] ;
                      Tyxml_js.Of_dom.of_iFrame text_iframe ] ;
-  let prelude = Learnocaml_exercise.(get prelude) exo in
+  let prelude = Learnocaml_exercise.(access File.prelude exo) in
   if prelude <> "" then begin
     let open Tyxml_js.Html5 in
     let state = ref (match arg "prelude" with
@@ -271,10 +271,10 @@ let () =
             %s\
             </body>\
             </html>"
-           (Learnocaml_exercise.(get title) exo)
+           (Learnocaml_exercise.(access File.title exo))
            mathjax_config
            mathjax_url
-           (Learnocaml_exercise.(get descr) exo) in
+           (Learnocaml_exercise.(access File.descr exo)) in
        d##open_;
        d##write (Js.string html);
        d##close) ;
@@ -285,11 +285,11 @@ let () =
   Ace.set_contents ace
     (match solution with
      | Some solution -> solution
-     | None -> Learnocaml_exercise.(get template) exo) ;
+     | None -> Learnocaml_exercise.(access File.template exo)) ;
   Ace.set_font_size ace 18;
   begin editor_button
       ~icon: "cleanup" [%i"Reset"] @@ fun () ->
-    Ace.set_contents ace (Learnocaml_exercise.(get template) exo) ;
+    Ace.set_contents ace (Learnocaml_exercise.(access File.template exo)) ;
     Lwt.return ()
   end ;
   begin editor_button

--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -33,11 +33,12 @@ let exercises_tab _ _ () =
       let open Tyxml_js.Html5 in
       match contents with
       | Learnocaml_exercises exercises ->
-          StringMap.fold
-            (fun exercise_id { exercise_kind ;
-                               exercise_title ;
-                               exercise_short_description ;
-                               exercise_stars } acc ->
+          List.fold_left
+            (fun acc (exercise_id,
+                      { exercise_kind ;
+                        exercise_title ;
+                        exercise_short_description ;
+                        exercise_stars }) ->
               let pct_init =
                 match StringMap.find exercise_id all_exercise_states with
                 | exception Not_found -> None
@@ -88,15 +89,15 @@ let exercises_tab _ _ () =
                   ]
                 ] ] ::
               acc)
-            exercises acc
+            acc exercises
       | Groups groups ->
           let h = match lvl with 1 -> h1 | 2 -> h2 | _ -> h3 in
-          StringMap.fold
-            (fun _ { group_title ; group_contents } acc ->
+          List.fold_left
+            (fun acc (_, { group_title ; group_contents }) ->
                format_contents (succ lvl)
                  (h ~a:[ a_class [ "pack" ] ] [ pcdata group_title ] :: acc)
                  group_contents)
-            groups acc in
+            acc groups in
     List.rev (format_contents 1 [] index) in
   let list_div =
     Tyxml_js.Html5.(div ~a: [ Tyxml_js.Html5.a_id "learnocaml-main-exercise-list" ])
@@ -319,10 +320,10 @@ let tryocaml_tab select (arg, set_arg, delete_arg) () =
   Manip.appendChild content_div tutorial_div ;
   Server_caller.fetch_tutorial_index () >>= fun index ->
   let index =
-    List.flatten @@ StringMap.fold
-      (fun _ { series_tutorials } acc ->
+    List.flatten @@ List.fold_left
+      (fun acc (_, { series_tutorials }) ->
          series_tutorials :: acc)
-      index [] in
+      [] index in
   let options =
     List.map
       (fun { tutorial_name; tutorial_title } ->

--- a/src/app/server_caller.mli
+++ b/src/app/server_caller.mli
@@ -27,7 +27,7 @@ val fetch_lesson_index : unit -> (string * string) list Lwt.t
 
 val fetch_lesson : string -> Learnocaml_lesson.lesson Lwt.t
 
-val fetch_tutorial_index : unit -> Learnocaml_index.series Map.Make(String).t Lwt.t
+val fetch_tutorial_index : unit -> (string * Learnocaml_index.series) list Lwt.t
 
 val fetch_tutorial : string -> Learnocaml_tutorial.tutorial Lwt.t
 

--- a/src/grader/grader_cli.ml
+++ b/src/grader/grader_cli.ml
@@ -91,19 +91,18 @@ let read_student_file exercise_dir path =
   else
     Lwt_io.with_file ~mode:Lwt_io.Input fn Lwt_io.read
 
-let grade ?(print_result=false) exercise_dir output_json =
+let grade ?(print_result=false) exercise output_json =
   Lwt.catch
     (fun () ->
-       let exercise_dir = remove_trailing_slash exercise_dir in
-       read_exercise exercise_dir >>= fun exo ->
        let code_to_grade = match !grade_student with
          | Some path -> read_student_file (Sys.getcwd ()) path
-         | None -> Lwt.return (Learnocaml_exercise.(get solution) exo) in
+         | None ->
+             Lwt.return (Learnocaml_exercise.(decipher File.solution exercise)) in
        let callback =
          if !display_callback then Some (Printf.eprintf "[ %s ]%!\r\027[K") else None in
        let timeout = !individual_timeout in
        code_to_grade >>= fun code ->
-       Grading_cli.get_grade ?callback ?timeout exo code
+       Grading_cli.get_grade ?callback ?timeout exercise code
        >>= fun (result, stdout_contents, stderr_contents, outcomes) ->
        flush stderr;
        match result with
@@ -178,24 +177,28 @@ let grade ?(print_result=false) exercise_dir output_json =
            if failure then begin
              if print_result then
                Printf.eprintf "%-30s - Failure - %d points\n%!"
-                 (Filename.basename exercise_dir) max;
+                 Learnocaml_exercise.(access File.id exercise) max;
              Lwt.return 2
            end
            else begin
              if print_result then
                Printf.eprintf "%-30s - Success - %d points\n%!"
-                 (Filename.basename exercise_dir) max;
+                 Learnocaml_exercise.(access File.id exercise) max;
              match output_json with
              | None ->
                  Lwt.return 0
              | Some json_file ->
-                 let exo = Learnocaml_exercise.(set max_score) max exo in
+                 let exo =
+                   Learnocaml_exercise.(update File.max_score max exercise) in
+                 let json =
+                   Json_encoding.construct Learnocaml_exercise.encoding exo in
+                 let json = match json with
+                   | `A _ | `O _ as d -> d
+                   | v -> `A [ v ] in
+                 let str = Ezjsonm.to_string ~minify:false (json :> Ezjsonm.t) in
                  Lwt_utils.mkdir_p (Filename.dirname json_file)  >>= fun () ->
-                 Learnocaml_exercise.write_lwt
-                   ~write_field: (fun f v acc -> Lwt.return ((f, `String v) :: acc))
-                   exo ~cipher:true [ "learnocaml_version", `String "1" ] >>= fun fields ->
                  Lwt_io.with_file ~mode: Lwt_io.Output json_file @@ fun chan ->
-                 Lwt_io.write chan (Ezjsonm.to_string (`O fields)) >>= fun () ->
+                 Lwt_io.write chan str >>= fun () ->
                  Lwt.return 0
            end)
     (fun exn ->
@@ -211,6 +214,12 @@ let grade ?(print_result=false) exercise_dir output_json =
        Format.eprintf "%a" Location.report_exception exn ;
        Lwt.return 1)
 
+let grade_from_dir ?(print_result=false) exercise_dir output_json =
+  let exercise_dir = remove_trailing_slash exercise_dir in
+  read_exercise exercise_dir >>= fun exo ->
+  grade ~print_result exo output_json
+
+
 let main () : unit =
   let anons = ref [] in
   Arg.parse args
@@ -224,4 +233,4 @@ let main () : unit =
       Format.eprintf "A single problem directory is expected@." ;
       exit 1
   | [ single ] ->
-      exit (Lwt_main.run (grade single !output_json))
+      exit (Lwt_main.run (grade_from_dir single !output_json))

--- a/src/grader/grader_jsoo_messages.ml
+++ b/src/grader/grader_jsoo_messages.ml
@@ -30,7 +30,7 @@ let to_worker_enc =
     (fun (solution, exercise) -> { solution ; exercise })
     (obj2
        (req "solution" string)
-       (req "exercise" Learnocaml_exercise.enc))
+       (req "exercise" Learnocaml_exercise.encoding))
 
 let from_worker_enc =
   union

--- a/src/grader/grading.ml
+++ b/src/grader/grading.ml
@@ -42,7 +42,7 @@ let internal_error name err =
 let user_code_error err =
   raise (User_code_error err)
 
-let get_grade ?callback ?timeout ~divert exo code =
+let get_grade ?callback ?timeout ~divert (exo : Learnocaml_exercise.t) code =
 
   let print_outcome = true in
   let outcomes_buffer = Buffer.create 503 in
@@ -101,12 +101,12 @@ let get_grade ?callback ?timeout ~divert exo code =
       set_progress [%i"Loading the prelude."] ;
       handle_error (internal_error [%i"while loading the prelude"]) @@
       Toploop_ext.use_string ~print_outcome ~ppf_answer ~filename:"prelude.ml"
-        (Learnocaml_exercise.(get prelude) exo) ;
+        (Learnocaml_exercise.(decipher File.prelude exo)) ;
 
       set_progress [%i"Preparing the test environment."] ;
       handle_error (internal_error [%i"while preparing the tests"]) @@
       Toploop_ext.use_string ~print_outcome ~ppf_answer ~filename:"prepare.ml"
-        (Learnocaml_exercise.(get prepare) exo) ;
+        (Learnocaml_exercise.(decipher File.prepare exo)) ;
 
       set_progress [%i"Loading your code."] ;
       handle_error user_code_error @@
@@ -115,7 +115,7 @@ let get_grade ?callback ?timeout ~divert exo code =
       set_progress [%i"Loading the solution."] ;
       handle_error (internal_error [%i"while loading the solution"]) @@
       Toploop_ext.use_mod_string ~print_outcome ~ppf_answer ~modname:"Solution"
-        (Learnocaml_exercise.(get solution) exo) ;
+        (Learnocaml_exercise.(decipher File.solution exo)) ;
 
       set_progress [%i"Preparing to launch the tests."] ;
       Introspection.allow_introspection ~divert ;
@@ -142,7 +142,7 @@ let get_grade ?callback ?timeout ~divert exo code =
       set_progress [%i"Launching the test bench."] ;
       handle_error (internal_error [%i"while testing your solution"]) @@
       Toploop_ext.use_string ~print_outcome ~ppf_answer ~filename:"test.ml"
-        (Learnocaml_exercise.(get test) exo) ;
+        (Learnocaml_exercise.(decipher File.test exo)) ;
 
       (* Memory cleanup... *)
       Toploop.initialize_toplevel_env () ;

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -335,7 +335,7 @@ let get_score =
   get_score 0
 
 let max_score exercise =
-  Learnocaml_exercise.(get max_score) exercise
+  Learnocaml_exercise.(access File.max_score exercise)
 
 let print_score ?(max=1) ?color i =
   let color = match color with
@@ -488,7 +488,7 @@ let upload_report server token exercise solution report =
   let new_save =
     { Learnocaml_sync.
       all_exercise_states =
-        StringMap.singleton (Learnocaml_exercise.(get id) exercise)
+        StringMap.singleton (Learnocaml_exercise.(access File.id) exercise)
           exercise_state;
       all_toplevel_histories = StringMap.empty;
       all_exercise_toplevel_histories = StringMap.empty;

--- a/src/main/learnocaml_main.ml
+++ b/src/main/learnocaml_main.ml
@@ -147,7 +147,7 @@ module Args = struct
       let apply repo_dir contents_dir =
         Learnocaml_process_exercise_repository.exercises_dir :=
           repo_dir/"exercises";
-        Learnocaml_process_tutorial_repository.tutorials_dir := 
+        Learnocaml_process_tutorial_repository.tutorials_dir :=
           repo_dir/"tutorials";
         { contents_dir }
       in
@@ -209,7 +209,7 @@ let main o =
        Lwt_list.fold_left_s (fun i ex ->
            Lwt.catch
              (fun () ->
-                Grader_cli.grade ~print_result:true ex o.grader.Grader.output_json
+                Grader_cli.grade_from_dir ~print_result:true ex o.grader.Grader.output_json
                 >|= max i)
              (fun e ->
                 Printf.ksprintf failwith

--- a/src/repo/build.ocp
+++ b/src/repo/build.ocp
@@ -4,13 +4,15 @@ begin library "learnocaml-repository"
     "learnocaml_index.ml"
     "learnocaml_lesson.ml"
     "learnocaml_tutorial.ml"
+    "learnocaml_meta.ml"
     "learnocaml_exercise.ml"
   ]
   requires = [
     "ocplib-json-typed"
     "xor"
     "lwt"
-  ]
+    "ezjsonm"
+]
 end
 
 begin program "learnocaml-tutorial-reader"

--- a/src/repo/learnocaml_exercise.ml
+++ b/src/repo/learnocaml_exercise.ml
@@ -1,3 +1,4 @@
+
 (* This file is part of Learn-OCaml.
  *
  * Copyright (C) 2016 OCamlPro.
@@ -15,66 +16,59 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *)
 
-module StringMap = Map.Make (String)
-type t = string StringMap.t
+open Lwt.Infix
 
-type 'a field =
-  { key : string ;
-    ciphered : bool ;
-    decode : string -> 'a ;
-    encode : 'a -> string }
+open Learnocaml_meta
+open Learnocaml_index
 
-exception Missing_field of string
+type t =
+  { id : string ;
+    meta : meta ;
+    prelude : string ;
+    template : string ;
+    descr : string ;
+    prepare : string ;
+    test : string ;
+    solution : string ;
+  }
 
-let get { key ; ciphered ; decode ; _ } ex =
-  try
-    let raw = StringMap.find key ex in
-    if ciphered then
-      let prefix =
-        Digest.string (StringMap.find "id" ex  ^ "_" ^ key) in
-      decode (Xor.decode ~prefix raw)
-    else
-      decode raw
-  with Not_found -> raise (Missing_field key)
+let cipher ex_id key v =
+  let prefix =
+    Digest.string (ex_id  ^ "_" ^ key) in
+  Xor.decode ~prefix v
 
-let has { key ; _ } ex =
-  StringMap.mem key ex
+let decipher ex_id key v =
+  let prefix =
+    Digest.string (ex_id  ^ "_" ^ key) in
+  Xor.decode ~prefix v
 
-let set { key ; ciphered ; encode ; _ } raw ex =
-  if ciphered then
-    let prefix =
-      Digest.string (StringMap.find "id" ex  ^ "_" ^ key) in
-    StringMap.add key (Xor.encode ~prefix (encode raw)) ex
-  else
-    StringMap.add key (encode raw) ex
+let encoding =
+  let open Json_encoding in
+  conv
+    (fun { id; meta; prelude; template; descr; prepare; test; solution } ->
+       id, meta, prelude, template, descr, prepare, test, solution)
+    (fun (id, meta, prelude, template, descr, prepare, test, solution) ->
+       { id ; meta ; prelude ; template ; descr ; prepare ; test ; solution })
+    (obj8
+       (req "id" string)
+       (req "meta" Learnocaml_meta.encoding)
+       (req "prelude" string)
+       (req "template" string)
+       (req "descr" string)
+       (req "prepare" string)
+       (req "test" string)
+       (req "solution" string))
 
-let id =
-  { key = "id" ; ciphered = false ;
-    decode = (fun v -> v) ; encode = (fun v -> v) }
-let title =
-  { key = "title.txt" ; ciphered = false ;
-    decode = (fun v -> String.trim v) ; encode = (fun v -> v) }
-let max_score =
-  { key = "max_score.txt" ; ciphered = false ;
-    decode = (fun v -> int_of_string v) ; encode = (fun v -> string_of_int v) }
-let prelude =
-  { key = "prelude.ml" ; ciphered = false ;
-    decode = (fun v -> v) ; encode = (fun v -> v) }
-let template =
-  { key = "template.ml" ; ciphered = false ;
-    decode = (fun v -> v) ; encode = (fun v -> v) }
-let descr =
-  { key = "descr.html" ; ciphered = false ;
-    decode = (fun v -> v) ; encode = (fun v -> v) }
-let prepare =
-  { key = "prepare.ml" ; ciphered = true ;
-    decode = (fun v -> v) ; encode = (fun v -> v) }
-let test =
-  { key = "test.ml" ; ciphered = true ;
-    decode = (fun v -> v) ; encode = (fun v -> v) }
-let solution =
-  { key = "solution.ml" ; ciphered = true ;
-    decode = (fun v -> v) ; encode = (fun v -> v) }
+let meta_from_string m =
+  Ezjsonm.from_string m
+  |> Json_encoding.destruct Learnocaml_meta.encoding
+
+let meta_to_string m =
+  Json_encoding.construct Learnocaml_meta.encoding m
+  |> (function
+    | `A _ | `O _ as d -> d
+    | v -> `A [ v ])
+  |> Ezjsonm.to_string ~minify:true
 
 module type Concur = sig
   type 'a t
@@ -84,51 +78,283 @@ module type Concur = sig
   val join : unit t list -> unit t
 end
 
+module Seq = struct
+  type 'a t = 'a
+  let (>>=) x f = f x
+  let return x = x
+  let fail = raise
+  let join l = ()
+end
+
+module File = struct
+
+  module StringMap = Map.Make (String)
+  type files = string StringMap.t
+
+  type 'a file =
+    { key : string ;
+      ciphered : bool ;
+      decode : string -> 'a ;
+      encode : 'a -> string ;
+      field : t -> 'a ;
+      update : 'a -> t -> t ;
+    }
+
+  exception Missing_file of string
+
+  let get { key ; ciphered ; decode } ex =
+    try
+      let raw = StringMap.find key ex in
+      if ciphered then
+        let prefix =
+          Digest.string (StringMap.find "id" ex  ^ "_" ^ key) in
+        decode (Xor.decode ~prefix raw)
+      else
+        decode raw
+    with Not_found -> raise (Missing_file ("get  " ^ key))
+
+  let has { key } ex =
+    StringMap.mem key ex
+
+  let set { key ; ciphered ; encode } raw ex =
+    if ciphered then
+      let prefix =
+        Digest.string (StringMap.find "id" ex  ^ "_" ^ key) in
+      StringMap.add key (Xor.encode ~prefix (encode raw)) ex
+    else
+      StringMap.add key (encode raw) ex
+
+  let id =
+    { key = "id" ; ciphered = false ;
+      decode = (fun v -> v) ; encode = (fun v -> v) ;
+      field = (fun ex -> ex.id) ;
+      update = (fun id ex -> { ex with id })
+    }
+  let meta =
+    { key = "meta.json" ; ciphered = false ;
+      decode = meta_from_string ; encode = meta_to_string ;
+      field = (fun ex -> ex.meta) ;
+      update = (fun meta ex -> { ex with meta })
+    }
+  let title =
+    let key = "title.txt" in
+    { key ; ciphered = false ;
+      decode = (fun v -> String.trim v) ; encode = (fun v -> v) ;
+      field = (fun ex ->
+          match ex.meta.meta_title with
+            None -> raise (Missing_file ("field " ^ key))
+          | Some t -> t) ;
+      update = (fun title ex ->
+          { ex with meta = { ex.meta with meta_title = Some title }})
+     }
+  let max_score =
+    let key = "max_score.txt" in
+    { key ; ciphered = false ;
+      decode = (fun v -> int_of_string v) ; encode = (fun v -> string_of_int v) ;
+      field = (fun ex ->
+          match ex.meta.meta_max_score with
+            None -> raise (Missing_file key)
+          | Some v -> v);
+      update = (fun score ex ->
+          { ex with meta = { ex.meta with meta_max_score = Some score }})
+     }
+  let prelude =
+    { key = "prelude.ml" ; ciphered = false ;
+      decode = (fun v -> v) ; encode = (fun v -> v) ;
+      field = (fun ex -> ex.prelude) ;
+      update = (fun prelude ex -> { ex with prelude })
+     }
+  let template =
+    { key = "template.ml" ; ciphered = false ;
+      decode = (fun v -> v) ; encode = (fun v -> v) ;
+      field = (fun ex -> ex.template) ;
+      update = (fun template ex -> { ex with template })
+     }
+  let descr =
+    { key = "descr.html" ; ciphered = false ;
+      decode = (fun v -> v) ; encode = (fun v -> v) ;
+      field = (fun ex -> ex.descr) ;
+      update = (fun descr ex -> { ex with descr })
+     }
+  let prepare =
+    { key = "prepare.ml" ; ciphered = true ;
+      decode = (fun v -> v) ; encode = (fun v -> v) ;
+      field = (fun ex -> ex.prepare) ;
+      update = (fun prepare ex -> { ex with prepare })
+     }
+  let test =
+    { key = "test.ml" ; ciphered = true ;
+      decode = (fun v -> v) ; encode = (fun v -> v) ;
+      field = (fun ex -> ex.test) ;
+      update = (fun test ex -> { ex with test })
+     }
+  let solution =
+    { key = "solution.ml" ; ciphered = true ;
+      decode = (fun v -> v) ; encode = (fun v -> v) ;
+      field = (fun ex -> ex.solution) ;
+      update = (fun solution ex -> { ex with solution })
+     }
+
+  module MakeReader (Concur : Concur) = struct
+    let read ~read_field ?id: ex_id ?(decipher = true) () =
+      let open Concur in
+      let ex = ref StringMap.empty in
+      read_field id.key >>= fun pr_id ->
+      begin match ex_id, pr_id with
+        | None, None -> fail (Failure "Exercise.read: missing id")
+        | Some id, None | None, Some id -> return id
+        | Some id, Some id' ->
+            if id = id' then return id else
+              fail (Failure "Exercise.read: conficting ids")
+      end >>= fun ex_id ->
+      ex := set id ex_id !ex ;
+      read_field meta.key >>=
+      begin function
+          None -> fail (Missing_file meta.key)
+        | Some meta_json ->
+            return (meta_from_string meta_json)
+      end >>= fun meta_json ->
+      ex := set meta meta_json !ex;
+      let read_field ({ key ; ciphered ; encode ; decode } as field) =
+        read_field key >>= function
+        | Some raw ->
+            let deciphered =
+              if ciphered && decipher then
+                let prefix =
+                  Digest.string (ex_id  ^ "_" ^ key) in
+                Xor.decode ~prefix raw
+              else
+                raw in
+            (* decode / encode now to catch malformed fields earlier *)
+            ex := set field (decode deciphered) !ex ;
+            return ()
+        | None -> return () in
+      let read_title () =
+        match meta_json.meta_title with
+          Some t ->
+            ex := set title t !ex;
+            return ()
+        | None ->
+            read_field title >>= fun () ->
+            try
+              let t = get title !ex in
+              ex := set meta { meta_json with meta_title = Some t } !ex;
+              return ()
+            with _ -> return ()
+      in
+      let read_max_score () =
+        match meta_json.meta_max_score with
+          Some score ->
+            ex := set max_score (score) !ex;
+            return ()
+        | None ->
+            read_field max_score >>= fun () ->
+            try
+              let score = get max_score !ex in
+              ex := set meta
+                  { meta_json with meta_max_score = Some score } !ex;
+              return ()
+            with _ -> return ()
+      in
+      join
+        [ read_title () ;
+          read_field prelude ;
+          read_field template ;
+          read_field descr ;
+          read_field prepare ;
+          read_field solution ;
+          read_field test ;
+          read_max_score () ] >>= fun () ->
+      return !ex
+  end
+
+  include MakeReader (Seq)
+end
+
+let access f ex =
+  f.File.field ex
+
+let decipher f ex =
+  let open File in
+  let raw = f.field ex in
+  if f.ciphered then
+    let prefix =
+      Digest.string (ex.id  ^ "_" ^ f.key) in
+    f.decode (Xor.decode ~prefix raw)
+  else
+    f.decode raw
+
+let update f v ex =
+  f.File.update v ex
+
+let cipher f v ex =
+  let open File in
+  if f.ciphered then
+    let prefix =
+      Digest.string (ex.id  ^ "_" ^ f.key) in
+    f.update (Xor.encode ~prefix (f.encode v)) ex
+  else
+    f.update (f.encode v) ex
+
+
+let meta_from_index ex =
+  { meta_kind = ex.exercise_kind ;
+    meta_title = Some ex.exercise_title ;
+    meta_short_description = ex.exercise_short_description ;
+    meta_stars = ex.exercise_stars ;
+    meta_identifier = ex.exercise_identifier ;
+    meta_author = ex.exercise_author ;
+    meta_focus = ex.exercise_focus ;
+    meta_requirements = ex.exercise_requirements ;
+    meta_forward = ex.exercise_forward ;
+    meta_backward = ex.exercise_backward ;
+    meta_max_score = ex.exercise_max_score ;
+  }
+
+let to_index exercise =
+  { exercise_kind = exercise.meta.meta_kind ;
+    exercise_stars = exercise.meta.meta_stars ;
+    exercise_title = access File.title exercise ;
+    exercise_short_description = exercise.meta.meta_short_description;
+    exercise_identifier = exercise.meta.meta_identifier ;
+    exercise_author = exercise.meta.meta_author ;
+    exercise_focus = exercise.meta.meta_focus ;
+    exercise_requirements =  exercise.meta.meta_requirements ;
+    exercise_forward = exercise.meta.meta_forward ;
+    exercise_backward = exercise.meta.meta_backward ;
+    exercise_max_score = exercise.meta.meta_max_score ;
+  }
+
+let field_from_file file files =
+  try File.(StringMap.find file.key files |> file.decode)
+  with Not_found -> raise File.(Missing_file file.key)
+
 module MakeReaderAnddWriter (Concur : Concur) = struct
-  let read ~read_field ?id: ex_id ?(decipher = true) () =
+  module FileReader = File.MakeReader(Concur)
+  let read ~read_field ?id ?decipher () =
     let open Concur in
-    let ex = ref StringMap.empty in
-    read_field "id" >>= fun pr_id ->
-    begin match ex_id, pr_id with
-      | None, None -> fail (Failure "Exercise.read: missing id")
-      | Some id, None | None, Some id -> return id
-      | Some id, Some id' ->
-          if id = id' then return id else
-            fail (Failure "Exercise.read: conficting ids")
-    end >>= fun ex_id ->
-    ex := set id ex_id !ex ;
-    let read_field ({ key ; ciphered ; decode ; _ } as field) =
-      read_field key >>= function
-      | Some raw ->
-          let deciphered =
-            if ciphered && decipher then
-              let prefix =
-                Digest.string (ex_id  ^ "_" ^ key) in
-              Xor.decode ~prefix raw
-            else
-              raw in
-          (* decode / encode now to catch malformed fields earlier *)
-          ex := set field (decode deciphered) !ex ;
-          return ()
-      | None -> return () in
-    join
-      [ read_field title ;
-        read_field prelude ;
-        read_field template ;
-        read_field descr ;
-        read_field prepare ;
-        read_field solution ;
-        read_field test ;
-        read_field max_score ] >>= fun () ->
-    return !ex
+    FileReader.read ~read_field ?id ?decipher () >>= fun ex ->
+    try
+      return
+        { id = field_from_file File.id ex;
+          meta = field_from_file File.meta ex;
+          prelude = field_from_file File.prelude ex ;
+          template = field_from_file File.template ex ;
+          descr = field_from_file File.descr ex ;
+          prepare = field_from_file File.prepare ex ;
+          test = field_from_file File.test ex ;
+          solution = field_from_file File.solution ex ;
+        }
+    with File.Missing_file f as e -> fail e
 
   let write ~write_field ex ?(cipher = true) acc =
     let open Concur in
+    let open File in
     let acc = ref acc in
-    let ex_id = get id ex in
-    let write_field { key ; ciphered ; _ } =
+    let ex_id = ex.id in
+    let write_field { key ; ciphered ; encode ; decode ; field } =
       try
-        let raw = StringMap.find key ex in
+        let raw = field ex |> encode in
         let ciphered = if ciphered && (not cipher) then
             let prefix =
               Digest.string (ex_id  ^ "_" ^ key) in
@@ -141,6 +367,7 @@ module MakeReaderAnddWriter (Concur : Concur) = struct
       with Not_found -> Concur.return () in
     join
       [ write_field id ;
+        write_field meta ;
         write_field title ;
         write_field prelude ;
         write_field template ;
@@ -152,41 +379,10 @@ module MakeReaderAnddWriter (Concur : Concur) = struct
     return !acc
 end
 
-module Seq = struct
-  type 'a t = 'a
-  let (>>=) x f = f x
-  let return x = x
-  let fail = raise
-  let join _ = ()
-end
-
 include MakeReaderAnddWriter (Seq)
+
 module LwtReaderAnddWriter = MakeReaderAnddWriter (Lwt)
 let read_lwt = LwtReaderAnddWriter.read
 let write_lwt = LwtReaderAnddWriter.write
 
-let enc =
-  let open Json_encoding in
-  conv
-    (fun exo ->
-       let obj =
-         [ "id", get id exo ;
-           "learnocaml_version", "1" ] in
-       write
-         ~write_field: (fun k v l -> (k, v) :: l)
-         exo ~cipher: true obj)
-    (fun l ->
-       begin try
-           if List.assoc "learnocaml_version" l <> "1" then
-             raise (Cannot_destruct ([], Failure "unknown version"))
-         with
-           Not_found -> raise (Cannot_destruct ([], Missing_field "learnocaml_version"))
-       end ;
-       let id =
-         try List.assoc "id" l with
-           Not_found -> raise (Cannot_destruct ([], Missing_field "id")) in
-       let read_field k =
-         try Some (List.assoc k l) with
-           Not_found -> None in
-       read ~read_field ~id ~decipher: true ())
-    (assoc string)
+let enc = encoding

--- a/src/repo/learnocaml_exercise.mli
+++ b/src/repo/learnocaml_exercise.mli
@@ -101,6 +101,8 @@ val update: 'a File.file -> 'a -> t -> t
     ciphers it. *)
 val cipher: string File.file -> string -> t -> t
 
+val meta_from_index: Learnocaml_index.exercise -> Learnocaml_meta.meta
+
 (** Generates the exercise representation for the exercises index. *)
 val to_index: t -> Learnocaml_index.exercise
 

--- a/src/repo/learnocaml_exercise.mli
+++ b/src/repo/learnocaml_exercise.mli
@@ -15,51 +15,94 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *)
 
-(** The exercise parts required by the exercise page and the grader.
-    Not the metadata from the repository. *)
-type t
+(** Internal representation of the exercises files, including the metadata from
+    the repository. *)
 
-(** An exercise field accessor *)
-type 'a field
+type t (* =
+   * { id : string ;
+   *   meta : Learnocaml_meta.meta ;
+   *   prelude : string ;
+   *   template : string ;
+   *   descr : string ;
+   *   prepare : string ;
+   *   test : string ;
+   *   solution : string ;
+   * } *)
 
-(** Get was called on a missing undefaulted field *)
-exception Missing_field of string
+(* JSON encoding of the exercise representation. Includes cipher and decipher at
+   at encoding and decoding. *)
+val encoding: t Json_encoding.encoding
 
-(** Access a field in an exercise, may raise [Missing_field] *)
-val get: 'a field -> t -> 'a
+(** Intermediate representation of files, resulting of reading the exercise directory *)
+module File : sig
 
-(** Check the existence of a field in an exercise *)
-val has: 'a field -> t -> bool
+  (** The exercise parts required by the exercise page and the grader.
+      Not the metadata from the repository. *)
+  type files
 
-(** Access a field in an exercise *)
-val set: 'a field -> 'a -> t -> t
+  (** An exercise file accessor *)
+  type 'a file
 
-(** Learnocaml_exercise id accessor *)
-val id: string field
+  (** Get was called on a missing undefaulted field *)
+  exception Missing_file of string
 
-(** Learnocaml_exercise title / name accessor *)
-val title: string field
+  (** Access a field in an exercise, may raise [Missing_field] *)
+  val get: 'a file -> files -> 'a
 
-(** Maximum score for the exercise *)
-val max_score: int field
+  (** Check the existence of a field in an exercise *)
+  val has: 'a file -> files -> bool
 
-(** Returns the (private, already decyphered) [prepare.ml] *)
-val prepare: string field
+  (** Access a field in an exercise *)
+  val set: 'a file -> 'a -> files -> files
 
-(** Returns the (private, already decyphered) [solution.ml] *)
-val solution: string field
+  (** Learnocaml_exercise id accessor *)
+  val id: string file
 
-(** Returns the (private, already decyphered) [test.ml] *)
-val test: string field
+  (** Learnocaml_exercise title / name accessor *)
+  val title: string file
 
-(** Returns the (public) [prelude.ml] *)
-val prelude: string field
+  (** Maximum score for the exercise *)
+  val max_score: int file
 
-(** Returns the (public) [template.ml] *)
-val template: string field
+  (** Returns the (private, already decyphered) [prepare.ml] *)
+  val prepare: string file
 
-(** Returns the (public) [descr.html] *)
-val descr: string field
+  (** Returns the (private, already decyphered) [solution.ml] *)
+  val solution: string file
+
+  (** Returns the (private, already decyphered) [test.ml] *)
+  val test: string file
+
+  (** Returns the (public) [prelude.ml] *)
+  val prelude: string file
+
+  (** Returns the (public) [template.ml] *)
+  val template: string file
+
+  (** Returns the (public) [descr.html] *)
+  val descr: string file
+
+end
+
+(** Access a field from the exercise, using the [t] representation, without **
+    deciphering it. May raise [Missing_file] if the field is optional and set to
+    [None]. *)
+val access: 'a File.file -> t -> 'a
+
+(** Access a string field from the exercise, using the [t] representation, and
+    deciphers if necessary. May raise [Missing_file] if the field is optional and
+    set to [None]. *)
+val decipher: string File.file -> t -> string
+
+(** Updates the value of a field of the exercise in its [t] representation. *)
+val update: 'a File.file -> 'a -> t -> t
+
+(** Updates the value of a field of the exercise in its [t] representation, and
+    ciphers it. *)
+val cipher: string File.file -> string -> t -> t
+
+(** Generates the exercise representation for the exercises index. *)
+val to_index: t -> Learnocaml_index.exercise
 
 (** Reader and decipherer *)
 val read:
@@ -85,5 +128,5 @@ val write_lwt:
   t -> ?cipher:bool -> 'a ->
   'a Lwt.t
 
-(** JSON serializer, with {!id} field included *)
+(** JSON serializer, with {!id} file included *)
 val enc : t Json_encoding.encoding

--- a/src/repo/learnocaml_exercise.mli
+++ b/src/repo/learnocaml_exercise.mli
@@ -18,16 +18,7 @@
 (** Internal representation of the exercises files, including the metadata from
     the repository. *)
 
-type t (* =
-   * { id : string ;
-   *   meta : Learnocaml_meta.meta ;
-   *   prelude : string ;
-   *   template : string ;
-   *   descr : string ;
-   *   prepare : string ;
-   *   test : string ;
-   *   solution : string ;
-   * } *)
+type t
 
 (* JSON encoding of the exercise representation. Includes cipher and decipher at
    at encoding and decoding. *)
@@ -80,7 +71,7 @@ module File : sig
   val template: string file
 
   (** Returns the (public) [descr.html] *)
-  val descr: string file
+  val descr: (string * string) list file
 
 end
 

--- a/src/repo/learnocaml_index.mli
+++ b/src/repo/learnocaml_index.mli
@@ -41,8 +41,8 @@ and group =
     group_contents : group_contents }
 
 and group_contents =
-  | Learnocaml_exercises of exercise Map.Make (String).t
-  | Groups of group Map.Make (String).t
+  | Learnocaml_exercises of (string * exercise) list
+  | Groups of (string * group) list
 
 val exercise_index_enc : group_contents Json_encoding.encoding
 
@@ -71,7 +71,7 @@ and series =
   { series_title : string ;
     series_tutorials : tutorial list }
 
-val tutorial_index_enc : series Map.Make (String).t Json_encoding.encoding
+val tutorial_index_enc : (string * series) list Json_encoding.encoding
 
 val check_version_1 : 'a Json_encoding.encoding -> 'a Json_encoding.encoding
 

--- a/src/repo/learnocaml_index.mli
+++ b/src/repo/learnocaml_index.mli
@@ -48,6 +48,8 @@ val exercise_index_enc : group_contents Json_encoding.encoding
 
 val lesson_index_enc : (string * string) list Json_encoding.encoding
 
+val exercise_enc : exercise Json_encoding.encoding
+
 type word =
   | Text of string
   | Code of code

--- a/src/repo/learnocaml_meta.ml
+++ b/src/repo/learnocaml_meta.ml
@@ -19,7 +19,7 @@ open Learnocaml_index
 
 open Lwt.Infix
 
-type t = {
+type meta = {
   meta_kind : exercise_kind ;
   meta_stars : float ;
   meta_title : string option ;

--- a/src/repo/learnocaml_meta.ml
+++ b/src/repo/learnocaml_meta.ml
@@ -1,0 +1,105 @@
+(* This file is part of Learn-OCaml.
+ *
+ * Copyright (C) 2018 OCamlPro.
+ *
+ * Learn-OCaml is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Learn-OCaml is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *)
+
+open Learnocaml_index
+
+open Lwt.Infix
+
+type t = {
+  meta_kind : exercise_kind ;
+  meta_stars : float ;
+  meta_title : string option ;
+  meta_short_description : string option ;
+  meta_identifier : string option ;
+  meta_author : (string * string) list ;
+  meta_focus : string list ;
+  meta_requirements : string list ;
+  meta_forward : string list ;
+  meta_backward : string list ;
+  meta_max_score : int option ;
+}
+
+let exercise_kind_enc =
+  let open Json_encoding in
+  string_enum
+    [ "problem", Problem ;
+      "project", Project ;
+      "exercise", Learnocaml_exercise ]
+
+let exercise_meta_enc_v1 =
+  let open Json_encoding in
+  obj2
+    (req "kind" exercise_kind_enc)
+    (req "stars" float)
+
+let exercise_meta_enc_v2 =
+  let open Json_encoding in
+  obj9
+     (opt "title" string)
+     (opt "short_description" string)
+     (opt "identifier" string)
+     (opt "author" (list (tup2 string string)))
+     (opt "focus" (list string))
+     (opt "requirements" (list string))
+     (opt "forward" (list string))
+     (opt "backward" (list string))
+     (opt "max_score" int)
+
+let exercise_meta_enc =
+  let open Json_encoding in
+  check_version_2
+    (merge_objs
+       (merge_objs
+          exercise_meta_enc_v1
+          exercise_meta_enc_v2)
+       unit) (* FIXME: temporary parameter, that allows unknown fields *)
+
+let opt_to_list_enc = function
+    None -> []
+  | Some l -> l
+
+let encoding =
+  let open Json_encoding in
+  conv
+    (fun
+      { meta_kind ; meta_stars ; meta_title ; meta_short_description;
+        meta_identifier ; meta_author ; meta_focus ; meta_requirements ;
+        meta_forward ; meta_backward ; meta_max_score ;
+      } ->
+      (((meta_kind, meta_stars),
+        (meta_title, meta_short_description, meta_identifier,
+         Some meta_author, Some meta_focus, Some meta_requirements,
+         Some meta_forward, Some meta_backward, meta_max_score)),
+       ()))
+    (fun (((meta_kind, meta_stars),
+           (meta_title, meta_short_description,
+            meta_identifier,
+            author, focus, requirements,
+            forward, backward, meta_max_score)),
+          _) ->
+      { meta_kind ; meta_stars ;
+        meta_title ;
+        meta_short_description;
+        meta_identifier ;
+        meta_author = opt_to_list_enc author ;
+        meta_focus = opt_to_list_enc focus ;
+        meta_requirements = opt_to_list_enc requirements ;
+        meta_forward = opt_to_list_enc forward ;
+        meta_backward = opt_to_list_enc backward ;
+        meta_max_score ;
+      })
+    exercise_meta_enc

--- a/src/repo/learnocaml_meta.ml
+++ b/src/repo/learnocaml_meta.ml
@@ -17,8 +17,6 @@
 
 open Learnocaml_index
 
-open Lwt.Infix
-
 type meta = {
   meta_kind : exercise_kind ;
   meta_stars : float ;

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -52,45 +52,6 @@ let index_enc =
         (function | `Groups map -> Some map | _ -> None)
         (fun map -> `Groups map) ]
 
-let exercise_kind_enc =
-  let open Json_encoding in
-  string_enum
-    [ "problem", Problem ;
-      "project", Project ;
-      "exercise", Learnocaml_exercise ]
-
-let exercise_meta_enc_v1 =
-  let open Json_encoding in
-  obj2
-    (req "kind" exercise_kind_enc)
-    (req "stars" float)
-
-let exercise_meta_enc_v2 =
-  let open Json_encoding in
-  obj9
-     (opt "title" string)
-     (opt "short_description" string)
-     (opt "identifier" string)
-     (opt "author" (list (tup2 string string)))
-     (opt "focus" (list string))
-     (opt "requirements" (list string))
-     (opt "forward" (list string))
-     (opt "backward" (list string))
-     (opt "max_score" int)
-
-let exercise_meta_enc =
-  let open Json_encoding in
-  check_version_2
-    (merge_objs
-       (merge_objs
-          exercise_meta_enc_v1
-          exercise_meta_enc_v2)
-       unit) (* FIXME: temporary parameter, that allows unknown fields *)
-
-let opt_to_list_enc = function
-    None -> []
-  | Some l -> l
-
 let to_file encoding fn value =
   Lwt_io.(with_file ~mode: Output) fn @@ fun chan ->
   let json = Json_encoding.construct encoding value in
@@ -203,7 +164,7 @@ let main dest_dir =
              List.fold_left
                (fun acc id ->
                   all_exercises := id :: !all_exercises ;
-                  from_file exercise_meta_enc (!exercises_dir / id / "meta.json")
+                  from_file Learnocaml_meta.exercise_meta_enc (!exercises_dir / id / "meta.json")
                   >>= fun (((exercise_kind, exercise_stars),
                             (title, exercise_short_description,
                              exercise_identifier,

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -163,49 +163,19 @@ let main dest_dir =
          | `Exercises ids ->
              List.fold_left
                (fun acc id ->
-                  all_exercises := id :: !all_exercises ;
-                  from_file Learnocaml_meta.exercise_meta_enc (!exercises_dir / id / "meta.json")
-                  >>= fun (((exercise_kind, exercise_stars),
-                            (title, exercise_short_description,
-                             exercise_identifier,
-                             author, focus, requirements,
-                             forward, backward, max_score)),
-                           _) ->
                   let exercise =
                     read_exercise (!exercises_dir / id) in
-                  let exercise_title =
-                    match title with
-                    | Some title -> title
-                    | None -> Learnocaml_exercise.(get title) exercise
-                  in
-                  let exercise_max_score =
-                    match max_score with
-                    | Some max_score -> Some max_score
-                    | None ->
-                        try Some (Learnocaml_exercise.(get max_score) exercise)
-                        with Learnocaml_exercise.Missing_field _ -> None
-                  in
-                  let exercise =
-                    { exercise_kind ; exercise_stars ;
-                      exercise_title ;
-                      exercise_short_description;
-                      exercise_identifier ;
-                      exercise_author = opt_to_list_enc author ;
-                      exercise_focus = opt_to_list_enc focus ;
-                      exercise_requirements = opt_to_list_enc requirements ;
-                      exercise_forward = opt_to_list_enc forward ;
-                      exercise_backward = opt_to_list_enc backward ;
-                      exercise_max_score ;
-                    } in
+                  all_exercises := (id, exercise) :: !all_exercises ;
+                  let exercise_indexed = Learnocaml_exercise.to_index exercise in
                   acc >>= fun acc ->
-                  Lwt.return (StringMap.add id exercise acc))
+                  Lwt.return (StringMap.add id exercise_indexed acc))
                (Lwt.return StringMap.empty) ids >>= fun exercises ->
              Lwt.return (Learnocaml_exercises exercises) in
        fill_structure structure >>= fun index ->
        to_file exercise_index_enc (dest_dir / exercise_index_path) index >>= fun () ->
        let processes_arguments =
          List.map
-           (fun id ->
+           (fun (id, exercise) ->
               let exercise_dir = !exercises_dir / id in
               let json_path = dest_dir / exercise_path id in
               let changed = try
@@ -223,17 +193,17 @@ let main dest_dir =
                 match !dump_reports with
                 | None -> None
                 | Some dir -> Some (dir / id) in
-              id, exercise_dir, json_path, changed, dump_outputs,dump_reports)
-           (List.sort_uniq compare !all_exercises) in
+              id, exercise_dir, exercise, json_path, changed, dump_outputs,dump_reports)
+           (List.sort_uniq (fun (id, _) (id', _) -> compare id id') !all_exercises) in
        begin if !n_processes = 1 then
-           Lwt_list.map_s (fun (id, exercise_dir, json_path, changed, dump_outputs,dump_reports) ->
+           Lwt_list.map_s (fun (id, exercise_dir, exercise, json_path, changed, dump_outputs,dump_reports) ->
                if not changed then begin
                  Format.printf "%-12s (no changes)@." id ;
                  Lwt.return true
                end else begin
                  Grader_cli.dump_outputs := dump_outputs ;
                  Grader_cli.dump_reports := dump_reports ;
-                 Grader_cli.grade exercise_dir (Some json_path) >>= fun result ->
+                 Grader_cli.grade exercise (Some json_path) >>= fun result ->
                  match result with
                  | 0 ->
                      Format.printf "%-12s     [OK]@." id ;
@@ -245,7 +215,7 @@ let main dest_dir =
              processes_arguments
          else
            let pool = Lwt_pool.create !n_processes (fun () -> Lwt.return ()) in
-           Lwt_list.map_p (fun (id, exercise_dir, json_path, changed, dump_outputs, dump_reports) ->
+           Lwt_list.map_p (fun (id, exercise_dir, _, json_path, changed, dump_outputs, dump_reports) ->
                Lwt_pool.use pool @@ fun () ->
                if not changed then begin
                  Format.printf "%-12s (no changes)@." id ;

--- a/src/repo/learnocaml_process_tutorial_repository.ml
+++ b/src/repo/learnocaml_process_tutorial_repository.ml
@@ -54,8 +54,6 @@ let from_file encoding fn =
   let json = Ezjsonm.from_string str in
   Lwt.return (Json_encoding.destruct encoding json)
 
-module StringMap = Map.Make (String)
-
 let main dest_dir =
   let (/) dir f =
     String.concat Filename.dir_sep [ dir ; f ] in
@@ -108,8 +106,8 @@ let main dest_dir =
                  Lwt.return server_index_handle)
               tutorials >>= fun series_tutorials ->
             acc >>= fun acc ->
-            Lwt.return (StringMap.add name { series_title ; series_tutorials } acc))
-         (Lwt.return StringMap.empty)
+            Lwt.return ((name, { series_title ; series_tutorials }) :: acc))
+         (Lwt.return [])
          series >>= fun index ->
        to_file tutorial_index_enc (dest_dir / tutorial_index_path) index >>= fun () ->
        Lwt.return true)

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -171,6 +171,10 @@ msgstr "Prec."
 msgid "Next"
 msgstr "Suiv."
 
+#: src/app/learnocaml_index_main.ml:269,35--80
+msgid "No description available for this exercise."
+msgstr "Aucune description pour cet exercice."
+
 #: src/app/learnocaml_index_main.ml:316,41--60
 msgid "Loading tutorials"
 msgstr "Chargement des tutoriels"


### PR DESCRIPTION
This PR refactors slightly how exercises are read and processed. It adds a proper representation for exercises, and correctly propagates the informations from `meta.json`.

The module `Learnocaml_exercise` now contains a proper representation for exercises, with its own encoding. The previous representation is still used as an intermediate state, which is still useful to store the result of reading files. As of now, the function `get` and `set` are both replaced by respectively `access` and `decipher`, and `update` and `cipher`. As their name suggest, only `cipher` and `decipher` can encode and decode files properly.

This also fixes #26 