### PR TITLE
Storage and retrieval of save histories using git

### DIFF
--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -44,6 +44,7 @@ depends: [
   "yojson" {>= "1.4.0" }
   "ppx_cstruct"
   "decompress" {= "0.8"}
+  "conf-git"
 ]
 build: [
   [make "static"]

--- a/learn-ocaml.opam.locked
+++ b/learn-ocaml.opam.locked
@@ -48,6 +48,7 @@ depends: [
   "ppx_cstruct" {= "3.2.1"}
   "ppx_tools" {= "5.0+4.05.0"}
   "conf-libev" {= "4-11"}
+  "conf-git" {= "1.0"}
 ]
 build: [
   [make "static"]

--- a/src/app/learnocaml_common.ml
+++ b/src/app/learnocaml_common.ml
@@ -90,7 +90,7 @@ let fatal ?(title=[%i"INTERNAL ERROR"]) message =
   Manip.replaceChildren div [
     H.div [
       H.h3 [ H.pcdata titletext ];
-      H.div [ H.pre [ H.pcdata (String.trim message) ] ];
+      H.div [ H.p [ H.pcdata (String.trim message) ] ];
     ]
   ]
 
@@ -140,7 +140,7 @@ let lwt_alert ~title ~buttons message =
   waiter
 
 let alert ?(title=[%i"ERROR"]) ?buttons message =
-  ext_alert ~title ?buttons [ H.pre [H.pcdata (String.trim message)] ]
+  ext_alert ~title ?buttons [ H.p [H.pcdata (String.trim message)] ]
 
 let confirm ~title ?(ok_label=[%i"OK"]) ?(cancel_label=[%i"Cancel"]) contents f =
   ext_alert ~title contents ~buttons:[

--- a/src/app/server_caller.ml
+++ b/src/app/server_caller.ml
@@ -45,7 +45,7 @@ module Json_codec = struct
     Js._JSON##(parse (Js.string s)) |>
     Json_repr_browser.Json_encoding.destruct enc
 
-  let encode enc x =
+  let encode ?minify:_ enc x =
     let json = Json_repr_browser.Json_encoding.construct enc x in
     Js.to_string Js._JSON##(stringify json)
 

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -417,7 +417,7 @@ module Json_codec = struct
      | s -> Ezjsonm.from_string s)
     |> Json_encoding.destruct enc
 
-  let encode enc x =
+  let encode ?minify:_ enc x =
     match Json_encoding.construct enc x with
     | `A _ | `O _ as json -> Ezjsonm.to_string json
     | `Null -> ""

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -629,8 +629,10 @@ let main o =
   let solution, exercise_id =
     match o.solution_file, o.exercise_id with
     | None, _ -> Printf.eprintf "You must specify a file to grade.\n%!"; exit 2
-    | Some f, None -> f, Filename.(remove_extension (basename f))
     | Some f, Some id -> f, id
+    | Some f, None ->
+        let id = Filename.remove_extension f in
+        f, id
   in
   status_line "Reading solution.";
   Lwt_io.with_file ~mode:Lwt_io.Input solution Lwt_io.read

--- a/src/server/learnocaml_server.ml
+++ b/src/server/learnocaml_server.ml
@@ -35,19 +35,7 @@ let args = Arg.align @@
 open Lwt.Infix
 
 let read_static_file path =
-  let shorten path =
-    let rec resolve acc = function
-      | [] -> List.rev acc
-      | "." :: rest -> resolve acc rest
-      | ".." :: rest ->
-          begin match acc with
-            | [] -> resolve [] rest
-            | _ :: acc -> resolve acc rest end
-      | name :: rest -> resolve (name :: acc) rest in
-    resolve [] path in
-  let path =
-    String.concat Filename.dir_sep (!static_dir :: shorten path) in
-  Lwt_io.(with_file ~mode: Input path read)
+  Lwt_io.(with_file ~mode: Input (sanitise_path !static_dir path) read)
 
 exception Too_long_body
 
@@ -262,6 +250,20 @@ module Request_handler = struct
               | Some prev_save ->
                   let save = Save.sync prev_save save in
                   Save.set token save >>= fun () -> respond_json cache save)
+      | Api.Git (token, path) ->
+          let prefix =
+            let ( / ) = Filename.concat in
+            !sync_dir / Token.to_path token / ".git"
+          in
+          let path = sanitise_path prefix path in
+          Lwt.catch (fun () ->
+              Lwt_io.(with_file ~mode:Input path read) >|= fun contents ->
+              Response { contents;
+                         content_type = "application/octet-stream";
+                         caching = Nocache })
+            (fun e ->
+               Lwt.return (Status { code = `Not_found;
+                                    body = Printexc.to_string e }))
 
       | Api.Students_list token ->
           with_verified_teacher_token token @@ fun () ->

--- a/src/state/learnocaml_api.ml
+++ b/src/state/learnocaml_api.ml
@@ -32,6 +32,8 @@ type _ request =
       'a token -> Save.t request
   | Update_save:
       'a token * Save.t -> Save.t request
+  | Git: 'a token * string list -> string request
+
   | Students_list:
       teacher token -> Student.t list request
   | Set_students_list:
@@ -103,6 +105,7 @@ module Conversions (Json: JSON_CODEC) = struct
           json Save.enc
       | Update_save _ ->
           json Save.enc
+      | Git _ -> str
       | Students_list _ ->
           json (J.list Student.enc)
       | Set_students_list _ ->
@@ -166,6 +169,8 @@ module Conversions (Json: JSON_CODEC) = struct
         get ~token ["save.json"]
     | Update_save (token, save) ->
         post ~token ["sync"] (Json.encode Save.enc save)
+    | Git _ ->
+        assert false (* Reserved for the [git] client *)
 
     | Students_list token ->
         assert (Token.is_teacher token);
@@ -261,6 +266,10 @@ module Server (Json: JSON_CODEC) (Rh: REQUEST_HANDLER) = struct
           (match Json.decode Save.enc body with
            | save -> Update_save (token, save) |> k
            | exception e -> Invalid_request (Printexc.to_string e) |> k)
+      | `GET, (stoken::"learnocaml-workspace.git"::p), None ->
+          (match Token.parse stoken with
+           | token -> Git (token, p) |> k
+           | exception Failure e -> Invalid_request e |> k)
 
       | `GET, ["teacher"; "students.json"], Some token
         when Token.is_teacher token ->

--- a/src/state/learnocaml_api.ml
+++ b/src/state/learnocaml_api.ml
@@ -75,7 +75,7 @@ module J = Json_encoding
 
 module type JSON_CODEC = sig
   val decode: 'a J.encoding -> string -> 'a
-  val encode: 'a J.encoding -> 'a -> string
+  val encode: ?minify:bool -> 'a J.encoding -> 'a -> string
 end
 
 module Conversions (Json: JSON_CODEC) = struct

--- a/src/state/learnocaml_api.mli
+++ b/src/state/learnocaml_api.mli
@@ -92,7 +92,7 @@ type http_request = {
 
 module type JSON_CODEC = sig
   val decode: 'a Json_encoding.encoding -> string -> 'a
-  val encode: 'a Json_encoding.encoding -> 'a -> string
+  val encode: ?minify:bool -> 'a Json_encoding.encoding -> 'a -> string
 end
 
 module type REQUEST_HANDLER = sig

--- a/src/state/learnocaml_api.mli
+++ b/src/state/learnocaml_api.mli
@@ -45,6 +45,9 @@ type _ request =
       'a token -> Save.t request
   | Update_save:
       'a token * Save.t -> Save.t request
+  | Git:
+      'a token * string list -> string request
+
   | Students_list:
       teacher token -> Student.t list request
   | Set_students_list:

--- a/src/state/learnocaml_store.ml
+++ b/src/state/learnocaml_store.ml
@@ -31,9 +31,9 @@ module Json_codec = struct
      | s -> Ezjsonm.from_string s)
     |> J.destruct enc
 
-  let encode enc x =
+  let encode ?minify enc x =
     match J.construct enc x with
-    | `A _ | `O _ as json -> Ezjsonm.to_string json
+    | `A _ | `O _ as json -> Ezjsonm.to_string ?minify json
     | `Null -> ""
     | _ -> assert false
 end
@@ -355,7 +355,7 @@ module Save = struct
     let file = Token.path token in
     Lwt.catch (fun () ->
         write ~no_create:(Token.is_teacher token) file
-          (Json_codec.encode enc save))
+          (Json_codec.encode ~minify:false enc save))
       (function
         | Not_found -> Lwt.fail_with "Unregistered teacher token"
         | e -> Lwt.fail e)

--- a/src/state/learnocaml_store.mli
+++ b/src/state/learnocaml_store.mli
@@ -30,6 +30,12 @@ val sync_dir: string ref
 (** Used both for file i/o and request handling *)
 module Json_codec: Learnocaml_api.JSON_CODEC
 
+(* [sanitise_path prefix subdir] simplifies "." and ".." references in [subdir],
+   and returns the concatenation, but guaranteeing the result remains below
+   [prefix] (not accounting for symlinks of course, this is purely syntaxical)
+*)
+val sanitise_path: string -> string list -> string
+
 (** {2 Static data} *)
 
 module Lesson: sig

--- a/src/utils/lwt_utils.mli
+++ b/src/utils/lwt_utils.mli
@@ -20,3 +20,10 @@ val mkdir_p: ?perm:int -> string -> unit Lwt.t
 (** [copy_tree src dst] copies the contents of directory [src] into directory
     [dst] *)
 val copy_tree: string -> string -> unit Lwt.t
+
+
+type 'a with_lock = { with_lock: 'b. 'a -> (unit -> 'b Lwt.t) -> 'b Lwt.t }
+
+(** Creates a mutex hashtable when applied to [()], and returns a `with_mutex`
+    function that can lock with a given mutex identifier *)
+val gen_mutex_table: unit -> 'a with_lock


### PR DESCRIPTION
This works but probably needs some more work:
- [X] a global write mutex is used, this should be refined for each separate git repo
- [x] git needs to be added to the dependencies, esp. in the Docker images
- [X] this might be an opportunity to re-examine the save format (one-line json files)