### PR TITLE
Make selecting prelude code easier

### DIFF
--- a/static/css/learnocaml_exercise.css
+++ b/static/css/learnocaml_exercise.css
@@ -369,7 +369,7 @@ body {
   max-height: 45%;
   background: #666;
   margin: 0;
-  padding: 5px 10px 5px 5px;
+  padding: 5px 10px 5px 10px;
   overflow: auto;
 }
 #learnocaml-exo-tab-text > h1::after {


### PR DESCRIPTION
Added extra padding to the left side of the prelude - currently it's just about impossible to select full lines of code in the prelude because the text is too close to the edge of the container.