### PR TITLE
If Lwt_utils.copy_tree with empty source directory, then Lwt.return_unit

### DIFF
--- a/.ci-macosx.sh
+++ b/.ci-macosx.sh
@@ -5,5 +5,5 @@ brew install opam
 opam init -y --compiler=4.05.0
 eval $(opam env)
 
-opam install -y . --deps-only
+opam install -y . --deps-only --locked
 make && make opaminstall


### PR DESCRIPTION
This fix will avoid invoking cp with no source-files for issue #228