### PR TITLE
Refactoring client and adding a create-token command

### DIFF
--- a/src/main/dune
+++ b/src/main/dune
@@ -34,6 +34,7 @@
             cohttp.lwt
             grading_cli
             learnocaml_data
+	    learnocaml_store
             learnocaml_api)
 )
 

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -56,7 +56,7 @@ module Args_global = struct
 
   let local =
     value & flag & info ["local"] ~doc:
-      "Generate a configuration file local to the current directory, rather \
+      "Use a configuration file local to the current directory, rather \
        than user-wide"
 
   let apply server_url token local =
@@ -78,7 +78,7 @@ module Args_create_token = struct
 
   let secret =
     value & pos 1 string "" & info [] ~docv:"SECRET" ~doc:
-      "The secret"
+      "The secret. If not provided, use \"\" as a secret"
 
   let apply nickname secret = {nickname; secret}
 
@@ -669,7 +669,7 @@ module Grade = struct
     Term.(
       const (fun go eo -> Pervasives.exit (Lwt_main.run (grade go eo)))
       $ Args_global.term $ Args_exercises.term),
-    Term.info ~version ~man
+    Term.info ~man
       ~doc:"Learn-ocaml grading client"
       "grade"
 end
@@ -686,12 +686,12 @@ module Print_token = struct
     Lwt_io.print (Token.to_string config.ConfigFile.token ^ "\n")
     >|= fun () -> 0
 
-  let man = man "Just print the configured user token and exit"
+  let man = man "Just print the configured user token"
 
   let cmd =
     use_global print_tok,
-    Term.info ~version ~man
-      ~doc:"Just print the configured user token and exit"
+    Term.info ~man
+      ~doc:"Just print the configured user token"
       "print-token"
 end
 
@@ -703,12 +703,12 @@ module Set_options = struct
   let man =
     man
       "Overwrite the configuration file with the command-line options \
-       ($(b,--server), $(b,--token)), and exit"
+       ($(b,--server), $(b,--token))"
 
   let cmd =
     use_global set_opts,
-    Term.info ~version ~man
-      ~doc:"Set local configuration and exit"
+    Term.info ~man
+      ~doc:"Set configuration"
       "set-options"
 end
 
@@ -743,11 +743,11 @@ module Fetch = struct
 
   let man =
     man
-      "Fetch the user's solutions on the server to the current directory and exit"
+      "Fetch the user's solutions on the server to the current directory"
 
   let cmd =
     use_global fetch,
-    Term.info ~version ~man
+    Term.info ~man
       ~doc:"Fetch the user's solutions"
       "fetch"
 end
@@ -774,7 +774,7 @@ module Create_token = struct
     Term.(
       const (fun go co -> Pervasives.exit (Lwt_main.run (create_tok go co)))
       $ Args_global.term $ Args_create_token.term),
-    Term.info ~version ~man
+    Term.info ~man
       ~doc:"Create a token"
       "create-token"
 end
@@ -782,7 +782,7 @@ end
 module Main = struct
   let man =
     man
-      "Learn-ocaml-client, default action is grading"
+      "Learn-ocaml-client, default command is grade"
 
   let cmd = fst Grade.cmd,
     Term.info ~version ~man

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -383,22 +383,7 @@ let console_report ?(verbose=false) ex report =
   List.iter (fun i -> print_endline (format_item i)) report;
   print_newline ()
 
-(* fixme: copied from Learnocaml_store *)
-module Json_codec = struct
-  let decode enc s =
-    (match s with
-     | "" -> `O []
-     | s -> Ezjsonm.from_string s)
-    |> Json_encoding.destruct enc
-
-  let encode ?minify:_ enc x =
-    match Json_encoding.construct enc x with
-    | `A _ | `O _ as json -> Ezjsonm.to_string json
-    | `Null -> ""
-    | _ -> assert false
-end
-
-module Api_client = Learnocaml_api.Client (Json_codec)
+module Api_client = Learnocaml_api.Client (Learnocaml_store.Json_codec)
 
 let fetch server_url req =
   let url path args =

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -29,7 +29,6 @@ module Args = struct
     set_options: bool;
     print_token: bool;
     fetch: bool;
-    version: bool;
   }
 
   let url_conv =
@@ -124,7 +123,7 @@ module Args = struct
   let term =
     let apply
         server_url solution_file exercise_id output_format dont_submit
-        color_when verbose token local set_options print_token fetch version =
+        color_when verbose token local set_options print_token fetch =
       let color = match color_when with
         | Some o -> o
         | None -> Unix.(isatty stdout) && Sys.getenv_opt "TERM" <> Some "dumb"
@@ -142,13 +141,11 @@ module Args = struct
         set_options;
         print_token;
         fetch;
-        version;
       }
     in
     Term.(const apply
           $server_url $solution_file $exercise_id $output_format $dont_submit
-          $color_when $verbose $token $local $set_options $print_token $fetch
-          $version)
+          $color_when $verbose $token $local $set_options $print_token $fetch)
 end
 
 module ConfigFile = struct
@@ -607,8 +604,6 @@ let get_config ?local ?(save_back=false) server_opt token_opt =
 let main o =
   Console.enable_colors := o.Args.color;
   Console.enable_utf8 := o.Args.color;
-  if o.Args.version then
-    (print_endline version; exit 0);
   let open Args in
   get_config ~local:o.local ~save_back:o.set_options o.server_url o.token
   >>= fun { ConfigFile.server; token } ->
@@ -702,6 +697,7 @@ let main_cmd =
   Cmdliner.Term.info
     ~man
     ~doc:"Learn-ocaml grading client"
+    ~version
     "learn-ocaml-client"
 
 let () =

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -446,18 +446,6 @@ let upload_save server_url token save =
         "Could not upload the results to the server: %s"
         (match e with Failure s -> s | e -> Printexc.to_string e)
 
-let write_save_files save =
-  Lwt_list.iter_s (fun (id, st) ->
-      let f = Filename.concat (Sys.getcwd ()) (id ^ ".ml") in
-      if Sys.file_exists f then
-        (Printf.eprintf "File %s already exists, not overwriting.\n" f;
-         Lwt.return_unit)
-      else
-        Lwt_io.(with_file ~mode:Output ~perm:0o600 f) @@ fun oc ->
-        Lwt_io.write oc st.Answer.solution >|= fun () ->
-        Printf.eprintf "Wrote file %s\n%!" f)
-    (SMap.bindings (save.Save.all_exercise_states))
-
 let upload_report server token ex solution report =
   let score = get_score report in
   let max_score = max_score ex in
@@ -729,6 +717,18 @@ module Fetch = struct
            "Token %S not found on the server."
            (Token.to_string token)
       | e -> Lwt.fail e
+
+  let write_save_files save =
+  Lwt_list.iter_s (fun (id, st) ->
+      let f = Filename.concat (Sys.getcwd ()) (id ^ ".ml") in
+      if Sys.file_exists f then
+        (Printf.eprintf "File %s already exists, not overwriting.\n" f;
+         Lwt.return_unit)
+      else
+        Lwt_io.(with_file ~mode:Output ~perm:0o600 f) @@ fun oc ->
+        Lwt_io.write oc st.Answer.solution >|= fun () ->
+        Printf.eprintf "Wrote file %s\n%!" f)
+    (SMap.bindings (save.Save.all_exercise_states))
 
   let fetch o =
     get_config_o o

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -671,6 +671,11 @@ module Grade = struct
       "grade"
 end
 
+let use_global f =
+  Cmdliner.Term.(
+    const (fun o -> Pervasives.exit (Lwt_main.run (f o)))
+    $ Args_global.term)
+
 module Print_token = struct
   let print_tok o =
     get_config_o o
@@ -681,9 +686,7 @@ module Print_token = struct
   let man = man "Just print the configured user token and exit"
 
   let cmd =
-    Cmdliner.Term.(
-      const (fun o -> Pervasives.exit (Lwt_main.run (print_tok o)))
-      $ Args_global.term),
+    use_global print_tok,
     Cmdliner.Term.info ~version ~man
       ~doc:"Just print the configured user token and exit"
       "print-token"
@@ -700,9 +703,7 @@ module Set_options = struct
        ($(b,--server), $(b,--token)), and exit"
 
   let cmd =
-    Cmdliner.Term.(
-      const (fun o -> Pervasives.exit (Lwt_main.run (set_opts o)))
-      $ Args_global.term),
+    use_global set_opts,
     Cmdliner.Term.info ~version ~man
       ~doc:"Set local configuration and exit"
       "set-options"
@@ -742,9 +743,7 @@ module Fetch = struct
       "Fetch the user's solutions on the server to the current directory and exit"
 
   let cmd =
-    Cmdliner.Term.(
-      const (fun o -> Pervasives.exit (Lwt_main.run (fetch o)))
-      $ Args_global.term),
+    use_global fetch,
     Cmdliner.Term.info ~version ~man
       ~doc:"Fetch the user's solutions"
       "fetch"
@@ -755,10 +754,7 @@ module Main = struct
     man
       "Learn-ocaml-client, default action is grading"
 
-  let cmd =
-    Cmdliner.Term.(
-      const (fun go eo -> Pervasives.exit (Lwt_main.run (Grade.grade go eo)))
-      $ Args_global.term $ Args_exercises.term),
+  let cmd = fst Grade.cmd,
     Cmdliner.Term.info ~version ~man
       ~doc:"Learn-ocaml grading client"
       "learn-ocaml-client"

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -437,15 +437,6 @@ let fetch_exercise server_url token id =
         id
   | e -> Lwt.fail e
 
-let fetch_save server_url token =
-  Lwt.catch (fun () -> fetch server_url (Api.Fetch_save token))
-  @@ function
-  | Not_found ->
-      Printf.ksprintf Lwt.fail_with
-        "Token %S not found on the server."
-        (Token.to_string token)
-  | e -> Lwt.fail e
-
 let upload_save server_url token save =
   Lwt.catch (fun () -> fetch server_url (Api.Update_save (token, save)))
   @@ function
@@ -729,6 +720,15 @@ module Set_options = struct
 end
 
 module Fetch = struct
+  let fetch_save server_url token =
+    Lwt.catch (fun () -> fetch server_url (Api.Fetch_save token))
+    @@ function
+      | Not_found ->
+         Printf.ksprintf Lwt.fail_with
+           "Token %S not found on the server."
+           (Token.to_string token)
+      | e -> Lwt.fail e
+
   let fetch o =
     get_config_o o
     >>= fun { ConfigFile.server; token } ->

--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -749,9 +749,23 @@ module Fetch = struct
       "fetch"
 end
 
+module Main = struct
+  let man =
+    man
+      "Learn-ocaml-client, default action is grading"
+
+  let cmd =
+    Cmdliner.Term.(
+      const (fun go eo -> Pervasives.exit (Lwt_main.run (Grade.grade go eo)))
+      $ Args.term_global $ Args.term_exercises),
+    Cmdliner.Term.info ~version ~man
+      ~doc:"Learn-ocaml grading client"
+      "learn-ocaml-client"
+end
+
 let () =
-  match Cmdliner.Term.eval_choice ~catch:false Grade.cmd
-          [Print_token.cmd; Set_options.cmd; Fetch.cmd]
+  match Cmdliner.Term.eval_choice ~catch:false Main.cmd
+          [Grade.cmd; Print_token.cmd; Set_options.cmd; Fetch.cmd]
   with
   | exception Failure msg ->
       Printf.eprintf "[ERROR] %s\n" msg;


### PR DESCRIPTION
Hi,

This PR introduces big changes on the syntax of `learn-ocaml-client`. To say it quickly, it adds commands to the client, and particularly one to create tokens (so this PR fixes #262).

The client seems to have been built to do a single task: grading file on a server. Now, it seems to have evolved, and there are many possible contradictory options (for example, a valid invocation is `learn-ocaml-client --fetch --console`, but has no sens, since the program will just fetch solutions and exit).

So, using `Cmdliner`, I restricted the use of options and added commands (the syntax looks like the one from `git`) to organize things. With this PR, the MAN page looks like:
```
NAME
       learn-ocaml-client - Learn-ocaml grading client

SYNOPSIS
       learn-ocaml-client COMMAND ...

DESCRIPTION
       Learn-ocaml-client, default command is grade

COMMANDS
       create-token
           Create a token

       fetch
           Fetch the user's solutions

       grade
           Learn-ocaml grading client

       print-token
           Just print the configured user token

       set-options
           Set configuration
```

So you can specify which command to run, and after use dedicated options if needed. For example, here is the output of `learn-ocaml-client create-token --help`:

```
NAME
       learn-ocaml-client-create-token - Create a token

SYNOPSIS
       learn-ocaml-client create-token [OPTION]... [NICKNAME] [SECRET]

DESCRIPTION
       Create a token on the server with the desired nickname

ARGUMENTS
       NICKNAME
           The desired nickname

       SECRET
           The secret. If not provided, use "" as a secret

OPTIONS
       --help[=FMT] (default=auto)
           Show this help in format FMT. The value FMT must be one of `auto',
           `pager', `groff' or `plain'. With `auto', the format is `pager` or
           `plain' whenever the TERM env var is `dumb' or undefined.

       -s URL, --server=URL (absent LEARNOCAML_SERVER env)
           The URL of the learn-ocaml server

       --version
           Show version information.
```

To keep things compatible, calling `learn-ocaml-client` without any command has the effect of calling `learn-ocaml-client grade` (for example, I did not have to change the test-suite, which use the client to grade files).

Note that, except for `create-token`, this PR does not add capabilities to the client. This change open the path to adding more capabilities to the client, since any command can now be added without breaking the others.

I tried to organize the `learnocaml_client.ml` file with modules, one for each command and for each arguments set. Anyway, I wonder if we should split this file: having 800 lines makes it difficult to read, even with modules to organize tings.