### PR TITLE
Add template command

### DIFF
--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -49,7 +49,7 @@ module Args_global = struct
   let token =
     value & opt (some token_conv) None & info ["token";"t"] ~docv:"TOKEN" ~doc:
       "Your token on the learn-ocaml server. This is required when submitting \
-       solutions or interracting whith the server."
+       solutions or interacting with the server."
       ~env:(Term.env_info "LEARNOCAML_TOKEN" ~doc:
               "Sets the learn-ocaml user token on the sever. Overridden by \
                $(b,--token).")


### PR DESCRIPTION
This fixes #259 .

It adds a `template` command to the client, which fetch the template of a given exercise id on the server.