### PR TITLE
Make code in descriptions more readable

### DIFF
--- a/static/css/learnocaml_standalone_description.css
+++ b/static/css/learnocaml_standalone_description.css
@@ -6,7 +6,6 @@ body {
 code, pre {
   padding: 0px 4px;
   background: #ddd;
-  border: 1px #fff solid;
   border-radius: 4px;
 }
 h2 {


### PR DESCRIPTION
Fixes #175 by removing borders of <code> elements.