### PR TITLE
Learn-ocaml build: filter exercises

### DIFF
--- a/src/repo/learnocaml_process_exercise_repository.mli
+++ b/src/repo/learnocaml_process_exercise_repository.mli
@@ -19,6 +19,7 @@
 
 val exercises_dir: string ref
 val exercises_index: string option ref
+val exercises_filtered: Set.Make(String).t ref
 val dump_outputs: string option ref
 val dump_reports: string option ref
 val n_processes: int ref


### PR DESCRIPTION
Add an option to `learn-ocaml build`: `-f` (or `--exercises-filtered`).
This option allows to select which exercises are kept in the repository. This adresses #61.