### PR TITLE
Allow custom MathJax configs

### DIFF
--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -276,7 +276,6 @@ let () =
          "MathJax.Hub.Config({\n\
          \  jax: [\"input/AsciiMath\", \"output/HTML-CSS\"],\n\
          \  extensions: [],\n\
-         \  elements: [\"learnocaml-exo-tab-text\"],\n\
          \  showMathMenu: false,\n\
          \  showMathMenuMSIE: false,\n\
          \  \"HTML-CSS\": {\n\

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -270,7 +270,7 @@ let () =
     (fun () -> failwith "cannot edit iframe document")
     (fun d ->
        let mathjax_url =
-         "js/mathjax/MathJax.js"
+         "js/mathjax/MathJax.js?delayStartupUntil=configured"
        in
        let mathjax_config =
          "MathJax.Hub.Config({\n\
@@ -313,6 +313,7 @@ let () =
             <body>\
             %s\
             </body>\
+            <script type='text/javascript'>MathJax.Hub.Configured()</script>\
             </html>"
            ex_meta.Exercise.Meta.title
            mathjax_config


### PR DESCRIPTION
This PR allows exercise authors to set their own MathJax config options. For example, enabling the `asciimath2jax.js` preprocessor to reduce the number of `<script>` tags can be done by adding
```html
<script type="text/x-mathjax-config">
  MathJax.Hub.Config({
      extensions: ["asciimath2jax.js"],
      asciimath2jax: {
          ...
      }
  })
</script>
```
to the beginning of the exercise description.

- MathJax startup is delayed until after the exercise description, as described in the [docs](https://docs.mathjax.org/en/latest/configuration.html#delaystartupuntil).
- Removes `elements: ["learnocaml-exo-tab-text"]` from the hardcoded config. Since the exercises are loaded as an iframe, their tags don't inherit the `learnocaml-exo-tab-text` class, so all the line does is in some cases prevent extensions from working properly. 