### PR TITLE
Allow resources in exercises

### DIFF
--- a/src/state/learnocaml_api.ml
+++ b/src/state/learnocaml_api.ml
@@ -316,7 +316,7 @@ module Server (Json: JSON_CODEC) (Rh: REQUEST_HANDLER) = struct
       | `GET,
         ( ["index.html"]
         | ["exercise.html"]
-        | ("js"|"fonts"|"icons"|"css") :: _ as path),
+        | ("js"|"fonts"|"icons"|"css"|"static") :: _ as path),
         _ ->
           Static path |> k
 


### PR DESCRIPTION
This allows exercises to contain sub-directories, in which case those will be
served from `/static/<exercise_id>/<subdir>/<file>`.

So if for example you need to include `foo.png` in your exercise
`tests/exo_foo`, you could do as follows:
- create a directory `<repo>/exercises/tests/exo_foo/images`
- put `foo.png` in there
- in `<repo>/exercises/tests/exo_foo/descr.html`, use the following

      <img src="/static/tests/exo_foo/images/foo.png">

I agree it's not the most convenient, but since all exercises are served from
the same `/exercise.html` page, we can't use relative URLs. Hopefully, this
can be handled by automatic rewriting when we plug the markdown engine for
exercise texts.