### PR TITLE
Add some missing modules from standard library

### DIFF
--- a/src/grader/dune
+++ b/src/grader/dune
@@ -47,29 +47,28 @@
 
 (rule
  (targets embedded_cmis.ml)
- (deps %{ocaml-config:standard_library}/pervasives.cmi
-       %{ocaml-config:standard_library}/array.cmi
+ (deps %{ocaml-config:standard_library}/array.cmi
        %{ocaml-config:standard_library}/arrayLabels.cmi
-       %{ocaml-config:standard_library}/list.cmi
+       %{ocaml-config:standard_library}/buffer.cmi
+       %{ocaml-config:standard_library}/bytes.cmi
        %{ocaml-config:standard_library}/camlinternalFormatBasics.cmi
        %{ocaml-config:standard_library}/camlinternalFormat.cmi
+       %{ocaml-config:standard_library}/char.cmi
+       %{ocaml-config:standard_library}/digest.cmi
+       %{ocaml-config:standard_library}/format.cmi
+       %{ocaml-config:standard_library}/hashtbl.cmi
+       %{ocaml-config:standard_library}/int32.cmi
+       %{ocaml-config:standard_library}/int64.cmi
+       %{ocaml-config:standard_library}/lexing.cmi
+       %{ocaml-config:standard_library}/list.cmi
+       %{ocaml-config:standard_library}/map.cmi
+       %{ocaml-config:standard_library}/pervasives.cmi
+       %{ocaml-config:standard_library}/printexc.cmi
        %{ocaml-config:standard_library}/printf.cmi
        %{ocaml-config:standard_library}/random.cmi
-       %{ocaml-config:standard_library}/string.cmi
-       %{ocaml-config:standard_library}/bytes.cmi
-       %{ocaml-config:standard_library}/sys.cmi
-       %{ocaml-config:standard_library}/format.cmi
-       %{ocaml-config:standard_library}/char.cmi
-       %{ocaml-config:standard_library}/printexc.cmi
-       %{ocaml-config:standard_library}/digest.cmi
-       %{ocaml-config:standard_library}/lexing.cmi
-       %{ocaml-config:standard_library}/buffer.cmi
-       %{ocaml-config:standard_library}/hashtbl.cmi
        %{ocaml-config:standard_library}/set.cmi
-       %{ocaml-config:standard_library}/map.cmi
-       %{ocaml-config:standard_library}/topdirs.cmi
-       %{ocaml-config:standard_library}/int32.cmi
-       %{ocaml-config:standard_library}/int64.cmi)
+       %{ocaml-config:standard_library}/string.cmi
+       %{ocaml-config:standard_library}/sys.cmi)
  (action (with-stdout-to %{targets} (run ocp-ocamlres -format ocamlres %{deps})))
 )
 

--- a/src/grader/dune
+++ b/src/grader/dune
@@ -53,22 +53,31 @@
        %{ocaml-config:standard_library}/bytes.cmi
        %{ocaml-config:standard_library}/camlinternalFormatBasics.cmi
        %{ocaml-config:standard_library}/camlinternalFormat.cmi
+       %{ocaml-config:standard_library}/camlinternalLazy.cmi
        %{ocaml-config:standard_library}/char.cmi
+       %{ocaml-config:standard_library}/complex.cmi
        %{ocaml-config:standard_library}/digest.cmi
+       %{ocaml-config:standard_library}/filename.cmi
        %{ocaml-config:standard_library}/format.cmi
        %{ocaml-config:standard_library}/hashtbl.cmi
        %{ocaml-config:standard_library}/int32.cmi
        %{ocaml-config:standard_library}/int64.cmi
+       %{ocaml-config:standard_library}/lazy.cmi
        %{ocaml-config:standard_library}/lexing.cmi
        %{ocaml-config:standard_library}/list.cmi
        %{ocaml-config:standard_library}/map.cmi
+       %{ocaml-config:standard_library}/marshal.cmi
        %{ocaml-config:standard_library}/pervasives.cmi
        %{ocaml-config:standard_library}/printexc.cmi
        %{ocaml-config:standard_library}/printf.cmi
+       %{ocaml-config:standard_library}/queue.cmi
        %{ocaml-config:standard_library}/random.cmi
+       %{ocaml-config:standard_library}/scanf.cmi
        %{ocaml-config:standard_library}/set.cmi
+       %{ocaml-config:standard_library}/stack.cmi
        %{ocaml-config:standard_library}/string.cmi
-       %{ocaml-config:standard_library}/sys.cmi)
+       %{ocaml-config:standard_library}/sys.cmi
+       %{ocaml-config:standard_library}/uchar.cmi)
  (action (with-stdout-to %{targets} (run ocp-ocamlres -format ocamlres %{deps})))
 )
 

--- a/src/grader/dune
+++ b/src/grader/dune
@@ -77,7 +77,8 @@
        %{ocaml-config:standard_library}/stack.cmi
        %{ocaml-config:standard_library}/string.cmi
        %{ocaml-config:standard_library}/sys.cmi
-       %{ocaml-config:standard_library}/uchar.cmi)
+       %{ocaml-config:standard_library}/uchar.cmi
+       %{ocaml-config:standard_library}/weak.cmi )
  (action (with-stdout-to %{targets} (run ocp-ocamlres -format ocamlres %{deps})))
 )
 


### PR DESCRIPTION
Hi,

This fixes (in part) issue #241.
This PR makes available the following modules: `Complex`, `Filename`, `Lazy`, `Marshal`, `Queue`, `Scanf`, `Stack`, `Uchar` and `Weak`.

Adding `Float` and `Bigarray` seems possible (see https://ocsigen.org/js_of_ocaml/3.1.0/manual/overview for bigarray), but it goes beyond my copying/pasting skill.

I allowed myself to order the list of modules in alphabetical order, to simplify the reading.