### PR TITLE
Add missing material in Test_functions_generic API

### DIFF
--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -393,6 +393,27 @@ module type S = sig
     ('ar -> 'row, 'ar -> 'urow, 'ret) args list ->
     Learnocaml_report.t
 
+  val test_function_against_solution :
+    ?gen:int ->
+    ?test: 'ret tester ->
+    ?test_stdout: io_tester ->
+    ?test_stderr: io_tester ->
+    ?before_reference:
+      (('ar -> 'row, 'ar -> 'urow, 'ret) args -> unit) ->
+    ?before_user:
+      (('ar -> 'row, 'ar -> 'urow, 'ret) args -> unit) ->
+    ?after:
+      (('ar -> 'row, 'ar -> 'urow, 'ret) args ->
+        'ret * string * string ->
+        'ret * string * string ->
+        Learnocaml_report.item list) ->
+    ?sampler:
+      (unit -> ('ar -> 'row, 'ar -> 'urow, 'ret) args) ->
+    (('ar -> 'row) Ty.ty, 'ar -> 'urow, 'ret) prot ->
+    string ->
+    ('ar -> 'row, 'ar -> 'urow, 'ret) args list ->
+    Learnocaml_report.item list
+
   val (==>) : 'params -> 'ret -> 'params * (unit -> 'ret)
 
   end
@@ -1327,6 +1348,15 @@ module Make
       test_function_against_generic ?gen
         ?test ?test_stdout ?test_stderr
         ?before_reference ?before_user ?after ?sampler prot uf rf tests
+      
+    let test_function_against_solution ?gen
+          ?test ?test_stdout ?test_stderr
+          ?before_reference ?before_user ?after ?sampler prot name tests =
+      let ty = ty_of_prot prot in
+      test_function_against_generic ?gen
+        ?test ?test_stdout ?test_stderr
+        ?before_reference ?before_user ?after ?sampler prot
+        (lookup_student ty name) (lookup_solution ty name) tests
 
   let (==>) params ret = (params, fun () -> ret)
 

--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -340,6 +340,11 @@ module type S = sig
       (('ar -> 'row) Ty.ty, 'ar -> 'urow, 'ret) prot ->
       (('a -> 'ar -> 'row) Ty.ty, ('a -> 'ar -> 'urow), 'ret) prot
 
+    val ty_of_prot :
+      (('ar -> 'row) Ty.ty, 'ar -> 'urow, 'ret) prot -> ('ar -> 'row) Ty.ty
+    val get_ret_ty :
+      ('p -> 'a) Ty.ty -> ('p -> 'a, 'p -> 'c, 'ret) args -> 'ret Ty.ty
+
     type 'a lookup = unit -> [ `Found of string * Learnocaml_report.t * 'a | `Unbound of string * Learnocaml_report.t ]
 
     val lookup : 'a Ty.ty -> ?display_name: string -> string -> 'a lookup
@@ -387,6 +392,8 @@ module type S = sig
     ('ar -> 'row) lookup -> ('ar -> 'row) lookup ->
     ('ar -> 'row, 'ar -> 'urow, 'ret) args list ->
     Learnocaml_report.t
+
+  val (==>) : 'params -> 'ret -> 'params * (unit -> 'ret)
 
   end
 
@@ -1320,6 +1327,8 @@ module Make
       test_function_against_generic ?gen
         ?test ?test_stdout ?test_stderr
         ?before_reference ?before_user ?after ?sampler prot uf rf tests
+
+  let (==>) params ret = (params, fun () -> ret)
 
   end
 

--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -307,14 +307,25 @@ module type S = sig
     (*----------------------------------------------------------------------------*)
 
     (* Usage: arg 3 @@ arg "word" @@ last false *)
+    (* Alternatively: 3 @: "word" @:!! false *)
     type ('arrow, 'uarrow, 'ret) args
     val last :
+      'a ->
+      ('a -> 'ret, 'a -> unit, 'ret) args
+    val (!!) :
       'a ->
       ('a -> 'ret, 'a -> unit, 'ret) args
     val arg :
       'a ->
       ('ar -> 'row, 'ar -> 'urow, 'ret) args ->
       ('a -> 'ar -> 'row, 'a -> 'ar -> 'urow, 'ret) args
+    val (@:) :
+      'a ->
+      ('ar -> 'row, 'ar -> 'urow, 'ret) args ->
+      ('a -> 'ar -> 'row, 'a -> 'ar -> 'urow, 'ret) args
+    val (@:!!) :
+      'a -> 'b ->
+      ('a -> 'b -> 'ret, 'a -> 'b -> unit, 'ret) args
 
     val apply : ('ar -> 'row) -> ('ar -> 'row, 'ar -> 'urow, 'ret) args -> 'ret
 
@@ -1117,6 +1128,9 @@ module Make
 
     let last x = Last x
     let arg x r = Arg (x, r)
+    let (!!) = last
+    let (@:) = arg
+    let (@:!!) a b = a @: !! b
 
     type (_, _, _) prot =
       | Last_ty : 'a Ty.ty * 'r Ty.ty -> (('a -> 'r) Ty.ty, 'a -> unit, 'r) prot

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -1015,6 +1015,10 @@ module type S = sig
       (('ar -> 'row) Ty.ty, 'ar -> 'urow, 'ret) prot ->
       (('a -> 'ar -> 'row) Ty.ty, ('a -> 'ar -> 'urow), 'ret) prot
 
+    val ty_of_prot :
+      (('ar -> 'row) Ty.ty, 'ar -> 'urow, 'ret) prot -> ('ar -> 'row) Ty.ty
+    val get_ret_ty :
+      ('p -> 'a) Ty.ty -> ('p -> 'a, 'p -> 'c, 'ret) args -> 'ret Ty.ty
 
     (** {2 Lookup functions} *)
 
@@ -1072,6 +1076,15 @@ module type S = sig
       ('ar -> 'row) lookup -> ('ar -> 'row) lookup ->
       ('ar -> 'row, 'ar -> 'urow, 'ret) args list ->
       Learnocaml_report.t
+
+    (** Helper notation to test pure functions.
+
+        [p ==> r] is the pair [(p, fun () -> r)].
+
+        Example: [test_function prot
+                  (lookup_student (ty_of_prot prot) name)
+                  [1 @: 2 @: 3 @: 4 @:!! 5 ==> 15; ... ==> ...]] *)
+    val (==>) : 'params -> 'ret -> 'params * (unit -> 'ret)
   end
 
     (** [r1 @@@ r2] is the function [x -> r1 x @ r2 x]. *)

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -976,15 +976,28 @@ module type S = sig
 
     (** The type of arguments, represented as heterogeneous lists.
 
-        Usage : [arg 3 @@ arg "word" @@ last false] *)
+        Usage: [arg 3 @@ arg "word" @@ last false]
+        
+        Alternatively: [3 @: "word" @:!! false]
+     *)
     type ('arrow, 'uarrow, 'ret) args
     val last :
+      'a ->
+      ('a -> 'ret, 'a -> unit, 'ret) args
+    val (!!) :
       'a ->
       ('a -> 'ret, 'a -> unit, 'ret) args
     val arg :
       'a ->
       ('ar -> 'row, 'ar -> 'urow, 'ret) args ->
       ('a -> 'ar -> 'row, 'a -> 'ar -> 'urow, 'ret) args
+    val (@:) :
+      'a ->
+      ('ar -> 'row, 'ar -> 'urow, 'ret) args ->
+      ('a -> 'ar -> 'row, 'a -> 'ar -> 'urow, 'ret) args
+    val (@:!!) :
+      'a -> 'b ->
+      ('a -> 'b -> 'ret, 'a -> 'b -> unit, 'ret) args
 
     val apply : ('ar -> 'row) -> ('ar -> 'row, 'ar -> 'urow, 'ret) args -> 'ret
 

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -1077,6 +1077,29 @@ module type S = sig
       ('ar -> 'row, 'ar -> 'urow, 'ret) args list ->
       Learnocaml_report.t
 
+    (** [test_function_against_solution ~gen ~test ~test_stdout ~test_stderr
+        ~before_reference ~before_user ~after ~sampler prot name tests] *)
+    val test_function_against_solution :
+      ?gen:int ->
+      ?test: 'ret tester ->
+      ?test_stdout: io_tester ->
+      ?test_stderr: io_tester ->
+      ?before_reference:
+        (('ar -> 'row, 'ar -> 'urow, 'ret) args -> unit) ->
+      ?before_user:
+        (('ar -> 'row, 'ar -> 'urow, 'ret) args -> unit) ->
+      ?after:
+        (('ar -> 'row, 'ar -> 'urow, 'ret) args ->
+         'ret * string * string ->
+         'ret * string * string ->
+         Learnocaml_report.item list) ->
+      ?sampler:
+        (unit -> ('ar -> 'row, 'ar -> 'urow, 'ret) args) ->
+      (('ar -> 'row) Ty.ty, 'ar -> 'urow, 'ret) prot ->
+      string ->
+      ('ar -> 'row, 'ar -> 'urow, 'ret) args list ->
+      Learnocaml_report.item list
+
     (** Helper notation to test pure functions.
 
         [p ==> r] is the pair [(p, fun () -> r)].


### PR DESCRIPTION
Dear learn-ocaml developers,

I'd like to propose these additions in `Test_functions_generic.`

As we had chosen to directly rely on the generic versions of the grading functions in learn-ocaml-editor's semi-automatic test.ml generator, these additions were necessary to be able to define tests as easily as when using fixed-arity `test_function_{1,2,3,4}` primitives.

I added some ocaml-doc and the PR is split into 3 commits (see the commit messages for details).

Kind regards, Erik