### PR TITLE
Add support for Markdown in exercises

### DIFF
--- a/src/repo/build.ocp
+++ b/src/repo/build.ocp
@@ -7,6 +7,7 @@ begin library "learnocaml-repository"
   requires = [
     "ocplib-json-typed"
     "xor"
+    "omd"
     "lwt"
     "ezjsonm"
   ]

--- a/src/repo/learnocaml_exercise.ml
+++ b/src/repo/learnocaml_exercise.ml
@@ -278,9 +278,15 @@ module File = struct
               descrs := (lang, f raw) :: !descrs;
               return ()
       in
+      let markdown_to_html md =
+        Omd.(md |> of_string |> to_html)
+      in
       let read_descrs () =
         let langs = [] in
-        let exts = (Filename.extension descr.key, fun h -> h) :: [] in
+        let exts = [
+            (Filename.extension descr.key, fun h -> h) ;
+            (".md", markdown_to_html)
+          ] in
         join (read_descr None exts :: List.map (fun l -> read_descr (Some l) exts) langs)
         >>= fun () ->
         ex := set descr


### PR DESCRIPTION
This PR is a small modification of the `learnocaml_exercise.ml` file that allows for support for Markdown in exercises description. It modifies the functions `read_descr` and `read_descrs` in such a way that:

- `read_descr` now has a new argument that is the list of extensions to try in order. I also fixed a bug that whould have happened if `land` was not empty in `read_descrs`.

- `read_descrs` now has a list of extensions to try that it can give to `read_descr`. I believe this list should at some point move somewhere else. Maybe in the `descr` record?

I had to add a small `markdown_to_html` function. I used the basic functions from Omd, which means that it might not support other features that you want to have in your flavour of Markdown. I believe there should be a module (`Markdown`?) that implements this flavour with an interface containing at least `from_string` and `to_html`.