### PR TITLE
If Lwt_utils.copy_tree with empty source directory, then Lwt.return_unit 

### DIFF
--- a/src/utils/lwt_utils.ml
+++ b/src/utils/lwt_utils.ml
@@ -21,8 +21,7 @@ let rec mkdir_p ?(perm=0o755) dir =
       Lwt_unix.mkdir dir perm
 
 let copy_tree src dst =
-  let files = Sys.readdir src
-  in
+  let files = Sys.readdir src in
   if Array.length files = 0 then Lwt.return_unit
   else
     Lwt.catch (fun () ->


### PR DESCRIPTION
This will avoid using cp if the directory is empty, and just return Lwt.return_unit for fix #228 