### PR TITLE
Fix 0pt success score colour in failure sections

### DIFF
--- a/static/css/learnocaml_report.css
+++ b/static/css/learnocaml_report.css
@@ -175,11 +175,11 @@
 #learnocaml-report .important > .title {
   border-color: #67f;
 }
-#learnocaml-report .success .text .score {
-  color: green;
-}
 #learnocaml-report .failure .text .score {
   color: red;
+}
+#learnocaml-report .success .text .score {
+  color: green;
 }
 #learnocaml-report div > .folded .report {
   display: none;


### PR DESCRIPTION
Currently, if a section has a total score of 0, all of the scores
within it are displayed in red font, even for 0pt success
messages. This reorders the CSS rules so that the success score
rule takes priority.

Old:
![image](https://user-images.githubusercontent.com/6691680/51444295-ce7cda00-1cc3-11e9-92d1-1f227c475a7d.png)

New:
![image](https://user-images.githubusercontent.com/6691680/51444274-9a091e00-1cc3-11e9-8f67-d1f57270ff47.png)
