### PR TITLE
Add other modules

### DIFF
--- a/src/grader/dune
+++ b/src/grader/dune
@@ -54,6 +54,8 @@
        %{ocaml-config:standard_library}/camlinternalFormatBasics.cmi
        %{ocaml-config:standard_library}/camlinternalFormat.cmi
        %{ocaml-config:standard_library}/camlinternalLazy.cmi
+       %{ocaml-config:standard_library}/camlinternalMod.cmi
+       %{ocaml-config:standard_library}/camlinternalOO.cmi
        %{ocaml-config:standard_library}/char.cmi
        %{ocaml-config:standard_library}/complex.cmi
        %{ocaml-config:standard_library}/digest.cmi


### PR DESCRIPTION
Hi,

This answer a request by @lsylvestre (made in #260 ).

It makes available to user code two more modules. `json_of_ocaml` does not seems to have problems with them. 