### PR TITLE
Print all buffers in case of error

### DIFF
--- a/src/grader/grading.ml
+++ b/src/grader/grading.ml
@@ -84,10 +84,9 @@ let get_grade
           !flush_stderr () ;
           !flush_stdout () ;
           let msg =
-            Buffer.contents stderr_buffer ^
-            "\n" ^
-            Buffer.contents stdout_buffer in
-          fail { Toploop_ext.msg ; locs = [] ; if_highlight = msg }
+            String.concat "\n"
+              (List.map Buffer.contents [stderr_buffer; stdout_buffer; outcomes_buffer])
+          in fail { Toploop_ext.msg ; locs = [] ; if_highlight = msg }
         end
     | Toploop_ext.Error (err, w) ->
         warn w ;


### PR DESCRIPTION
Hi,

While working on another issue, I hit the exact same than described in #232 : In the webapp, the grading fails with:
```
Erreur dans l'exercice lors du test de la solution utilisateur
```

And no other information.

So I decided to give it a try, and discovered that a buffer which contained some logs was not printed (and it was indeed the one where was the information I needed).

This PR fix this problem.