### PR TITLE
Expose Timeout exception in Test_lib API.

### DIFF
--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -418,7 +418,7 @@ module type S = sig
     (** [sample_int ()] returns a random integer between -5 and 5. *)
     val sample_int : int sampler
 
-    (** [sample_float ()] returns a random float betwenn -5. and 5. *)
+    (** [sample_float ()] returns a random float between -5. and 5. *)
     val sample_float : float sampler
 
     (** [sample_string ()] returns a randomly long random string. *)
@@ -490,7 +490,7 @@ module type S = sig
        report if reference [got] value is equal to [exp] and
        {!LearnOcaml_report.Failure} report otherwise.
 
-        {e WARNING:} contrary to other grading functions, you can not
+        {e WARNING:} contrary to other grading functions, you cannot
        use this function to evaluate a reference defined or modified
        in student's code. In this case, you should use
        {{!Mutation}mutation functions}. This function should be used

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -232,6 +232,11 @@ module type S = sig
   type io_tester =
     string -> string -> Learnocaml_report.t
 
+  (** The exception [Timeout limit] is raised by [run_timeout]. Thus, the
+      functions [exec] and [result] can return [Error (Timeout limit)].
+      The integer [limit] is the maximum time that was allowed, in seconds. *)
+  exception Timeout of int
+
   module Tester : sig
     (** Testers are essentially used for the optional arguments
        [~test], [~test_stdout], [~test_stderr] of
@@ -1013,13 +1018,14 @@ module type S = sig
         if no exception is raised and where [r] is the result of [v
         ()], [stdout] the standard output string (possibly empty) and
         [stderr] the standard error string (possibly empty) or returns
-        [Error exn] is exception [exn] is raised. May also return a
-        timeout error. *)
+        [Error exn] is exception [exn] is raised. In particular, a
+        timeout error [Error (Timeout limit)] can be returned. *)
     val exec : (unit -> 'a) -> ('a * string * string) result
 
     (** [result v] executes [v ()] and returns [Ok r] where [r] is
         the result of [v ()] or [Error exn] if exception [exn] is
-        raised. May also return a timeout error. *)
+        raised. In particular, a timeout error [Error (Timeout limit)]
+        can be returned. *)
     val result : (unit -> 'a) -> 'a result
 
     (** The type of arguments, represented as heterogeneous lists.


### PR DESCRIPTION
Change the exception `Timeout` to carry a `limit` in seconds.
(I think this change is OK, as the exception was not public so far.)
Expose this exception in the `Test_lib` API.
Change the default printing code so that the time limit is shown when the student's code runs out of time.