### PR TITLE
Enlarge body font size

### DIFF
--- a/static/css/learnocaml_common.css
+++ b/static/css/learnocaml_common.css
@@ -1,6 +1,6 @@
 body {
   font-family: 'Fontin', 'Linux Biolinum', sans-serif;
-  font-size: 16px;
+  font-size: 18px;
   line-height: 18px;
 }
 button, select {


### PR DESCRIPTION
Hi,

This fix a part of #214 : the default font size is inherited from `body` and was indeed inconsistent with the size from `code` (and with the `line-height` attribute, I am not an artist so please tell me if you want to keep the `2px` difference between the two attributes).