### PR TITLE
Server: add a server-side cache

### DIFF
--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -24,7 +24,7 @@ depends: [
   "js_of_ocaml-compiler"
   "js_of_ocaml-lwt"
   "js_of_ocaml-tyxml"
-  "lwt" {>= "3.1.0" & < "4.0.0"}
+  "lwt" {>= "3.2.0" & < "4.0.0"}
   "lwt_ssl"
   "ocp-indent-nlfork"
   "ocp-ocamlres" {= "0.4"}


### PR DESCRIPTION
avoiding to decode & recode everything from & to json, and more importantly,
avoiding recompressions.

The cache is purely in memory at the moment, but given the size of the static
files we serve, that should be no problem.