### PR TITLE
Fix dune install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build
+all: static build
 
 # config variables ------------------------------------------------------------
 


### PR DESCRIPTION
Make sure `make static` is run before `make build`.

Fixes #217 