### PR TITLE
Rework the Stack overflow message

### DIFF
--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -888,7 +888,7 @@ module Make
         | Error (Failure s) when s = "EXCESS"->
             Learnocaml_report.[ Message ([ Text "Your code exceeded the output buffer size limit." ], Failure) ]
         | Error Stack_overflow ->
-            Learnocaml_report.[ Message ([ Text "Your code did too many recursions." ], Failure) ]
+            Learnocaml_report.[ Message ([ Text "Stack overflow. Too many recursions?" ], Failure) ]
         | Error Timeout ->
             Learnocaml_report.[ Message ([ Text "Your code exceeded the time limit. Too many recursions?" ], Failure) ]
         | Error exn ->
@@ -905,7 +905,7 @@ module Make
     | Error (Failure s), _ when s = "EXCESS" ->
         Learnocaml_report.[ Message ([ Text "Your code exceeded the output buffer size limit." ], Failure) ]
     | Error Stack_overflow, _ ->
-        Learnocaml_report.[ Message ([ Text "Your code did too many recursions." ], Failure) ]
+        Learnocaml_report.[ Message ([ Text "Stack overflow. Too many recursions?" ], Failure) ]
     | Error _, Error _ -> []
     | Error exn, Ok _ ->
         Learnocaml_report.[ Message ([ Text "Unexpected exception" ; Code (Printexc.to_string exn) ], Failure) ]


### PR DESCRIPTION
The current message that is printed when a stack overflow occurs is "Your code did too many recursions.". This is wrong in some cases. 
The cause for the Stack overflow might also be that the code is not tail-recursive -- the current message is particularly confusing in a practical session which is *teaching* tail-recursion.

The PR contains a mild refactoring of the message. I kept the "too many recursions" part, but as a hint after printing the root cause (similarly to the timeout message just after).

