### PR TITLE
Separate submitted solutions from saved state, sync just the current exercise

### DIFF
--- a/src/app/learnocaml_common.mli
+++ b/src/app/learnocaml_common.mli
@@ -102,6 +102,12 @@ val get_state_as_save_file : unit -> Save.t
     file. The save will be created on the server if it doesn't exist. *)
 val sync: Token.t -> Save.t Lwt.t
 
+(** The same, but limiting the submission to the given exercise, using the given
+   answer if any. *)
+val sync_exercise:
+  Token.t -> ?answer:Learnocaml_data.Answer.t -> Learnocaml_data.Exercise.id ->
+  Save.t Lwt.t
+
 val countdown:
   ?ontimeout: (unit -> unit) -> 'a Tyxml_js.Html5.elt -> float -> unit
 

--- a/src/app/learnocaml_common.mli
+++ b/src/app/learnocaml_common.mli
@@ -93,19 +93,25 @@ val render_rich_text :
 
 val extract_text_from_rich_text : Learnocaml_data.Tutorial.text -> string
 
+(** Sets the local storage from the data in a save file *)
 val set_state_from_save_file :
   ?token:Token.t -> Save.t -> unit
 
-val get_state_as_save_file : unit -> Save.t
+(** Gets a save file containing the locally stored data *)
+val get_state_as_save_file : ?include_reports:bool -> unit -> Save.t
 
 (** Sync the local save state with the server state, and returns the merged save
-    file. The save will be created on the server if it doesn't exist. *)
+    file. The save will be created on the server if it doesn't exist.
+
+    This syncs student {b,content}, but never the reports which are only synched
+    on "Grade" *)
 val sync: Token.t -> Save.t Lwt.t
 
 (** The same, but limiting the submission to the given exercise, using the given
-   answer if any. *)
+    answer if any, and the given editor text, if any. *)
 val sync_exercise:
-  Token.t -> ?answer:Learnocaml_data.Answer.t -> Learnocaml_data.Exercise.id ->
+  Token.t -> ?answer:Learnocaml_data.Answer.t -> ?editor:string ->
+  Learnocaml_data.Exercise.id ->
   Save.t Lwt.t
 
 val countdown:

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -426,15 +426,7 @@ let () =
         Lwt.pick [ grading ; abortion ] >>= fun report ->
         let grade = display_report exo report in
         worker := Grading_jsoo.get_grade ~callback exo ;
-        let submit_report =
-          if !is_readonly then false else
-          match (* only if the grade improved *)
-            Learnocaml_local_storage.(retrieve (exercise_state id)).Answer.grade
-          with
-          | Some g -> g <= grade
-          | None -> true
-          | exception Not_found -> true
-        in
+        let submit_report = not !is_readonly in
         let editor, answer =
           if submit_report then
             None,

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -204,7 +204,8 @@ let () =
        match Manip.by_id "learnocaml-countdown" with
        | Some elt -> countdown elt t ~ontimeout:make_readonly
        | None -> ());
-  let solution = match Learnocaml_local_storage.(retrieve (exercise_state id)) with
+  let solution =
+    match Learnocaml_local_storage.(retrieve (exercise_state id)) with
     | { Answer.report = Some report ; solution } ->
         let _ : int = display_report exo report in
         Some solution
@@ -338,21 +339,7 @@ let () =
   begin editor_button
       ~icon: "sync" [%i"Sync"] @@ fun () ->
     token >>= fun token ->
-    let solution = Ace.get_contents ace in
-    let report, grade =
-      match Learnocaml_local_storage.(retrieve (exercise_state id)) with
-      | { Answer.report ; grade } -> report, grade
-      | exception Not_found -> None, None in
-    let answer =
-      { Answer.report ; grade ; solution ;
-        mtime = max_float }
-    in
-    sync_exercise token id ~answer >|= fun save ->
-    if not !is_readonly then
-      match SMap.find_opt id save.Save.all_exercise_states with
-      | Some s -> Ace.set_contents ace s.Answer.solution
-      | None -> ()
-      (* exercise expired server-side, so the submission was ignored *)
+    sync_exercise token id ~editor:(Ace.get_contents ace) >|= fun _save -> ()
   end ;
   begin editor_button
       ~icon: "download" [%i"Download"] @@ fun () ->
@@ -439,12 +426,27 @@ let () =
         Lwt.pick [ grading ; abortion ] >>= fun report ->
         let grade = display_report exo report in
         worker := Grading_jsoo.get_grade ~callback exo ;
-        let answer =
-          { Answer.grade = Some grade ; solution ; report = Some report ;
-            mtime = max_float } (* To ensure server time will be used *)
+        let submit_report =
+          if !is_readonly then false else
+          match (* only if the grade improved *)
+            Learnocaml_local_storage.(retrieve (exercise_state id)).Answer.grade
+          with
+          | Some g -> g <= grade
+          | None -> true
+          | exception Not_found -> true
+        in
+        let editor, answer =
+          if submit_report then
+            None,
+            Some { Answer.grade = Some grade ;
+                   solution ;
+                   report = Some report ;
+                   mtime = max_float } (* To ensure server time will be used *)
+          else
+            Some solution, None
         in
         token >>= fun token ->
-        sync_exercise token id ~answer >>= fun save ->
+        sync_exercise token id ?answer ?editor >>= fun _save ->
         select_tab "report" ;
         Lwt_js.yield () >>= fun () ->
         hide_loading ~id:"learnocaml-exo-loading" () ;

--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -1802,7 +1802,7 @@ let () =
       let json =
         Json_repr_browser.Json_encoding.construct
           Save.enc
-          (get_state_as_save_file ()) in
+          (get_state_as_save_file ~include_reports:true ()) in
       Js._JSON##(stringify json) in
     Learnocaml_common.fake_download ~name ~contents ;
     Lwt.return ()

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -497,17 +497,19 @@ let upload_report server token ex solution report =
   let score = get_score report in
   let max_score = max_score ex in
   let id = Learnocaml_exercise.(access File.id ex) in
+  let mtime = Unix.gettimeofday () in
   let exercise_state =
     { Answer.
       solution;
       grade = if max_score = 0 then None else Some (score * 100 / max_score);
       report = Some report;
-      mtime = Unix.gettimeofday ();
+      mtime;
     }
   in
   let new_save =
     { Save.
       nickname = "";
+      all_exercise_editors = SMap.empty;
       all_exercise_states = SMap.singleton id exercise_state;
       all_toplevel_histories = SMap.empty;
       all_exercise_toplevel_histories = SMap.empty;

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -50,6 +50,7 @@ module Save: sig
 
   type t = {
     nickname: string ;
+    all_exercise_editors: (float * string) SMap.t;
     all_exercise_states: Answer.t SMap.t;
     all_toplevel_histories: Learnocaml_toplevel_history.snapshot SMap.t;
     all_exercise_toplevel_histories: Learnocaml_toplevel_history.snapshot SMap.t;


### PR DESCRIPTION
This makes a few changes in the "sync" mechanism, separating it from
solution submitting (even if the same API call is used).

- solutions are only submitted on using the `Grade!` button: no need to
 repeat sending them (this also defeats the 'editing my own grade'
 hack, although without any safety since it's just client-side)

- the rest of the workspace is saved as before; but the server stores
 the editor contents separately from what was used for the submissions

- it seemed a good idea to actually avoid submitting the report after
 grading when the grade went down. Are there any downsides to that ?

- students see only:
  - their latest editor contents (not what was submitted)
  - while working, obviously, their latest report
  - on reconnecting, the report that was submitted (i.e. the best one
   that was submitted before the deadline)

This patch is backwards-compatible with the storage formats, but adds new
fields. It works but more testing would be better.