### PR TITLE
Generalize assignments

### DIFF
--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -873,7 +873,9 @@ let teacher_tab token _select _params () =
                     match AM.find_opt assg am with
                     | None -> AM.add assg (Token.Set.singleton tok) am
                     | Some ts -> AM.add assg (Token.Set.add tok ts) am)
-                  AM.empty
+                  (AM.singleton
+                     (Exercise.Status.default_assignment a)
+                     Token.Set.empty)
               in
               AM.fold (fun assg toks atm ->
                   match ATM.find_opt (assg, toks) atm with
@@ -1067,11 +1069,8 @@ let teacher_tab token _select _params () =
      | Some l -> Manip.replaceSelf l (assignment_line id)
      | None -> failwith "Assignment line not found");
     let set_assg st tmap default_assignment =
-      if Token.Map.is_empty tmap then
-        Exercise.Status.{st with status = Closed}
-      else
-        let a = Exercise.Status.make_assignments tmap default_assignment in
-        Exercise.Status.{st with status = Assigned a}
+      let a = Exercise.Status.make_assignments tmap default_assignment in
+      Exercise.Status.{st with status = Assigned a}
     in
     let ch =
       SSet.fold (fun ex_id acc ->
@@ -1091,7 +1090,7 @@ let teacher_tab token _select _params () =
               students tmap
           in
           (* The most recent assignment is used for students that will
-             register *after* the creation of these assignments. *)
+             register *after* the creation of this homework. *)
           let default_assignment =
             assg
           in

--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -648,6 +648,7 @@ let teacher_tab token _select _params () =
   let student_change = ref (fun _ -> assert false) in
   let assignment_change = ref (fun _ -> assert false) in
   let assignment_remove = ref (fun _ -> assert false) in
+  let assignment_set_mode = ref (fun _ _ -> assert false) in
 
   (* Exercises table *)
   let rec mk_table group_level acc status group =
@@ -796,8 +797,29 @@ let teacher_tab token _select _params () =
           ();
       ]
     in
+    let switch_autobox ~current_mode mode1 mode2 =
+      let switch = ref current_mode in
+      let next () = switch := not !switch in
+      let get () = if !switch then mode1 else mode2 in
+      let id = Random.(Printf.sprintf "switch_%x%x" (bits ()) (bits ())) in
+      fun cb ->
+      let cb _ =
+        next ();
+        cb !switch;
+        begin match Manip.by_id id with
+        | None ->
+           ()
+        | Some id ->
+           Manip.(replaceChildren id [get ()]);
+        end;
+        true
+      in
+      H.span ~a:[H.a_id id; H.a_onclick cb] [get ()]
+    in
     let hid = assg_line_id id in
-    let (assg, tokens, exo_ids) = Hashtbl.find assignments_tbl id in
+    let (assg, tokens, exo_ids, current_mode) =
+      Hashtbl.find assignments_tbl id
+    in
     let cls =
       let n = gettimeofday () in
       if assg.Exercise.Status.stop < n then ["assg_finished"]
@@ -820,6 +842,10 @@ let teacher_tab token _select _params () =
       H.td [date ("stop_"^hid) id assg.Exercise.Status.stop];
       H.td [H.pcdata (Printf.sprintf [%if"%d exercises"] (SSet.cardinal exo_ids))];
       H.td [H.pcdata (Printf.sprintf [%if"%d students"] (Token.Set.cardinal tokens))];
+      H.td [switch_autobox ~current_mode
+                (H.pcdata [%i"auto"])
+                (H.pcdata [%i"manual"])
+                (!assignment_set_mode id)];
       H.td ~a:[H.a_onclick (fun _ -> !assignment_remove id; false);
                H.a_class ["remove-cross"]]
         [H.pcdata "\xe2\xa8\x82" (* U+2A02 *)];
@@ -868,6 +894,7 @@ let teacher_tab token _select _params () =
           match st.Exercise.Status.status with
           | Exercise.Status.Open | Exercise.Status.Closed -> atm
           | Exercise.Status.Assigned a ->
+             let mode = Exercise.Status.is_automatic a in
               let am =
                 Exercise.Status.fold_over_assignments a (fun tok assg am ->
                     match AM.find_opt assg am with
@@ -879,17 +906,19 @@ let teacher_tab token _select _params () =
               in
               AM.fold (fun assg toks atm ->
                   match ATM.find_opt (assg, toks) atm with
-                  | None -> ATM.add (assg, toks) (SSet.singleton id) atm
-                  | Some ids -> ATM.add (assg, toks) (SSet.add id ids) atm)
+                  | None ->
+                     ATM.add (assg, toks) (SSet.singleton id, mode) atm
+                  | Some (ids, mode) ->
+                     ATM.add (assg, toks) (SSet.add id ids, mode) atm)
                 am atm)
         (status_current ())
         ATM.empty
     in
     let line_n = ref 0 in
-    let make_line ?selected assg tokens exo_ids =
+    let make_line ?selected assg tokens exo_ids mode =
       incr line_n;
       let id = !line_n in
-      Hashtbl.add assignments_tbl id (assg, tokens, exo_ids);
+      Hashtbl.add assignments_tbl id (assg, tokens, exo_ids, mode);
       assignment_line id
     in
     let new_assg_id = "new_assignment" in
@@ -921,7 +950,7 @@ let teacher_tab token _select _params () =
       in
       let line =
         make_line
-          Exercise.Status.{start; stop} tokens exercises
+          Exercise.Status.{start; stop} tokens exercises true
       in
       let id = !line_n in
       Dom.insertBefore (H.toelt table)
@@ -933,8 +962,8 @@ let teacher_tab token _select _params () =
     Manip.Ev.onclick new_assg_line (fun _ -> new_assignment (); false);
     Manip.replaceChildren table @@
     (List.rev
-       (ATM.fold (fun (assg, tokens) exos acc ->
-            make_line assg tokens exos :: acc)
+       (ATM.fold (fun (assg, tokens) (exos, mode) acc ->
+            make_line assg tokens exos mode :: acc)
            atm [])) @
     [new_assg_line];
     table
@@ -1058,13 +1087,14 @@ let teacher_tab token _select _params () =
     | Some elt -> class_f elt "selected"
     | None -> ()
   in
-  let set_assignment ?(reopen=false) ?assg ?students ?exos id =
-    let (assg0, students0, exos0) = Hashtbl.find assignments_tbl id in
+  let set_assignment ?(reopen=false) ?assg ?students ?exos ?mode id =
+    let (assg0, students0, exos0, mode0) = Hashtbl.find assignments_tbl id in
     let dft x0 = function Some x -> x | None -> x0 in
     let assg = dft assg0 assg in
     let students = dft students0 students in
     let exos = dft exos0 exos in
-    Hashtbl.replace assignments_tbl id (assg, students, exos);
+    let mode = dft mode0 mode in
+    Hashtbl.replace assignments_tbl id (assg, students, exos, mode);
     (match Manip.by_id (assg_line_id id) with
      | Some l -> Manip.replaceSelf l (assignment_line id)
      | None -> failwith "Assignment line not found");
@@ -1072,8 +1102,13 @@ let teacher_tab token _select _params () =
       if reopen then
         Exercise.Status.{st with status = Open}
       else
+        let mode =
+          (* For the moment, we only offer two modes, manual
+             or automatic. *)
+          Exercise.Status.(if mode then True else False)
+        in
         let a =
-          Exercise.Status.(make_assignments tmap default_assignment0 True)
+          Exercise.Status.(make_assignments tmap default_assignment0 mode)
         in
         Exercise.Status.{st with status = Assigned a}
     in
@@ -1139,7 +1174,7 @@ let teacher_tab token _select _params () =
         (all_exercises !exercises_index)
     in
     let current_assignment = match !selected_assignment with
-      | Some id -> let _, _, exos = Hashtbl.find assignments_tbl id in exos
+      | Some id -> let _, _, exos, _ = Hashtbl.find assignments_tbl id in exos
       | None -> SSet.empty
     in
     disabled
@@ -1162,7 +1197,7 @@ let teacher_tab token _select _params () =
         !students_map
     in
     let current_assignment = match !selected_assignment with
-      | Some id -> let _, std, _ = Hashtbl.find assignments_tbl id in std
+      | Some id -> let _, std, _, _ = Hashtbl.find assignments_tbl id in std
       | None -> Token.Set.empty
     in
     disabled
@@ -1226,7 +1261,7 @@ let teacher_tab token _select _params () =
       match Manip.by_id (assg_line_id id) with
       | None -> ()
       | Some line ->
-          let (assg, students, exos) = Hashtbl.find assignments_tbl id in
+          let (assg, students, exos, _) = Hashtbl.find assignments_tbl id in
           !toggle_selected_exercises ~force:false
             (all_exercises !exercises_index);
           !toggle_selected_exercises ~force:true (SSet.elements exos);
@@ -1263,7 +1298,7 @@ let teacher_tab token _select _params () =
     ()
   end;
   assignment_change := begin fun assg_id ->
-    let (assg0, _, _) = Hashtbl.find assignments_tbl assg_id in
+    let (assg0, _, _, _) = Hashtbl.find assignments_tbl assg_id in
     let get_date id =
       let retr =
         match Manip.by_id ("date_"^id), Manip.by_id ("time_"^id) with
@@ -1294,6 +1329,13 @@ let teacher_tab token _select _params () =
     let assg = Exercise.Status.{start; stop} in
     set_assignment assg_id ~assg
   end;
+
+  assignment_set_mode := begin fun assg_id mode ->
+    Lwt.async @@ fun () ->
+    set_assignment assg_id ~mode;
+    Lwt.return_unit;
+  end;
+
   assignment_remove := begin fun assg_id ->
     Lwt.async @@ fun () ->
     set_assignment

--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -1068,11 +1068,13 @@ let teacher_tab token _select _params () =
     (match Manip.by_id (assg_line_id id) with
      | Some l -> Manip.replaceSelf l (assignment_line id)
      | None -> failwith "Assignment line not found");
-    let set_assg st tmap default_assignment =
+    let set_assg st tmap default_assignment0 =
       if reopen then
         Exercise.Status.{st with status = Open}
       else
-        let a = Exercise.Status.make_assignments tmap default_assignment in
+        let a =
+          Exercise.Status.(make_assignments tmap default_assignment0 True)
+        in
         Exercise.Status.{st with status = Assigned a}
     in
     let ch =

--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -1066,11 +1066,11 @@ let teacher_tab token _select _params () =
     (match Manip.by_id (assg_line_id id) with
      | Some l -> Manip.replaceSelf l (assignment_line id)
      | None -> failwith "Assignment line not found");
-    let set_assg st tmap =
+    let set_assg st tmap default_assignment =
       if Token.Map.is_empty tmap then
         Exercise.Status.{st with status = Closed}
       else
-        let a = Exercise.Status.assignments_of_token_map tmap in
+        let a = Exercise.Status.make_assignments tmap default_assignment in
         Exercise.Status.{st with status = Assigned a}
     in
     let ch =
@@ -1090,7 +1090,12 @@ let teacher_tab token _select _params () =
             Token.Set.fold (fun tk -> Token.Map.add tk assg)
               students tmap
           in
-          SMap.add ex_id (set_assg st tmap) acc)
+          (* The most recent assignment is used for students that will
+             register *after* the creation of these assignments. *)
+          let default_assignment =
+            assg
+          in
+          SMap.add ex_id (set_assg st tmap default_assignment) acc)
         exos
         !status_changes
     in
@@ -1106,7 +1111,10 @@ let teacher_tab token _select _params () =
           let tmap =
             Token.Set.fold (fun tk -> Token.Map.remove tk) students0 tmap0
           in
-          SMap.add ex_id (set_assg st tmap) acc)
+          let default_assignment =
+            assg
+          in
+          SMap.add ex_id (set_assg st tmap default_assignment) acc)
         (SSet.diff exos0 exos)
         ch
     in

--- a/src/state/learnocaml_data.ml
+++ b/src/state/learnocaml_data.ml
@@ -400,6 +400,10 @@ module Exercise = struct
         precondition       : assignment_precondition;
       }
 
+    let is_automatic a =
+      (* We encode manual assignment by False. *)
+      a.precondition <> False
+
     let is_open_assignment token a =
       match Token.Map.find_opt token a.token_map with
       | Some a ->

--- a/src/state/learnocaml_data.ml
+++ b/src/state/learnocaml_data.ml
@@ -385,9 +385,6 @@ module Exercise = struct
         default_assignment : assignment
       }
 
-    let no_assignment a =
-      Token.Map.is_empty a.token_map
-
     let is_open_assignment token a =
       match Token.Map.find_opt token a.token_map with
       | Some a ->
@@ -410,6 +407,9 @@ module Exercise = struct
 
     let is_token_eligible _ _ =
       true
+
+    let default_assignment a =
+      a.default_assignment
 
     let assignment_for_token a _ =
       a.default_assignment

--- a/src/state/learnocaml_data.ml
+++ b/src/state/learnocaml_data.ml
@@ -380,10 +380,35 @@ module Exercise = struct
       stop: float;
     }
 
+    type assignments =
+      assignment Token.Map.t
+
+    let no_assignment = Token.Map.is_empty
+
+    let is_open_assignment token a =
+      match Token.Map.find_opt token a with
+      | Some a ->
+         let t = Unix.gettimeofday () in
+         if t < a.start then `Closed
+         else `Deadline (a.stop -. t)
+      | None -> `Closed
+
+    let exists_assignment a pred =
+      Token.Map.exists pred a
+
+    let fold_over_assignments a f init =
+      Token.Map.fold f a init
+
+    let token_map_of_assignments a =
+      a
+
+    let assignments_of_token_map a =
+      a
+
     type status =
       | Open
       | Closed
-      | Assigned of assignment Token.Map.t
+      | Assigned of assignments
 
     type t = {
       id: id;

--- a/src/state/learnocaml_data.ml
+++ b/src/state/learnocaml_data.ml
@@ -380,13 +380,16 @@ module Exercise = struct
       stop: float;
     }
 
-    type assignments =
-      assignment Token.Map.t
+    type assignments = {
+        token_map          : assignment Token.Map.t;
+        default_assignment : assignment
+      }
 
-    let no_assignment = Token.Map.is_empty
+    let no_assignment a =
+      Token.Map.is_empty a.token_map
 
     let is_open_assignment token a =
-      match Token.Map.find_opt token a with
+      match Token.Map.find_opt token a.token_map with
       | Some a ->
          let t = Unix.gettimeofday () in
          if t < a.start then `Closed
@@ -394,16 +397,29 @@ module Exercise = struct
       | None -> `Closed
 
     let exists_assignment a pred =
-      Token.Map.exists pred a
+      Token.Map.exists pred a.token_map
 
     let fold_over_assignments a f init =
-      Token.Map.fold f a init
+      Token.Map.fold f a.token_map init
 
     let token_map_of_assignments a =
-      a
+      a.token_map
 
-    let assignments_of_token_map a =
-      a
+    let make_assignments token_map default_assignment =
+      { token_map; default_assignment }
+
+    let is_token_eligible _ _ =
+      true
+
+    let assignment_for_token a _ =
+      a.default_assignment
+
+    let consider_token_for_assignment a t =
+      if is_token_eligible a t then
+        let assignment = assignment_for_token a t in
+        Some { a with token_map = Token.Map.add t assignment a.token_map }
+      else
+        None
 
     type status =
       | Open
@@ -418,18 +434,34 @@ module Exercise = struct
 
     let enc =
       let assignments_enc =
+        let token_map_enc =
+          J.conv
+            (fun m ->
+              Token.Map.bindings m |> List.map (fun (tok, a) ->
+                                          Token.to_string tok,
+                                          (a.start, a.stop)))
+            (List.fold_left (fun acc (tok, (start, stop)) ->
+                 Token.Map.add (Token.parse tok) {start; stop} acc)
+               Token.Map.empty)
+            (J.assoc
+               (J.obj2
+                  (J.req "start" J.float)
+                  (J.req "stop" J.float)))
+        in
+        let assignment_enc =
+          J.conv
+            (fun a -> (a.start, a.stop))
+            (fun (start, stop) -> { start; stop })
+            (J.obj2
+               (J.req "start" J.float)
+               (J.req "stop" J.float))
+        in
         J.conv
-          (fun m ->
-             Token.Map.bindings m |> List.map (fun (tok, a) ->
-                 Token.to_string tok,
-                 (a.start, a.stop)))
-          (List.fold_left (fun acc (tok, (start, stop)) ->
-               Token.Map.add (Token.parse tok) {start; stop} acc)
-              Token.Map.empty)
-          (J.assoc
-             (J.obj2
-                (J.req "start" J.float)
-                (J.req "stop" J.float)))
+          (fun a -> (a.token_map, a.default_assignment))
+          (fun (t, d) -> { token_map = t; default_assignment = d})
+          (J.obj2
+             (J.req "token_map" token_map_enc)
+             (J.req "default_assignment" assignment_enc))
       in
       let status_enc =
         J.union [

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -167,8 +167,11 @@ module Exercise: sig
     val token_map_of_assignments:
       assignments -> assignment Token.Map.t
 
-    val assignments_of_token_map:
-      assignment Token.Map.t -> assignments
+    val make_assignments:
+      assignment Token.Map.t -> assignment -> assignments
+
+    val consider_token_for_assignment:
+      assignments -> Token.t -> assignments option
 
     type status =
       | Open

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -152,11 +152,11 @@ module Exercise: sig
 
     type assignments
 
-    val no_assignment:
-      assignments -> bool
-
     val is_open_assignment:
       Token.t -> assignments -> [> `Closed | `Deadline of float]
+
+    val default_assignment:
+      assignments -> assignment
 
     val exists_assignment:
       assignments -> (Token.t -> assignment -> bool) -> bool

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -150,10 +150,30 @@ module Exercise: sig
       stop: float;
     }
 
+    type assignments
+
+    val no_assignment:
+      assignments -> bool
+
+    val is_open_assignment:
+      Token.t -> assignments -> [> `Closed | `Deadline of float]
+
+    val exists_assignment:
+      assignments -> (Token.t -> assignment -> bool) -> bool
+
+    val fold_over_assignments:
+      assignments -> (Token.t -> assignment -> 'a -> 'a) -> 'a -> 'a
+
+    val token_map_of_assignments:
+      assignments -> assignment Token.Map.t
+
+    val assignments_of_token_map:
+      assignment Token.Map.t -> assignments
+
     type status =
       | Open
       | Closed
-      | Assigned of assignment Token.Map.t
+      | Assigned of assignments
 
     type t = {
       id: id;
@@ -161,9 +181,11 @@ module Exercise: sig
       status: status;
     }
 
-    val enc: t Json_encoding.encoding
+    val enc:
+      t Json_encoding.encoding
 
-    val default: id -> t
+    val default:
+      id -> t
 
   end
 

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -167,11 +167,20 @@ module Exercise: sig
     val token_map_of_assignments:
       assignments -> assignment Token.Map.t
 
-    val make_assignments:
-      assignment Token.Map.t -> assignment -> assignments
+    type assignment_precondition =
+      | True
+      | False
+      | Or of assignment_precondition list
+      | And of assignment_precondition list
+      | Not of assignment_precondition
+      | HasTag of tag
 
-    val consider_token_for_assignment:
-      assignments -> Token.t -> assignments option
+    val make_assignments:
+      assignment Token.Map.t -> assignment -> assignment_precondition
+      -> assignments
+
+    val consider_student_for_assignment:
+      assignments -> Student.t -> assignments option
 
     type status =
       | Open

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -152,6 +152,9 @@ module Exercise: sig
 
     type assignments
 
+    val is_automatic:
+      assignments -> bool
+
     val is_open_assignment:
       Token.t -> assignments -> [> `Closed | `Deadline of float]
 

--- a/src/state/learnocaml_store.ml
+++ b/src/state/learnocaml_store.ml
@@ -237,7 +237,26 @@ module Token = struct
           Lwt.fail_with "token already exists"
       | e -> raise e
 
-  let create_student () = create_gen random
+  let check_for_student_assignments token = Exercise.Status.(
+    let check_exercise_status s =
+      match s.status with
+      | Open | Closed ->
+         Lwt.return ()
+      | Assigned a ->
+         match consider_token_for_assignment a token with
+         | None ->
+            Lwt.return ()
+         | Some a' ->
+            set { s with status = Assigned a' }
+    in
+    all () >>= Lwt_list.iter_s check_exercise_status
+  )
+
+  let create_student () =
+    create_gen random >>= fun token ->
+    check_for_student_assignments token >>= fun () ->
+    Lwt.return token
+
   let create_teacher () = create_gen random_teacher
 
   let delete token = Lwt_unix.unlink (path token)

--- a/src/state/learnocaml_store.ml
+++ b/src/state/learnocaml_store.ml
@@ -233,12 +233,18 @@ module Token = struct
       | e -> raise e
 
   let check_for_student_assignments token = Exercise.Status.(
+    let student =
+      (* FIXME:@yurug: I do not know how to load the student descriptor
+         from a token. Hence, I put a dummy student descriptor here for
+         now. *)
+      Student.{ token; nickname = None; results = SMap.empty; tags = [] }
+    in
     let check_exercise_status s =
       match s.status with
       | Open | Closed ->
          Lwt.return ()
       | Assigned a ->
-         match consider_token_for_assignment a token with
+         match consider_student_for_assignment a student with
          | None ->
             Lwt.return ()
          | Some a' ->

--- a/src/state/learnocaml_store.ml
+++ b/src/state/learnocaml_store.ml
@@ -157,7 +157,7 @@ module Exercise = struct
       fun x ->
         let x =
           { x with status = match x.status with
-                | Assigned tm when Token.Map.is_empty tm -> Closed
+                | Assigned tm when no_assignment tm -> Closed
                 | s -> s }
         in
         Lwt_mutex.with_lock mutex @@ fun () ->
@@ -180,13 +180,7 @@ module Exercise = struct
       match status with
       | Open -> `Open
       | Closed -> `Closed
-      | Assigned a ->
-          match Token.Map.find_opt token a with
-          | Some a ->
-              let t = Unix.gettimeofday () in
-              if t < a.start then `Closed
-              else `Deadline (a.stop -. t)
-          | None -> `Closed
+      | Assigned a -> is_open_assignment token a
 
   end
 

--- a/src/state/learnocaml_store.ml
+++ b/src/state/learnocaml_store.ml
@@ -155,11 +155,6 @@ module Exercise = struct
     let set =
       let mutex = Lwt_mutex.create () in
       fun x ->
-        let x =
-          { x with status = match x.status with
-                | Assigned tm when no_assignment tm -> Closed
-                | s -> s }
-        in
         Lwt_mutex.with_lock mutex @@ fun () ->
         Lazy.force tbl >>= fun tbl ->
         Hashtbl.replace tbl x.id x;


### PR DESCRIPTION
This pull request introduces a generalization of assignments. 

Currently, assignments are manually defined by the teacher by picking students one-by-one in a list widget and by assigning them an assignment. This is not convenient for at least two reasons: (i) the students list can be very long ; (ii) the students list can be incomplete because some students might have not registered at the time of homework creation.

Now, assignments are defined by a precondition (i.e. a filter predicate) which is applied automatically on each student at homework creation time and when a new student registers.