### PR TITLE
Use exercise ids in the URL path

### DIFF
--- a/src/app/learnocaml_common.ml
+++ b/src/app/learnocaml_common.ml
@@ -191,7 +191,7 @@ let show_loading ?(id = "ocp-loading-layer") contents =
   Manip.(removeClass elt "loaded") ;
   Manip.(addClass elt "loading") ;
   let chamo_src =
-    "icons/tryocaml_loading_" ^ string_of_int (Random.int 8 + 1) ^ ".gif" in
+    "/icons/tryocaml_loading_" ^ string_of_int (Random.int 8 + 1) ^ ".gif" in
   Manip.replaceChildren elt
     H.[
       div ~a: [ a_id "chamo" ] [ img ~alt: "loading" ~src: chamo_src () ] ;
@@ -296,7 +296,7 @@ let button ~container ~theme ?group ?state ~icon lbl cb =
     | Some group -> group in
   let button =
     H.(button [
-        img ~alt:"" ~src:("icons/icon_" ^ icon ^ "_" ^ theme ^ ".svg") () ;
+        img ~alt:"" ~src:("/icons/icon_" ^ icon ^ "_" ^ theme ^ ".svg") () ;
         pcdata " " ;
         span ~a:[ a_class [ "label" ] ] [ pcdata lbl ]
       ]) in
@@ -516,6 +516,6 @@ let stars_div stars =
     let num = 5 * int_of_float (stars *. 2.) in
     let num = max (min num 40) 0 in
     let alt = Format.asprintf [%if"difficulty: %d / 40"] num in
-    let src = Format.asprintf "icons/stars_%02d.svg" num in
+    let src = Format.asprintf "/icons/stars_%02d.svg" num in
     H.img ~alt ~src ()
   ]

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -110,7 +110,7 @@ let display_stars ex_meta =
     let num = 5 * int_of_float (ex_meta.Meta.stars *. 2.) in
     let num = max (min num 40) 0 in
     let alt = Format.asprintf [%if"difficulty: %d / 40"] num in
-    let src = Format.asprintf "icons/stars_%02d.svg" num in
+    let src = Format.asprintf "/icons/stars_%02d.svg" num in
     img ~alt ~src ()
   in
   div ~a:[ a_class [ "stars" ] ] [
@@ -143,18 +143,13 @@ let get_exercise_meta token id =
 
 let exercise_link ?(cl = []) id content =
   let open Tyxml_js.Html5 in
-  a ~a:[ a_href ("exercise.html#id=" ^ id ^ "&action=open") ;
+  a ~a:[ a_href ("/exercises/"^id^"/") ;
          a_class cl ;
-         (* dirty trick to reload the page *)
-         a_onclick (fun _ ->
-             Js_utils.set_fragment [("id", id); ("action", "open")];
-             window##.location##reload; true)
        ]
     content
 
 let display_exercise_meta id meta_value content_id =
   let open Tyxml_js.Html5 in
-  let open Learnocaml_data.Exercise in
   let content = find_component content_id in
   Lazy.force meta_value >>= fun meta ->
   let descr =
@@ -323,7 +318,13 @@ let make_readonly () =
         from now on will remain local only."]
 
 let () =
-  Lwt.async_exception_hook := begin function
+  Lwt.async_exception_hook := begin fun e ->
+    Firebug.console##log (Js.string
+                            (Printexc.to_string e ^
+                             if Printexc.backtrace_status () then
+                               Printexc.get_backtrace ()
+                             else ""));
+    match e with
     | Failure message -> fatal message
     | Server_caller.Cannot_fetch message -> fatal message
     | exn -> fatal (Printexc.to_string exn)
@@ -353,7 +354,11 @@ let () =
    | exception Not_found -> ());
   let toplevel_button = button ~container: toplevel_toolbar ~theme: "dark" in
   let editor_button = button ~container: editor_toolbar ~theme: "light" in
-  let id = arg "id" in
+  let id = match Url.Current.path with
+    | "" :: "exercises" :: p | "exercises" :: p ->
+        String.concat "/" (List.map Url.urldecode (List.filter ((<>) "") p))
+    | _ -> arg "id"
+  in
   let exercise_fetch =
     token >>= fun token ->
     Server_caller.fetch_exercise token id
@@ -478,7 +483,7 @@ let () =
     (fun () -> failwith "cannot edit iframe document")
     (fun d ->
        let mathjax_url =
-         "js/mathjax/MathJax.js?delayStartupUntil=configured"
+         "/js/mathjax/MathJax.js?delayStartupUntil=configured"
        in
        let mathjax_config =
          "MathJax.Hub.Config({\n\
@@ -513,7 +518,7 @@ let () =
             <html><head>\
             <title>%s - exercise text</title>\
             <meta charset='UTF-8'>\
-            <link rel='stylesheet' href='css/learnocaml_standalone_description.css'>\
+            <link rel='stylesheet' href='/css/learnocaml_standalone_description.css'>\
             <script type='text/x-mathjax-config'>%s</script>
             <script type='text/javascript' src='%s'></script>\
             </head>\
@@ -594,7 +599,7 @@ let () =
   begin toolbar_button
       ~icon: "list" [%i"Exercises"] @@ fun () ->
     Dom_html.window##.location##assign
-      (Js.string "index.html#activity=exercises") ;
+      (Js.string "/index.html#activity=exercises") ;
     Lwt.return ()
   end ;
   let messages = Tyxml_js.Html5.ul [] in

--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -117,7 +117,7 @@ let exercises_tab token _ _ () =
                     | Some pct when  pct >= 100 -> [ "stats" ; "success" ]
                     | Some _ -> [ "stats" ; "partial" ])
                   pct_signal in
-              a ~a:[ a_href ("exercise.html#id=" ^ exercise_id ^ "&action=open") ;
+              a ~a:[ a_href ("/exercises/" ^ Url.urlencode exercise_id ^ "/") ;
                      a_class [ "exercise" ] ] [
                 div ~a:[ a_class [ "descr" ] ] (
                   h1 [ pcdata title ] ::

--- a/src/app/server_caller.ml
+++ b/src/app/server_caller.ml
@@ -79,14 +79,16 @@ let () =
               (Printexc.to_string e))
   | _ -> None
 
+let urlpath p = String.concat "/" (""::p)
+
 let request req =
   let do_req = function
     | { Learnocaml_api.meth = `GET; path; args } ->
-        Lwt_request.get ?headers:None ~url:(String.concat "/" path) ~args:args
+        Lwt_request.get ?headers:None ~url:(urlpath path) ~args:args
     | { Learnocaml_api.meth = `POST body; path; args } ->
         let get_args = match args with [] -> None | a -> Some a in
         Lwt_request.post ?headers:None ?get_args
-          ~url:(String.concat "/" path) ~body:(Some body)
+          ~url:(urlpath path) ~body:(Some body)
   in
   Lwt.catch (fun () ->
       Api_client.make_request (fun http_request ->

--- a/src/grader/grading_jsoo.ml
+++ b/src/grader/grading_jsoo.ml
@@ -24,7 +24,7 @@ let get_grade
     ?(timeout = infinity)
     exercise =
   let t, u = Lwt.task () in
-  let worker = Worker.create "js/learnocaml-grader-worker.js" in
+  let worker = Worker.create "/js/learnocaml-grader-worker.js" in
   Lwt.on_cancel t (fun () -> worker##terminate) ;
   let onmessage (ev : Json_repr_browser.Repr.value Worker.messageEvent Js.t) =
     let json = ev##.data in

--- a/src/server/learnocaml_server.ml
+++ b/src/server/learnocaml_server.ml
@@ -510,7 +510,14 @@ let launch () =
     let uri = Request.uri req in
     let path = Uri.path uri in
     let path = Stringext.split ~on:'/' path in
-    let path = List.filter ((<>) "") path in
+    let path =
+      let rec clean = function
+        | [] | [_] as l -> l
+        | ""::l -> clean l
+        | s::l -> s::clean l
+      in
+      clean path
+    in
     let path = List.map Uri.pct_decode path in
     let query = Uri.query uri in
     let args = List.map (fun (s, l) -> s, String.concat "," l) query in

--- a/src/toplevel/learnocaml_toplevel_worker_caller.ml
+++ b/src/toplevel/learnocaml_toplevel_worker_caller.ml
@@ -197,7 +197,7 @@ and do_reset_worker () =
       Lwt.return_unit
 
 let create
-    ?(js_file = "js/learnocaml-toplevel-worker.js")
+    ?(js_file = "/js/learnocaml-toplevel-worker.js")
     ?(after_init = fun _ -> Lwt.return_unit)
     ?(pp_stdout = (fun text -> Firebug.console##(log (Js.string text))))
     ?(pp_stderr = (fun text -> Firebug.console##(log (Js.string text))))

--- a/src/toplevel/learnocaml_toplevel_worker_caller.mli
+++ b/src/toplevel/learnocaml_toplevel_worker_caller.mli
@@ -41,7 +41,7 @@ type t
            console).
 
     @param js_file the web worker [.js] file.
-           (default: ["js/learnocaml-toplevel-worker.js"]). *)
+           (default: ["/js/learnocaml-toplevel-worker.js"]). *)
 val create:
   ?js_file: string ->
   ?after_init:(t -> unit Lwt.t) ->

--- a/static/exercise.html
+++ b/static/exercise.html
@@ -4,47 +4,48 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1">
     <title>Learn OCaml by OCamlPro - Exercise</title>
-    <link rel="stylesheet" href="css/learnocaml_common.css">
-    <link rel="stylesheet" href="css/learnocaml_exercise.css">
-    <link rel="stylesheet" href="css/learnocaml_report.css">
-    <link rel="stylesheet" href="css/learnocaml_tryocaml.css">
-    <script src="js/ace/ace.js" type="text/javascript" charset="utf-8" defer></script>
+    <link rel="stylesheet" href="/css/learnocaml_common.css">
+    <link rel="stylesheet" href="/css/learnocaml_exercise.css">
+    <link rel="stylesheet" href="/css/learnocaml_report.css">
+    <link rel="stylesheet" href="/css/learnocaml_tryocaml.css">
+    <script src="/js/ace/ace.js" type="text/javascript" charset="utf-8" defer></script>
     <!-- var editor = ace.edit("learnocaml-exo-editor-pane"); -->
     <!-- editor.setOptions({ fontFamily: 'Inconsolata', fontSize: "18px" }); -->
-    <script language="JavaScript" src="js/learnocaml-exercise.js" defer></script>
+    <script language="JavaScript" src="/js/learnocaml-exercise.js" defer></script>
   </head>
   <body>
     <!-- Shoule be kept untouched. -->
     <div style="display:none">
       <!-- (Weakly) preload images. -->
-      <img src="icons/tryocaml_loading_1.gif"><img src="icons/tryocaml_loading_2.gif">
-      <img src="icons/tryocaml_loading_3.gif"><img src="icons/tryocaml_loading_4.gif">
-      <img src="icons/tryocaml_loading_5.gif"><img src="icons/tryocaml_loading_6.gif">
-      <img src="icons/tryocaml_loading_7.gif"><img src="icons/tryocaml_loading_8.gif">
+      <img src="/icons/tryocaml_loading_1.gif"><img src="/icons/tryocaml_loading_2.gif">
+      <img src="/icons/tryocaml_loading_3.gif"><img src="/icons/tryocaml_loading_4.gif">
+      <img src="/icons/tryocaml_loading_5.gif"><img src="/icons/tryocaml_loading_6.gif">
+      <img src="/icons/tryocaml_loading_7.gif"><img src="/icons/tryocaml_loading_8.gif">
+      <img src="/icons/tryocaml_loading_9.gif">
     </div>
     <!-- Three states: .initial, .loading and .loaded.
          Set to .loaded when initial loading finished.
          Set to .loading while loading, then to .loaded. -->
     <div id="learnocaml-exo-loading" class="loading-layer initial">
-      <div id="chamo"><img id="chamo-img" src="icons/tryocaml_loading_5.gif"></div>
+      <div id="chamo"><img id="chamo-img" src="/icons/tryocaml_loading_5.gif"></div>
       <div class="messages"><ul><li id="txt_preparing">Preparing the environment</li></ul></div>
     </div>
     <script language="JavaScript">
-      var n = Math.floor (Math.random () * 7.99) + 1;
-      document.getElementById('chamo-img').src = 'icons/tryocaml_loading_' + n + '.gif';
+      var n = Math.floor (Math.random () * 8.99) + 1;
+      document.getElementById('chamo-img').src = '/icons/tryocaml_loading_' + n + '.gif';
     </script>
     <!-- Anything below could be recreated dynamically, but IDs must be kept. -->
     <div id="learnocaml-exo-toolbar">
-      <a href="./">
+      <a href="/">
       <div class ="logo">
-        <img src="icons/logo_ocaml.svg">
+        <img src="/icons/logo_ocaml.svg">
         <span>Learn OCaml</span>
-        <img src="icons/logo_ocp.svg">
+        <img src="/icons/logo_ocp.svg">
       </div>
       </a>
       <!--
       <button id="learnocaml-exo-button-grade">
-        <img src="icons/icon_reload_light.svg">
+        <img src="/icons/icon_reload_light.svg">
         <span class="label">Grade!</span>
       </button>
       -->
@@ -74,22 +75,26 @@
           <!-- Any button can be added.
                Structure: button>img, button>span.label. -->
           <!-- <button> -->
-          <!--   <img src="icons/icon_typecheck_light.svg"> -->
+          <!--   <img src="/icons/icon_typecheck_light.svg"> -->
           <!--   <span class="label">Typecheck</span> -->
           <!-- </button> -->
           <!-- <button> -->
-          <!--   <img src="icons/icon_cleanup_light.svg"> -->
+          <!--   <img src="/icons/icon_cleanup_light.svg"> -->
           <!--   <span class="label">Reset</span> -->
           <!-- </button> -->
           <!-- <button> -->
-          <!--   <img src="icons/icon_download_light.svg"> -->
+          <!--   <img src="/icons/icon_download_light.svg"> -->
           <!--   <span class="label">Download</span> -->
           <!-- </button> -->
           <!-- <button> -->
-          <!--   <img src="icons/icon_save_light.svg"> -->
+          <!--   <img src="/icons/icon_save_light.svg"> -->
           <!--   <span class="label">Save</span> -->
           <!-- </button> -->
         </div>
+      </div>
+      <div id="learnocaml-exo-tab-text">
+        <!-- <h1>title</h1> -->
+        <!-- <iframe src="/standalone-descr.html"></iframe> -->
       </div>
       <div id="learnocaml-exo-tab-toplevel" class="front-tab">
         <div id="learnocaml-exo-toplevel-pane" class="toplevel-pane">
@@ -103,27 +108,23 @@
           <!-- Any button can be added.
                Structure: button>img, button>span.label. -->
           <!-- <button> -->
-          <!--   <img src="icons/icon_run_dark.svg"> -->
+          <!--   <img src="/icons/icon_run_dark.svg"> -->
           <!--   <span class="label">Reset &amp; Run</span> -->
           <!-- </button> -->
           <!-- <button> -->
-          <!--   <img src="icons/icon_cleanup_dark.svg"> -->
+          <!--   <img src="/icons/icon_cleanup_dark.svg"> -->
           <!--   <span class="label">Reset</span> -->
           <!-- </button> -->
           <!-- <button> -->
-          <!--   <img src="icons/icon_download_dark.svg"> -->
+          <!--   <img src="/icons/icon_download_dark.svg"> -->
           <!--   <span class="label">Download</span> -->
           <!-- </button> -->
         </div>
       </div>
-      <div id="learnocaml-exo-tab-text">
-        <!-- <h1>title</h1> -->
-        <!-- <iframe src="standalone-descr.html"></iframe> -->
-      </div>
       <div id="learnocaml-exo-tab-report">
         <!-- Using an iframe is the easiest way to isolate the CSSs. -->
-        <!-- <iframe src="mockup_report.html"></iframe> -->
-        <img src="icons/icon_reload_dark.svg"
+        <!-- <iframe src="/mockup_report.html"></iframe> -->
+        <img src="/icons/icon_reload_dark.svg"
              style="position: absolute; top: 50%; left: 50%;
                     margin: -100px 0 0 -100px; width: 200px;
                     opacity: 0.2">

--- a/static/index.html
+++ b/static/index.html
@@ -3,27 +3,27 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1">
     <title>Learn OCaml by OCamlPro</title>
-    <link rel="stylesheet" href="css/learnocaml_common.css">
-    <link rel="stylesheet" href="css/learnocaml_tryocaml.css">
-    <link rel="stylesheet" href="css/learnocaml_main.css">
-    <script src="js/ace/ace.js" type="text/javascript" charset="utf-8" defer></script>
-    <script language="JavaScript" src="js/learnocaml-config.js"></script>
-    <script language="JavaScript" src="js/learnocaml-main.js" defer></script>
+    <link rel="stylesheet" href="/css/learnocaml_common.css">
+    <link rel="stylesheet" href="/css/learnocaml_tryocaml.css">
+    <link rel="stylesheet" href="/css/learnocaml_main.css">
+    <script src="/js/ace/ace.js" type="text/javascript" charset="utf-8" defer></script>
+    <script language="JavaScript" src="/js/learnocaml-config.js"></script>
+    <script language="JavaScript" src="/js/learnocaml-main.js" defer></script>
   </head>
   <body>
     <div style="display:none">
       <!-- preload -->
-      <img src="icons/tryocaml_loading_1.gif"><img src="icons/tryocaml_loading_2.gif">
-      <img src="icons/tryocaml_loading_3.gif"><img src="icons/tryocaml_loading_4.gif">
-      <img src="icons/tryocaml_loading_5.gif"><img src="icons/tryocaml_loading_6.gif">
-      <img src="icons/tryocaml_loading_7.gif"><img src="icons/tryocaml_loading_8.gif">
-      <img src="icons/tryocaml_loading_9.gif">
+      <img src="/icons/tryocaml_loading_1.gif"><img src="/icons/tryocaml_loading_2.gif">
+      <img src="/icons/tryocaml_loading_3.gif"><img src="/icons/tryocaml_loading_4.gif">
+      <img src="/icons/tryocaml_loading_5.gif"><img src="/icons/tryocaml_loading_6.gif">
+      <img src="/icons/tryocaml_loading_7.gif"><img src="/icons/tryocaml_loading_8.gif">
+      <img src="/icons/tryocaml_loading_9.gif">
     </div>
     <div id="learnocaml-main-toolbar">
       <div class="logo">
-        <img src="icons/logo_ocaml.svg">
+        <img src="/icons/logo_ocaml.svg">
         <span>Learn OCaml</span>
-        <img src="icons/logo_ocp.svg">
+        <img src="/icons/logo_ocp.svg">
       </div>
     </div>
     <div id="learnocaml-main-panel" class="hidden">
@@ -59,7 +59,7 @@
       <!--     <p>Short description of the exercise.</p> -->
       <!--   </div> -->
       <!--   <div class="stats failure"|partial|success> -->
-      <!--     <div class="stars"><img src="icons/stars_00|05|10|15|20|25|30|35|40.svg"></div> -->
+      <!--     <div class="stars"><img src="/icons/stars_00|05|10|15|20|25|30|35|40.svg"></div> -->
       <!--     <div class="length">Exercise kind</div> -->
       <!--     <div class="score">42%</div> -->
       <!--   </div> -->


### PR DESCRIPTION
This replaces usage of a url `/exercise.html#id%3Dsome%ABexercise` by usage of a nicer exercise URL: `/exercises/some/exercise/`

Also provides a much better answer to #128 (improving on #156),
because exercise texts can now use relative links, e.g. `<img
src="images/foo.png">`, rather than needing to depend on the exercise
ID (and risking becoming broken if the exercise is renamed).