### PR TITLE
A little improvement in the setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The exercises and lessons are in another github repository:
 Howtos
 ------
 
-* [How to setup an environment to develop exercises?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-setup-exercise-development-environment.md)
+* [How to set up an environment to develop exercises?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-setup-exercise-development-environment.md)
 * [How to write exercises?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-write-exercises.md)
 * [How to submit an exercise to the global corpus?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-submit-an-exercise.md)
 * [How to deploy an instance of Learn OCaml?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-deploy-a-learn-ocaml-instance.md)

--- a/docs/howto-setup-exercise-development-environment.md
+++ b/docs/howto-setup-exercise-development-environment.md
@@ -8,10 +8,16 @@ GNU/Linux and MacOS X are supported.
 
 > An alternative to following the instructions below is to use a pre-built
 > Docker container. Assuming you have an exercise repository in directory
-> `REPOSITORY` (absolute path), and a recent enough version of Docker installed,
+> `$REPOSITORY` (absolute path), and a recent enough version of Docker installed,
 > use:
 >
->     docker run --rm -v REPOSITORY:/repository:ro -v learn-ocaml-sync:/sync -p 80:8080 --name learn-ocaml-server altgr/learn-ocaml
+>     docker version # If this fails, find out how to run Docker, first
+>     docker login
+>     docker run --rm \
+>       -v $REPOSITORY:/repository:ro \
+>       -v learn-ocaml-sync:/sync \
+>       -p 80:8080 --name learn-ocaml-server \
+>       ocamlsf/learn-ocaml
 >
 > This will start an instance of the learn-ocaml server on port 80 (ignore the
 > message about 8080, this is the port used internally).

--- a/docs/howto-setup-exercise-development-environment.md
+++ b/docs/howto-setup-exercise-development-environment.md
@@ -1,7 +1,7 @@
-How to setup your development environment
+How to set up your development environment
 =========================================
 
-This section explains how to setup a development environment on your
+This section explains how to set up a development environment on your
 local machine. At the end of this tutorial, you will be able to follow
 the tutorial `howto-write-an-exercise.md`. For the moment, only
 GNU/Linux and MacOS X are supported.
@@ -74,7 +74,7 @@ learn-ocaml --help
 This should open the manpage of the command-line tool to interact
 with the platform.
 
-## Step 2: Setup a work directory
+## Step 2: Set up a work directory
 
 Now, let us go back to `$DIR` and create a root for the source tree of exercises:
 ```

--- a/docs/howto-setup-exercise-development-environment.md
+++ b/docs/howto-setup-exercise-development-environment.md
@@ -17,7 +17,7 @@ GNU/Linux and MacOS X are supported.
 >       -v $REPOSITORY:/repository:ro \
 >       -v learn-ocaml-sync:/sync \
 >       -p 80:8080 --name learn-ocaml-server \
->       ocamlsf/learn-ocaml
+>       ocamlsf/learn-ocaml:dev
 >
 > This will start an instance of the learn-ocaml server on port 80 (ignore the
 > message about 8080, this is the port used internally).


### PR DESCRIPTION
The name of the Docker image is still incorrect, though:
there is no "latest" image. Should this image be created?
Currently, then the user must add a version number such
as "0.9" to the image name.