### PR TITLE
Fix error with 'sync' on expired exercises

### DIFF
--- a/src/app/learnocaml_common.ml
+++ b/src/app/learnocaml_common.ml
@@ -428,7 +428,6 @@ let countdown ?(ontimeout = fun () -> ()) container t =
   in
   let rec callback () =
     let remaining = int_of_float (deadline -. gettimeofday ()) in
-    Firebug.console##log(Js.string (Printf.sprintf "Remaining: %f - %f = %ds" deadline (gettimeofday ()) remaining));
     if remaining <= 0 then
       (update 0;
        ontimeout ())

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -108,11 +108,13 @@ let set_string_translations () =
        Manip.setInnerHtml (find_component id) text)
     translations
 
+let is_readonly = ref false
+
 let make_readonly () =
-  match Manip.by_id "learnocaml-exo-editor-pane" with None -> () | Some ed ->
-    alert ~title:[%i"TIME'S UP"]
-      [%i"The deadline for this exercise has expired. Any changes you make \
-          from now on will remain local only."]
+  is_readonly := true;
+  alert ~title:[%i"TIME'S UP"]
+    [%i"The deadline for this exercise has expired. Any changes you make \
+        from now on will remain local only."]
 
 let () =
   Lwt.async_exception_hook := begin function
@@ -345,12 +347,11 @@ let () =
       { Answer.report ; grade ; solution ;
         mtime = gettimeofday () } ;
     sync token >|= fun save ->
-    let solution =
-      (SMap.find
-         id save.Save.all_exercise_states)
-      .Answer.solution
-    in
-    Ace.set_contents ace solution
+    if not !is_readonly then
+      match SMap.find_opt id save.Save.all_exercise_states with
+      | Some s -> Ace.set_contents ace s.Answer.solution
+      | None -> ()
+      (* exercise expired server-side, so the submission was ignored *)
   end ;
   begin editor_button
       ~icon: "download" [%i"Download"] @@ fun () ->


### PR DESCRIPTION
Closes #116

the error actually happened only if there was no submission before the 
deadline, and with the 'sync' button, but not the 'grade' button (which also
does sync after doing the grading).