### PR TITLE
Exercises dependency graph

### DIFF
--- a/src/grader/grader_cli.ml
+++ b/src/grader/grader_cli.ml
@@ -23,6 +23,7 @@ let display_outcomes = ref false
 let grade_student = ref None
 let individual_timeout = ref None
 let display_reports = ref false
+let dump_dot = ref None
 
 open Lwt.Infix
 

--- a/src/grader/grader_cli.mli
+++ b/src/grader/grader_cli.mli
@@ -41,6 +41,9 @@ val individual_timeout: int option ref
 (** Display reports to stderr *)
 val display_reports: bool ref
 
+(** Should the tool generate and dump a dependency graph of the exercises and where *)
+val dump_dot: string option ref
+
 (** {2 Functions} *)
 
 (** Runs the grading process *)

--- a/src/main/learnocaml_main.ml
+++ b/src/main/learnocaml_main.ml
@@ -101,6 +101,11 @@ module Args = struct
       value & flag & info ["verbose"; "v"] ~doc:
         "Display detailed grading reports to stdout"
 
+    let dump_dot =
+      value & opt (some string) None & info ["dump-dot"] ~doc:
+        "Generates a dependency graph of the repository and dumps it into the \
+         given file"
+
     type t = {
       exercises: string list;
       output_json: string option;
@@ -110,7 +115,8 @@ module Args = struct
       let apply
           exercises
           output_json grade_student display_outcomes quiet
-          display_std_outputs dump_outputs dump_reports timeout verbose =
+          display_std_outputs dump_outputs dump_reports timeout
+          verbose dump_dot =
         let exercises = List.flatten exercises in
         Grader_cli.grade_student := grade_student;
         Grader_cli.display_outcomes := display_outcomes;
@@ -120,6 +126,7 @@ module Args = struct
         Grader_cli.dump_reports := dump_reports;
         Grader_cli.individual_timeout := timeout;
         Grader_cli.display_reports := verbose;
+        Grader_cli.dump_dot := dump_dot;
         Learnocaml_process_exercise_repository.dump_outputs := dump_outputs;
         Learnocaml_process_exercise_repository.dump_reports := dump_reports;
         { exercises; output_json }
@@ -127,7 +134,7 @@ module Args = struct
       Term.(const apply
             $exercises $output_json $grade_student $display_outcomes
             $quiet $display_std_outputs $dump_outputs $dump_reports
-            $timeout $verbose)
+            $timeout $verbose $dump_dot)
   end
 
   module Builder = struct

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -60,6 +60,14 @@ let dump_outputs = ref None
 
 let dump_reports = ref None
 
+let dump_dot exs =
+  match !Grader_cli.dump_dot with
+    None -> Lwt.return ()
+  | Some filename ->
+      let graph = Exercise.Graph.compute_graph ~filters:[] exs in
+      Lwt_io.with_file ~mode:Lwt_io.Output filename
+        (fun oc -> Lwt_io.write oc (Format.asprintf "%a" Exercise.Graph.dump_dot graph))
+
 let n_processes = ref 1
 
 let print_grader_error exercise = function
@@ -201,6 +209,7 @@ let main dest_dir =
        in
        fill_structure SMap.empty structure >>= fun (all_exercises, index) ->
        to_file Index.enc (dest_dir / Learnocaml_index.exercise_index_path) index >>= fun () ->
+       dump_dot index >>= fun () ->
        SSet.iter (fun id ->
            if not (SMap.mem id all_exercises) then
              Format.printf "[Warning] Filtered exercise '%s' not found.@." id)

--- a/src/state/learnocaml_data.ml
+++ b/src/state/learnocaml_data.ml
@@ -917,7 +917,7 @@ module Exercise = struct
               meta.Meta.backward in
           { meta with Meta.requirements; Meta.focus; Meta.backward })
 
-    let compute_graph ~filters exercises =
+    let compute_graph ?(filters=[]) exercises =
       let exercises_nodes = Hashtbl.create 17 in
       let ex_filtered = apply_filters filters exercises in
       let focus = focus_map ex_filtered in
@@ -939,6 +939,28 @@ module Exercise = struct
         end
       in
       compute [] graph
+
+    let dump_dot fmt nodes =
+      let print_kind fmt = function
+        | Skill s -> Format.fprintf fmt "(S %s)" s
+        | Exercise s -> Format.fprintf fmt "(E %s)" s
+      in
+      let print_child fmt ex child kinds =
+        Format.fprintf fmt "%s -> %s [label=\"%a\"];\n"
+          ex
+          child.name
+          (fun fmt -> List.iter (print_kind fmt)) kinds
+      in
+      let print_node fmt n =
+        List.iter (fun (child, kinds) ->
+            print_child fmt n.name child kinds)
+          n.children
+      in
+      Format.fprintf fmt
+        "digraph exercises {\n\
+         %a\n\
+         }"
+        (fun fmt -> List.iter (print_node fmt)) nodes
 
   end
 

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -282,11 +282,14 @@ module Exercise: sig
 
     (** Computes the dependency graph of exercises, and filters out exercises
         or skills if any are given. *)
-    val compute_graph : filters:relation list -> Index.t -> node list
+    val compute_graph : ?filters:relation list -> Index.t -> node list
 
     (** Computes a set of exercises that appear as dependencies of the given
         exercise. *)
     val compute_exercise_set : node -> string list
+
+    (** Dumps the graph as a `dot` representation, into the given formatter. *)
+    val dump_dot : Format.formatter -> node list -> unit
 
   end
 

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -265,6 +265,25 @@ module Exercise: sig
 
   end
 
+  (** Dependency graph of exercises *)
+  module Graph : sig
+
+    type relation = Skill of string | Exercise of id
+
+    (** An exercise depends on others, by a skill or/and backward relation *)
+    type node = private {
+      name : id;
+      mutable children : (node * relation list) list
+    }
+
+    val compute_graph : Index.t -> node list
+
+    (** Computes a set of exercises that might be needed to do the exercise
+        given. *)
+    val compute_exercise_set : node -> string list
+
+  end
+
 end
 
 module Lesson: sig

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -268,18 +268,24 @@ module Exercise: sig
   (** Dependency graph of exercises *)
   module Graph : sig
 
+    (** Two exercises can be related either by a skill dependency, or backward
+        relationship *)
     type relation = Skill of string | Exercise of id
 
-    (** An exercise depends on others, by a skill or/and backward relation *)
-    type node = private {
-      name : id;
-      mutable children : (node * relation list) list
-    }
+    (** An exercise depends on others, by a skill or/and backward relation.
+        Due to hashconsing, its representation is not directly available.
+    *)
+    type node
 
-    val compute_graph : Index.t -> node list
+    val node_exercise : node -> id
+    val node_children : node -> (node * relation list) list
 
-    (** Computes a set of exercises that might be needed to do the exercise
-        given. *)
+    (** Computes the dependency graph of exercises, and filters out exercises
+        or skills if any are given. *)
+    val compute_graph : filters:relation list -> Index.t -> node list
+
+    (** Computes a set of exercises that appear as dependencies of the given
+        exercise. *)
     val compute_exercise_set : node -> string list
 
   end


### PR DESCRIPTION
Generates a graph of dependencies between the exercises of a repository.
An exercise depends on:
* Its declared backward exercises
* The exercises that focusing on its required skills

This PR only includes the data structure and the graph generation, with a CLI option to dump the graph into its dot representation when building the repository. It should be useful to generate a set of exercises ordered by dependencies (a small algorithm is given as `compute_exercise_set`, but it is really naive).

For example, here is a generated repository with only 10 exercises and 3 skills (it should be clearer for a well-thought repository): 
![image](https://user-images.githubusercontent.com/4539892/48206949-df2ddd00-e36f-11e8-8412-b663e7769dfe.png)
