### PR TITLE
Add basic support for HTTPS with a '--cert' option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,13 @@ VOLUME ["/repository"]
 RUN mkdir -p /sync && chown learn-ocaml:learn-ocaml /sync
 VOLUME ["/sync"]
 EXPOSE 8080
+EXPOSE 8443
 
 USER learn-ocaml
 WORKDIR /home/learn-ocaml
 
 CMD ["build","serve"]
-ENTRYPOINT ["dumb-init","learn-ocaml","--sync-dir=/sync","--repo=/repository","--port=8080"]
+ENTRYPOINT ["dumb-init","learn-ocaml","--sync-dir=/sync","--repo=/repository"]
 
 COPY --from=compilation /home/opam/install-prefix /usr
 

--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -23,6 +23,7 @@ depends: [
   "js_of_ocaml-lwt"
   "js_of_ocaml-tyxml"
   "lwt" {= "3.1.0"}
+  "lwt_ssl"
   "ocp-indent-nlfork"
   "ocp-ocamlres" {= "0.4"}
   "ocplib-json-typed" {= "0.6"}

--- a/src/.merlin
+++ b/src/.merlin
@@ -18,4 +18,5 @@ PKG omd
 PKG markup
 PKG uutf
 PKG js_of_ocaml.ppx
+PKG cmdliner
 FLG -ppx ../_obuild/ppx_ocplib_i18n/ppx_ocplib_i18n.asm

--- a/src/server/learnocaml_server.mli
+++ b/src/server/learnocaml_server.mli
@@ -20,6 +20,7 @@
 val static_dir: string ref
 val sync_dir: string ref
 val port: int ref
+val cert_key_files: (string * string) option ref
 
 val args: (Arg.key * Arg.spec * Arg.doc) list
 


### PR DESCRIPTION
Not sure it scales to a proper certificate chain, but works well enough with a self-signed cert. You can generate one using:

    openssl req -x509 -newkey rsa:4096 -keyout learnocaml-server.key -out learnocaml-server.pem -days 365 -nodes -subj '/CN=localhost'

(adjust `localhost` with your hostname!) then pass the option `--cert learnocaml-server` to learn-ocaml.