### PR TITLE
Various improvements to the exercises interface

### DIFF
--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -555,6 +555,13 @@ let () =
     Learnocaml_common.fake_download ~name ~contents ;
     Lwt.return ()
   end ;
+  begin editor_button
+      ~group: toplevel_buttons_group
+      ~icon: "run" [%i"Eval code"] @@ fun () ->
+    Learnocaml_toplevel.execute_phrase top (Ace.get_contents ace) >>= fun _ ->
+    select_tab "toplevel";
+    Lwt.return_unit
+  end ;
   let typecheck set_class =
     Learnocaml_toplevel.check top (Ace.get_contents ace) >>= fun res ->
     let error, warnings =
@@ -577,12 +584,6 @@ let () =
     Ocaml_mode.report_error ~set_class editor error warnings  >>= fun () ->
     Ace.focus ace ;
     Lwt.return () in
-  begin toplevel_button
-      ~group: toplevel_buttons_group
-      ~icon: "run" [%i"Eval code"] @@ fun () ->
-    Learnocaml_toplevel.execute_phrase top (Ace.get_contents ace) >>= fun _ ->
-    Lwt.return ()
-  end ;
   (* ---- main toolbar -------------------------------------------------- *)
   let exo_toolbar = find_component "learnocaml-exo-toolbar" in
   let toolbar_button = button ~container: exo_toolbar ~theme: "light" in

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -577,11 +577,6 @@ let () =
     Ocaml_mode.report_error ~set_class editor error warnings  >>= fun () ->
     Ace.focus ace ;
     Lwt.return () in
-  begin editor_button
-      ~group: toplevel_buttons_group
-      ~icon: "typecheck" [%i"Check"] @@ fun () ->
-    typecheck true
-  end ;
   begin toplevel_button
       ~group: toplevel_buttons_group
       ~icon: "run" [%i"Eval code"] @@ fun () ->
@@ -601,6 +596,10 @@ let () =
   let callback text =
     Manip.appendChild messages Tyxml_js.Html5.(li [ pcdata text ]) in
   let worker = ref (Grading_jsoo.get_grade ~callback exo) in
+  begin toolbar_button
+      ~icon: "typecheck" [%i"Compile"] @@ fun () ->
+    typecheck true
+  end;
   begin toolbar_button
       ~icon: "reload" [%i"Grade!"] @@ fun () ->
     let aborted, abort_message =

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -648,6 +648,7 @@ let () =
         select_tab "report" ;
         Lwt_js.yield () >>= fun () ->
         hide_loading ~id:"learnocaml-exo-loading" () ;
+        Ace.focus ace ;
         Lwt.return ()
     | Toploop_results.Error _ ->
         let msg =
@@ -661,6 +662,7 @@ let () =
         select_tab "report" ;
         Lwt_js.yield () >>= fun () ->
         hide_loading ~id:"learnocaml-exo-loading" () ;
+        Ace.focus ace ;
         typecheck true
   end ;
   Window.onunload (fun _ev ->

--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -592,6 +592,12 @@ let toplevel_tab select _ () =
   hide_loading ();
   Lwt.return div
 
+let teacher_tab token a b () =
+  show_loading [%i"Loading student info"];
+  Learnocaml_teacher_tab.teacher_tab token a b () >>= fun div ->
+  hide_loading ();
+  Lwt.return div
+
 let get_stored_token () =
   Learnocaml_local_storage.(retrieve sync_token)
 
@@ -601,6 +607,7 @@ let token_disp_div token =
   H.input ~a: [
     H.a_input_type `Text;
     H.a_size 17;
+    H.a_style "font-size: 110%; font-weight: bold;";
     H.a_class ["learnocaml_token"];
     H.a_readonly ();
     H.a_value (Token.to_string token);
@@ -763,7 +770,7 @@ let () =
        then [ "toplevel", ([%i"Toplevel"], toplevel_tab) ] else []) @
       (match token with
        | Some t when Token.is_teacher t ->
-           [ "teacher", ([%i"Teach"], Learnocaml_teacher_tab.teacher_tab t) ]
+           [ "teacher", ([%i"Teach"], teacher_tab t) ]
        | _ -> [])
     in
     let container = El.tab_buttons_container in

--- a/src/toplevel/dune
+++ b/src/toplevel/dune
@@ -52,10 +52,7 @@
           Learnocaml_toplevel_output
           Learnocaml_toplevel_input
           Learnocaml_toplevel)
- (preprocess (per_module
-              ((pps js_of_ocaml.ppx) Learnocaml_toplevel_worker_caller
-               Learnocaml_toplevel_output
-               Learnocaml_toplevel_input)))
+ (preprocess (pps js_of_ocaml.ppx))
 )
 
 (install

--- a/src/toplevel/learnocaml_toplevel.ml
+++ b/src/toplevel/learnocaml_toplevel.ml
@@ -108,7 +108,11 @@ let start_timeout top _name timeout =
       top.current_timeout_prompt <- top.timeout_prompt top ;
       top.current_timeout_prompt
 
+let input_focus top f =
+  f () >>= fun r -> Learnocaml_toplevel_input.focus top.input; Lwt.return r
+
 let reset_with_timeout top ?timeout () =
+  input_focus top @@ fun () ->
   match top.status with
   | `Reset (t, _) -> t
   | `Idle ->
@@ -139,6 +143,7 @@ let reset top =
   reset_with_timeout top ~timeout ()
 
 let protect_execution top exec =
+  input_focus top @@ fun () ->
   wait_for_prompts top >>= fun () ->
   match top.status with
   | `Reset _ | `Execute _ ->
@@ -177,6 +182,7 @@ let protect_execution top exec =
       thread
 
 let execute_phrase top ?timeout content =
+  input_focus top @@ fun () ->
   let phrase = Learnocaml_toplevel_output.phrase () in
   let pp_code = Learnocaml_toplevel_output.output_code ~phrase top.output in
   let pp_answer = Learnocaml_toplevel_output.output_answer ~phrase top.output in

--- a/src/toplevel/learnocaml_toplevel_input.ml
+++ b/src/toplevel/learnocaml_toplevel_input.ml
@@ -133,6 +133,8 @@ let go_forward ({ history ; textbox } as input) =
     textbox##.value := Js.string (Learnocaml_toplevel_history.current history) ;
     resize input
 
+let focus input = input.textbox##focus
+
 let setup
     ?sizing ?history
     ?(on_resize = (fun () -> ()))

--- a/src/toplevel/learnocaml_toplevel_input.mli
+++ b/src/toplevel/learnocaml_toplevel_input.mli
@@ -67,3 +67,6 @@ val go_backward : input -> unit
 
 (** Simulates a hit on the [Down] key *)
 val go_forward : input -> unit
+
+(** Sets focus to the text input field *)
+val focus : input -> unit

--- a/static/css/learnocaml_exercise.css
+++ b/static/css/learnocaml_exercise.css
@@ -471,9 +471,6 @@ body {
   line-height: 26px;
 }
 @media (min-width: 1000px) {
-  #learnocaml-exo-tab-meta {
-    position: relative;
-  }
   #learnocaml-exo-tab-meta::after {
     position: absolute;
     left:0; top:0; bottom: 0px; width: 8px;

--- a/static/css/learnocaml_main.css
+++ b/static/css/learnocaml_main.css
@@ -995,8 +995,6 @@ body {
   margin-left: auto;
   margin-right: auto;
   text-align: center;
-  font-size: 110%;
-  font-weight: bold;
   font-family: 'Inconsolata';
 }
 

--- a/static/exercise.html
+++ b/static/exercise.html
@@ -58,11 +58,11 @@
       <!-- To select a tab, make it the only one whose
            button and tab have the class .front-tab.
            Don't set the editor to .front-tab initially. -->
+      <button id="learnocaml-exo-button-text">Exercise</button>
       <button id="learnocaml-exo-button-toplevel" class="front-tab">Toplevel</button>
       <!-- When graded, apply one of .partial, .success or .failure.
            The score must be put in a span.score. -->
       <button id="learnocaml-exo-button-report">Report</button>
-      <button id="learnocaml-exo-button-text">Exercise</button>
       <button id="learnocaml-exo-button-meta">Details</button>
       <!-- Any other button can be added. -->
     </div>

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: learn-ocaml ~dev\n"
-"PO-Revision-Date: 2018-10-08 16:25+0200\n"
+"PO-Revision-Date: 2018-10-09 10:34+0200\n"
 "Last-Translator: Louis Gesbert <Louis.gesbert@ocamlpro.com>\n"
 "Language-Team: OCamlPro\n"
 "Language: french\n"
@@ -16,7 +16,7 @@ msgstr ""
 #: src/app/learnocaml_exercise_main.ml:79,33--41
 #: src/app/learnocaml_exercise_main.ml:83,33--41
 #: src/app/learnocaml_exercise_main.ml:88,33--41
-#: src/app/learnocaml_exercise_main.ml:306,39--47
+#: src/app/learnocaml_exercise_main.ml:301,39--47
 msgid "Report"
 msgstr "Rapport"
 
@@ -42,7 +42,7 @@ msgid "Problem"
 msgstr "Problème"
 
 #: src/app/learnocaml_exercise_main.ml:133,35--45
-#: src/app/learnocaml_exercise_main.ml:307,37--47
+#: src/app/learnocaml_exercise_main.ml:302,37--47
 msgid "Exercise"
 msgstr "Exercice"
 
@@ -50,61 +50,61 @@ msgstr "Exercice"
 msgid "Kind: %s"
 msgstr "Type: %s"
 
-#: src/app/learnocaml_exercise_main.ml:257,32--54
+#: src/app/learnocaml_exercise_main.ml:252,32--54
 msgid "Exercise identifier:"
 msgstr "Identifiant de l'exercice :"
 
-#: src/app/learnocaml_exercise_main.ml:259,22--34
+#: src/app/learnocaml_exercise_main.ml:254,22--34
 msgid "Author(s):"
 msgstr "Auteur(s) :"
 
-#: src/app/learnocaml_exercise_main.ml:261,8--25
+#: src/app/learnocaml_exercise_main.ml:256,8--25
 msgid "Skills trained:"
 msgstr "Compétences pratiquées :"
 
-#: src/app/learnocaml_exercise_main.ml:267,8--26
+#: src/app/learnocaml_exercise_main.ml:262,8--26
 msgid "Skills required:"
 msgstr "Compétences requises :"
 
-#: src/app/learnocaml_exercise_main.ml:273,8--29
+#: src/app/learnocaml_exercise_main.ml:268,8--29
 msgid "Previous exercises:"
 msgstr "Exercices précédents :"
 
-#: src/app/learnocaml_exercise_main.ml:278,10--32
+#: src/app/learnocaml_exercise_main.ml:273,10--32
 msgid "Exercises following:"
 msgstr "Exercices suivants :"
 
-#: src/app/learnocaml_exercise_main.ml:286,19--29
+#: src/app/learnocaml_exercise_main.ml:281,19--29
 msgid "Metadata"
 msgstr "Métadonnées"
 
-#: src/app/learnocaml_exercise_main.ml:303,24--51
+#: src/app/learnocaml_exercise_main.ml:298,24--51
 msgid "Preparing the environment"
 msgstr "Préparation de l'environnement"
 
-#: src/app/learnocaml_exercise_main.ml:304,39--47
-#: src/app/learnocaml_exercise_main.ml:309,37--45
+#: src/app/learnocaml_exercise_main.ml:299,39--47
+#: src/app/learnocaml_exercise_main.ml:304,37--45
 msgid "Editor"
 msgstr "Éditeur"
 
-#: src/app/learnocaml_exercise_main.ml:305,41--51
+#: src/app/learnocaml_exercise_main.ml:300,41--51
 #: src/app/learnocaml_index_main.ml:763,30--40
 msgid "Toplevel"
 msgstr "Toplevel"
 
-#: src/app/learnocaml_exercise_main.ml:308,37--46
+#: src/app/learnocaml_exercise_main.ml:303,37--46
 msgid "Details"
 msgstr "Détails"
 
-#: src/app/learnocaml_exercise_main.ml:310,27--70
+#: src/app/learnocaml_exercise_main.ml:305,27--70
 msgid "Click the Grade button to get your report"
 msgstr "Cliquez sur le bouton Noter pour obtenir votre rapport"
 
-#: src/app/learnocaml_exercise_main.ml:321,18--29
+#: src/app/learnocaml_exercise_main.ml:316,18--29
 msgid "TIME'S UP"
 msgstr "TEMPS ÉCOULÉ"
 
-#: src/app/learnocaml_exercise_main.ml:322,7--119
+#: src/app/learnocaml_exercise_main.ml:317,7--119
 msgid ""
 "The deadline for this exercise has expired. Any changes you make from now on "
 "will remain local only."
@@ -112,64 +112,60 @@ msgstr ""
 "La date limite de rendu de cet exercice est passée. Vos changements ne "
 "seront plus sauvegardés sur le serveur."
 
-#: src/app/learnocaml_exercise_main.ml:367,25--49
+#: src/app/learnocaml_exercise_main.ml:372,25--49
 msgid "loading the prelude..."
 msgstr "Chargement du prélude..."
 
-#: src/app/learnocaml_exercise_main.ml:372,41--59
+#: src/app/learnocaml_exercise_main.ml:377,41--59
 msgid "error in prelude"
 msgstr "erreur dans le prélude"
 
-#: src/app/learnocaml_exercise_main.ml:424,26--33
+#: src/app/learnocaml_exercise_main.ml:437,22--33
+msgid "Eval code"
+msgstr "Évaluer le code"
+
+#: src/app/learnocaml_exercise_main.ml:443,26--33
 #: src/app/learnocaml_index_main.ml:515,57--64
 #: src/app/learnocaml_index_main.ml:579,57--64
 msgid "Clear"
 msgstr "Effacer"
 
-#: src/app/learnocaml_exercise_main.ml:429,25--32
-#: src/app/learnocaml_exercise_main.ml:542,26--33
+#: src/app/learnocaml_exercise_main.ml:448,25--32
+#: src/app/learnocaml_exercise_main.ml:553,26--33
 #: src/app/learnocaml_index_main.ml:522,24--31
 #: src/app/learnocaml_index_main.ml:584,24--31
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: src/app/learnocaml_exercise_main.ml:435,22--35
+#: src/app/learnocaml_exercise_main.ml:454,22--35
 #: src/app/learnocaml_index_main.ml:528,53--66
 #: src/app/learnocaml_index_main.ml:588,53--66
 msgid "Eval phrase"
 msgstr "Évaluer la phrase"
 
-#: src/app/learnocaml_exercise_main.ml:454,39--54
+#: src/app/learnocaml_exercise_main.ml:473,39--54
 msgid "OCaml prelude"
 msgstr "Prélude OCaml"
 
-#: src/app/learnocaml_exercise_main.ml:461,62--68
+#: src/app/learnocaml_exercise_main.ml:480,62--68
 msgid "Hide"
 msgstr "Cacher"
 
-#: src/app/learnocaml_exercise_main.ml:465,62--68
+#: src/app/learnocaml_exercise_main.ml:484,62--68
 msgid "Show"
 msgstr "Montrer"
 
-#: src/app/learnocaml_exercise_main.ml:509,35--80
+#: src/app/learnocaml_exercise_main.ml:528,35--80
 msgid "No description available for this exercise."
 msgstr "Aucune description pour cet exercice."
 
-#: src/app/learnocaml_exercise_main.ml:547,23--29
+#: src/app/learnocaml_exercise_main.ml:558,23--29
 msgid "Sync"
 msgstr "Sync"
 
-#: src/app/learnocaml_exercise_main.ml:552,27--37
+#: src/app/learnocaml_exercise_main.ml:563,27--37
 msgid "Download"
 msgstr "Télécharger"
-
-#: src/app/learnocaml_exercise_main.ml:582,28--35
-msgid "Check"
-msgstr "Valider"
-
-#: src/app/learnocaml_exercise_main.ml:587,22--33
-msgid "Eval code"
-msgstr "Évaluer le code"
 
 #: src/app/learnocaml_exercise_main.ml:595,23--34
 #: src/app/learnocaml_index_main.ml:760,48--59
@@ -177,31 +173,35 @@ msgstr "Évaluer le code"
 msgid "Exercises"
 msgstr "Exercices"
 
-#: src/app/learnocaml_exercise_main.ml:605,25--33
+#: src/app/learnocaml_exercise_main.ml:605,28--37
+msgid "Compile"
+msgstr "Compiler"
+
+#: src/app/learnocaml_exercise_main.ml:609,25--33
 msgid "Grade!"
 msgstr "Noter!"
 
-#: src/app/learnocaml_exercise_main.ml:608,51--58
+#: src/app/learnocaml_exercise_main.ml:612,51--58
 msgid "abort"
 msgstr "abandonner"
 
-#: src/app/learnocaml_exercise_main.ml:612,38--73
+#: src/app/learnocaml_exercise_main.ml:616,38--73
 msgid "Grading is taking a lot of time, "
 msgstr "La notation prend longtemps, "
 
-#: src/app/learnocaml_exercise_main.ml:618,38--60
+#: src/app/learnocaml_exercise_main.ml:622,38--60
 msgid "Launching the grader"
 msgstr "Lancement de la notation"
 
-#: src/app/learnocaml_exercise_main.ml:633,60--86
+#: src/app/learnocaml_exercise_main.ml:637,60--86
 msgid "Grading aborted by user."
 msgstr "Notation annulée par l'utilisateur"
 
-#: src/app/learnocaml_exercise_main.ml:655,38--59
+#: src/app/learnocaml_exercise_main.ml:660,38--59
 msgid "Error in your code."
 msgstr "Erreur dans le code."
 
-#: src/app/learnocaml_exercise_main.ml:656,27--85
+#: src/app/learnocaml_exercise_main.ml:661,27--85
 msgid "Cannot start the grader if your code does not typecheck."
 msgstr "La notation ne peut être lancée si le code ne type pas."
 
@@ -365,7 +365,9 @@ msgstr "Votre token Learn-OCaml"
 msgid ""
 "Your token is displayed below. It identifies you and allows to share your "
 "workspace between devices."
-msgstr "Votre token est affiché ci-dessous. Il vous identifie et permet de partager un même espace de travail entre plusieurs machines."
+msgstr ""
+"Votre token est affiché ci-dessous. Il vous identifie et permet de partager "
+"un même espace de travail entre plusieurs machines."
 
 #: src/app/learnocaml_index_main.ml:613,21--44
 msgid "Please write it down."
@@ -445,7 +447,10 @@ msgstr "Assurez-vous d'avoir noté votre token:"
 msgid ""
 "WARNING: the data could not be synchronised with the server. Logging out "
 "will lose your local changes, be sure you exported a backup."
-msgstr "ATTENTION: l'espace de travail n'a pas pu être synchronisé avec le serveur. En vous déconnectant, vous perdrez tous les changements locaux, à moins d'avoir exporté votre espace de travail au préalable."
+msgstr ""
+"ATTENTION: l'espace de travail n'a pas pu être synchronisé avec le serveur. "
+"En vous déconnectant, vous perdrez tous les changements locaux, à moins "
+"d'avoir exporté votre espace de travail au préalable."
 
 #: src/app/learnocaml_index_main.ml:855,22--30
 #: src/app/learnocaml_index_main.ml:855,45--53
@@ -662,6 +667,9 @@ msgstr "Lancement du banc de test."
 #: src/grader/grading.ml:155,38--67
 msgid "while testing your solution"
 msgstr "lors du test de la solution utilisateur"
+
+#~ msgid "Check"
+#~ msgstr "Valider"
 
 #~ msgid "Welcome to <emph>LearnOCaml</emph> by OCamlPro."
 #~ msgstr "Bienvenue sur <emph>LearnOCaml</emph> par OCamlPro."


### PR DESCRIPTION
- Move and relabel buttons around (closes #126, #146, #147)
- Keep the focus on the editor after grading
- Keep focus on the toplevel after evaluating (closes #165. Previously worked only in some cases on some browsers)