### PR TITLE
Add a facility for grading using a postcondition

### DIFF
--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -1157,26 +1157,9 @@ module Make
       | Error exn -> Error exn
 
 
-  (*----------------------------------------------------------------------------*)
+    (*----------------------------------------------------------------------------*)
 
-    let expect
-          ?(test = test) ?(test_stdout = io_test_ignore) ?(test_stderr = io_test_ignore)
-          ?(pre = (fun _ -> ())) ?(post = (fun _ _ -> [])) ty va vb  =
-      let vb = exec vb in
-      let va = pre () ; exec va in
-      match va, vb with
-      | Ok (va, outa, erra), Ok (vb, outb, errb) ->
-         let post_report = post (va, outa, erra) (vb, outb, errb) in
-         let report = test ty (Ok va) (Ok vb) in
-         let stdout_report = test_stdout outa outb in
-         let stderr_report = test_stderr erra errb in
-         report @ stdout_report @ stderr_report @ post_report
-      | Ok (va, _, _), Error exnb ->
-         test ty (Ok va) (Error exnb)
-      | Error exna, Ok (vb, _, _) ->
-         test ty (Error exna) (Ok vb)
-      | Error exna, Error exnb ->
-         test ty (Error exna) (Error exnb)
+    let flip f y x = f x y
 
     let verify
           ?(test_stdout = fun _ -> []) ?(test_stderr = fun _ -> [])
@@ -1190,6 +1173,21 @@ module Make
          let stderr_report = test_stderr err in
          report @ stdout_report @ stderr_report @ post_report
       | Error exn -> test ty (Error exn)
+
+    let expect
+          ?(test = test) ?(test_stdout = io_test_ignore) ?(test_stderr = io_test_ignore)
+          ?pre ?(post = (fun _ _ -> [])) ty va vb  =
+      match exec vb with
+      | Ok (vb, outb, errb) ->
+         let post = flip post (vb, outb, errb) in
+         let test_stdout = flip test_stdout outb in
+         let test_stderr = flip test_stderr errb in
+         let test ty = flip (test ty) (Ok vb) in
+         verify ?pre
+           ~post ~test_stdout ~test_stderr test ty va
+      | Error exnb ->
+         let test ty va = test ty va (Error exnb) in
+         verify ?pre test ty va
 
     (*----------------------------------------------------------------------------*)
 

--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -1498,7 +1498,7 @@ module Make
   module Test_functions_function = struct
     open Test_functions_generic
 
-    let function_1_adapter sampler ty =
+    let function_1_adapter_pre sampler ty =
       let pre = function
         | None -> (fun _ -> ())
         | Some pre -> (function Last x -> pre x) in
@@ -1509,12 +1509,12 @@ module Make
       let prot = last_ty arg_ty @@ ret_ty in
       pre, sampler, prot
 
-    let function_1_adapter_2 after sampler ty =
+    let function_1_adapter after sampler ty =
       let after = match after with
         | None -> fun _ _ _ -> []
         | Some after -> (function Last x -> after x)
       in
-      let pre, sampler, prot = function_1_adapter sampler ty in
+      let pre, sampler, prot = function_1_adapter_pre sampler ty in
       after, pre, sampler, prot
 
     let test_function_1
@@ -1523,7 +1523,7 @@ module Make
       let tests = List.map (fun (x, r, out, err) ->
           (last x, (fun () -> output_string stdout out ; output_string stderr err ; r)))
                     tests in
-      let after, pre, _, prot = function_1_adapter_2 after None ty in
+      let after, pre, _, prot = function_1_adapter after None ty in
       test_function
         ?test ?test_stdout ?test_stderr
         ~before:(pre before)
@@ -1533,7 +1533,7 @@ module Make
           ?test ?test_stdout ?test_stderr
           ?before_reference ?before_user ?after ?sampler ty name rf tests =
       let tests = List.map (fun x -> last x) tests in
-      let after, pre, sampler, prot = function_1_adapter_2 after sampler ty in
+      let after, pre, sampler, prot = function_1_adapter after sampler ty in
       test_function_against ?gen
         ?test ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1544,7 +1544,7 @@ module Make
           ?test ?test_stdout ?test_stderr
           ?before_reference ?before_user ?after ?sampler ty name tests =
       let tests = List.map (fun x -> last x) tests in
-      let after, pre, sampler, prot = function_1_adapter_2 after sampler ty in
+      let after, pre, sampler, prot = function_1_adapter after sampler ty in
       test_function_against ?gen
         ?test ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1559,7 +1559,7 @@ module Make
         | None -> fun _ _ -> []
         | Some after -> (function Last x -> after x)
       in
-      let pre, sampler, prot = function_1_adapter sampler ty in
+      let pre, sampler, prot = function_1_adapter_pre sampler ty in
       test_function_against_generic_postcond ?gen
         ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1568,7 +1568,7 @@ module Make
 
     (*----------------------------------------------------------------------------*)
 
-    let function_2_adapter sampler ty =
+    let function_2_adapter_pre sampler ty =
       let pre = function
         | None -> (fun _ -> ())
         | Some pre -> (function | Arg (x, Last y) -> pre x y) in
@@ -1581,11 +1581,11 @@ module Make
       let prot = arg_ty arg1_ty @@ last_ty arg2_ty @@ ret_ty in
       pre, sampler, prot
 
-    let function_2_adapter_2 after sampler ty =
+    let function_2_adapter after sampler ty =
       let after = match after with
         | None -> (fun _ _ _ -> [])
         | Some after -> (function | Arg (x, Last y) -> after x y) in
-      let pre, sampler, prot = function_2_adapter sampler ty in
+      let pre, sampler, prot = function_2_adapter_pre sampler ty in
       after, pre, sampler, prot
 
     let test_function_2
@@ -1594,7 +1594,7 @@ module Make
       let tests = List.map (fun (x, y, r, out, err) ->
         (arg x @@ last y, (fun () ->  output_string stdout out ; output_string stderr err ; r)))
         tests in
-      let after, pre, _, prot = function_2_adapter_2 after None ty in
+      let after, pre, _, prot = function_2_adapter after None ty in
       test_function
         ?test ?test_stdout ?test_stderr
         ~before:(pre before)
@@ -1604,7 +1604,7 @@ module Make
           ?test ?test_stdout ?test_stderr
           ?before_reference ?before_user ?after ?sampler ty name rf tests =
       let tests = List.map (fun (x, y) -> arg x @@ last y) tests in
-      let after, pre, sampler, prot = function_2_adapter_2 after sampler ty in
+      let after, pre, sampler, prot = function_2_adapter after sampler ty in
       test_function_against ?gen
         ?test ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1615,7 +1615,7 @@ module Make
           ?test ?test_stdout ?test_stderr
           ?before_reference ?before_user ?after ?sampler ty name tests =
       let tests = List.map (fun (x, y) -> arg x @@ last y) tests in
-      let after, pre, sampler, prot = function_2_adapter_2 after sampler ty in
+      let after, pre, sampler, prot = function_2_adapter after sampler ty in
       test_function_against ?gen
         ?test ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1629,7 +1629,7 @@ module Make
       let after = match after with
         | None -> (fun _ _ -> [])
         | Some after -> (function | Arg (x, Last y) -> after x y) in
-      let pre, sampler, prot = function_2_adapter sampler ty in
+      let pre, sampler, prot = function_2_adapter_pre sampler ty in
       test_function_against_generic_postcond ?gen
         ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1638,7 +1638,7 @@ module Make
 
     (*----------------------------------------------------------------------------*)
 
-    let function_3_adapter sampler ty =
+    let function_3_adapter_pre sampler ty =
       let pre = function
         | None -> (fun _ -> ())
         | Some pre -> (function Arg (w, Arg (x, Last y)) -> pre w x y) in
@@ -1655,20 +1655,20 @@ module Make
       let prot = arg_ty arg1_ty @@ arg_ty arg2_ty @@ last_ty arg3_ty @@ ret_ty in
       pre, sampler, prot
 
-    let function_3_adapter_2 after sampler ty =
+    let function_3_adapter after sampler ty =
       let after = match after with
         | None -> (fun _ _ _-> [])
         | Some after -> (function Arg (w, Arg (x, Last y)) -> after w x y) in
-      let pre, sampler, prot = function_3_adapter sampler ty in
+      let pre, sampler, prot = function_3_adapter_pre sampler ty in
       after, pre, sampler, prot
 
     let test_function_3
           ?test ?test_stdout ?test_stderr
           ?before ?after ty name tests =
       let tests = List.map (fun (w, x, y, r, out, err) ->
-       (arg w @@ arg x @@ last y, (fun () ->  output_string stdout out ; output_string stderr err ; r)))
+       (arg w @@ arg x @@ last y, (fun () -> output_string stdout out ; output_string stderr err ; r)))
        tests in
-      let after, pre, _, prot = function_3_adapter_2 after None ty in
+      let after, pre, _, prot = function_3_adapter after None ty in
       test_function
         ?test ?test_stdout ?test_stderr
         ~before:(pre before)
@@ -1678,7 +1678,7 @@ module Make
           ?test ?test_stdout ?test_stderr
           ?before_reference ?before_user ?after ?sampler ty name rf tests =
       let tests = List.map (fun (w, x, y) -> arg w @@ arg x @@ last y) tests in
-      let after, pre, sampler, prot = function_3_adapter_2 after sampler ty in
+      let after, pre, sampler, prot = function_3_adapter after sampler ty in
       test_function_against ?gen
         ?test ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1689,7 +1689,7 @@ module Make
           ?test ?test_stdout ?test_stderr
           ?before_reference ?before_user ?after ?sampler ty name tests =
       let tests = List.map (fun (w, x, y) -> arg w @@ arg x @@ last y) tests in
-      let after, pre, sampler, prot = function_3_adapter_2 after sampler ty in
+      let after, pre, sampler, prot = function_3_adapter after sampler ty in
       test_function_against ?gen
         ?test ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1703,7 +1703,7 @@ module Make
       let after = match after with
         | None -> (fun _ _ -> [])
         | Some after -> (function Arg (w, Arg (x, Last y)) -> after w x y) in
-      let pre, sampler, prot = function_3_adapter sampler ty in
+      let pre, sampler, prot = function_3_adapter_pre sampler ty in
       test_function_against_generic_postcond ?gen
         ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1712,7 +1712,7 @@ module Make
 
     (*----------------------------------------------------------------------------*)
 
-    let function_4_adapter sampler ty =
+    let function_4_adapter_pre sampler ty =
       let pre = function
         | None -> (fun _ -> ())
         | Some pre ->
@@ -1732,12 +1732,12 @@ module Make
         arg_ty arg1_ty @@ arg_ty arg2_ty @@ arg_ty arg3_ty @@ last_ty arg4_ty @@ ret_ty in
       pre, sampler, prot
 
-    let function_4_adapter_2 after sampler ty =
+    let function_4_adapter after sampler ty =
       let after = match after with
         | None -> (fun _ _ _-> [])
         | Some after ->
            (function Arg (w, Arg (x, Arg (y, Last z))) -> after w x y z) in
-      let pre, sampler, prot = function_4_adapter sampler ty in
+      let pre, sampler, prot = function_4_adapter_pre sampler ty in
       after, pre, sampler, prot
 
     let test_function_4
@@ -1747,7 +1747,7 @@ module Make
        (arg w @@ arg x @@ arg y @@ last z, (fun () ->
         output_string stdout out ; output_string stderr err ; r)))
         tests in
-      let after, pre, _, prot = function_4_adapter_2 after None ty in
+      let after, pre, _, prot = function_4_adapter after None ty in
       test_function
         ?test ?test_stdout ?test_stderr
         ~before:(pre before)
@@ -1757,7 +1757,7 @@ module Make
           ?test ?test_stdout ?test_stderr
           ?before_reference ?before_user ?after ?sampler ty name rf tests =
       let tests = List.map (fun (w, x, y, z) -> arg w @@ arg x @@ arg y @@ last z) tests in
-      let after, pre, sampler, prot = function_4_adapter_2 after sampler ty in
+      let after, pre, sampler, prot = function_4_adapter after sampler ty in
       test_function_against ?gen
         ?test ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1768,7 +1768,7 @@ module Make
           ?test ?test_stdout ?test_stderr
           ?before_reference ?before_user ?after ?sampler ty name tests =
       let tests = List.map (fun (w, x, y, z) -> arg w @@ arg x @@ arg y @@ last z) tests in
-      let after, pre, sampler, prot = function_4_adapter_2 after sampler ty in
+      let after, pre, sampler, prot = function_4_adapter after sampler ty in
       test_function_against ?gen
         ?test ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)
@@ -1783,7 +1783,7 @@ module Make
         | None -> (fun _ _ -> [])
         | Some after ->
            (function Arg (w, Arg (x, Arg (y, Last z))) -> after w x y z) in
-      let pre, sampler, prot = function_4_adapter sampler ty in
+      let pre, sampler, prot = function_4_adapter_pre sampler ty in
       test_function_against_generic_postcond ?gen
         ?test_stdout ?test_stderr
         ~before_reference:(pre before_reference)

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -765,7 +765,18 @@ module type S = sig
                 -> ('c * string * string)
                 -> Learnocaml_report.t) ->
       ?sampler : (unit -> 'a * 'b) ->
-      ('a -> 'b -> 'c) Ty.ty -> string -> ('a * 'b) list -> Learnocaml_report.t
+                 ('a -> 'b -> 'c) Ty.ty -> string -> ('a * 'b) list -> Learnocaml_report.t
+
+    (* TODO *)
+    val test_function_2_against_postcond :
+      ?gen: int ->
+      ?test_stdout: io_postcond ->
+      ?test_stderr: io_postcond ->
+      ?before_reference : ('a -> 'b -> unit) ->
+      ?before_user : ('a -> 'b -> unit) ->
+      ?after : ('a -> 'b -> ('c * string * string) -> Learnocaml_report.t) ->
+      ?sampler : (unit -> 'a * 'b) ->
+      'c postcond -> ('a -> 'b -> 'c) Ty.ty -> string -> ('a * 'b) list -> Learnocaml_report.t
 
     (** {3 Three-arguments functions }*)
 
@@ -854,6 +865,17 @@ module type S = sig
       -> string -> ('a * 'b * 'c) list
       -> Learnocaml_report.t
 
+    (* TODO *)
+    val test_function_3_against_postcond :
+      ?gen: int ->
+      ?test_stdout: io_postcond ->
+      ?test_stderr: io_postcond ->
+      ?before_reference : ('a -> 'b -> 'c -> unit) ->
+      ?before_user : ('a -> 'b -> 'c -> unit) ->
+      ?after : ('a -> 'b -> 'c -> ('d * string * string) -> Learnocaml_report.t) ->
+      ?sampler : (unit -> 'a * 'b * 'c) ->
+      'd postcond -> ('a -> 'b -> 'c -> 'd) Ty.ty -> string -> ('a * 'b * 'c) list -> Learnocaml_report.t
+
     (** {3 Four-arguments functions }*)
 
     (** [test_function_4 ty name tests] tests the function named
@@ -939,6 +961,17 @@ module type S = sig
       ?sampler : (unit -> 'a * 'b * 'c * 'd)
       -> ('a -> 'b -> 'c -> 'd -> 'e) Ty.ty -> string
       -> ('a * 'b * 'c * 'd) list -> Learnocaml_report.t
+
+    (* TODO *)
+    val test_function_4_against_postcond :
+      ?gen: int ->
+      ?test_stdout: io_postcond ->
+      ?test_stderr: io_postcond ->
+      ?before_reference : ('a -> 'b -> 'c -> 'd -> unit) ->
+      ?before_user : ('a -> 'b -> 'c -> 'd -> unit) ->
+      ?after : ('a -> 'b -> 'c -> 'd -> ('e * string * string) -> Learnocaml_report.t) ->
+      ?sampler : (unit -> 'a * 'b * 'c * 'd) ->
+      'e postcond -> ('a -> 'b -> 'c -> 'd -> 'e) Ty.ty -> string -> ('a * 'b * 'c * 'd) list -> Learnocaml_report.t
 
     (** {2:optional_arguments_sec Optional arguments for grading functions} *)
 

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -227,11 +227,6 @@ module type S = sig
   type 'a tester =
     'a Ty.ty -> 'a result -> 'a result -> Learnocaml_report.t
 
-  (** Functions of type [postcond] are used to verify that student result
-     satisfies a postcondition. *)
-  type 'a postcond =
-    'a Ty.ty -> 'a result -> Learnocaml_report.t
-
   (** Functions of type [io_tester] are used to compare student
      standard out or standard error channels with solution ones. *)
   type io_tester =
@@ -687,7 +682,8 @@ module type S = sig
       ?before_user : ('a -> unit) ->
       ?after : ('a -> ('b * string * string) -> Learnocaml_report.t) ->
       ?sampler : (unit -> 'a) ->
-      'b postcond -> ('a -> 'b) Ty.ty -> string -> 'a list -> Learnocaml_report.t
+      ('a -> 'b Ty.ty -> 'b result -> Learnocaml_report.t) ->
+      ('a -> 'b) Ty.ty -> string -> 'a list -> Learnocaml_report.t
 
     (** {3 Binary functions }*)
 
@@ -786,7 +782,8 @@ module type S = sig
       ?before_user : ('a -> 'b -> unit) ->
       ?after : ('a -> 'b -> ('c * string * string) -> Learnocaml_report.t) ->
       ?sampler : (unit -> 'a * 'b) ->
-      'c postcond -> ('a -> 'b -> 'c) Ty.ty -> string -> ('a * 'b) list -> Learnocaml_report.t
+      ('a -> 'b -> 'c Ty.ty -> 'c result -> Learnocaml_report.t) ->
+      ('a -> 'b -> 'c) Ty.ty -> string -> ('a * 'b) list -> Learnocaml_report.t
 
     (** {3 Three-arguments functions }*)
 
@@ -888,7 +885,8 @@ module type S = sig
       ?before_user : ('a -> 'b -> 'c -> unit) ->
       ?after : ('a -> 'b -> 'c -> ('d * string * string) -> Learnocaml_report.t) ->
       ?sampler : (unit -> 'a * 'b * 'c) ->
-      'd postcond -> ('a -> 'b -> 'c -> 'd) Ty.ty -> string -> ('a * 'b * 'c) list -> Learnocaml_report.t
+      ('a -> 'b -> 'c -> 'd Ty.ty -> 'd result -> Learnocaml_report.t) ->
+      ('a -> 'b -> 'c -> 'd) Ty.ty -> string -> ('a * 'b * 'c) list -> Learnocaml_report.t
 
     (** {3 Four-arguments functions }*)
 
@@ -989,7 +987,8 @@ module type S = sig
       ?before_user : ('a -> 'b -> 'c -> 'd -> unit) ->
       ?after : ('a -> 'b -> 'c -> 'd -> ('e * string * string) -> Learnocaml_report.t) ->
       ?sampler : (unit -> 'a * 'b * 'c * 'd) ->
-      'e postcond -> ('a -> 'b -> 'c -> 'd -> 'e) Ty.ty -> string -> ('a * 'b * 'c * 'd) list -> Learnocaml_report.t
+      ('a -> 'b -> 'c -> 'd -> 'e Ty.ty -> 'e result -> Learnocaml_report.t) ->
+      ('a -> 'b -> 'c -> 'd -> 'e) Ty.ty -> string -> ('a * 'b * 'c * 'd) list -> Learnocaml_report.t
 
     (** {2:optional_arguments_sec Optional arguments for grading functions} *)
 

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -223,11 +223,12 @@ module type S = sig
 
   (** Functions of type [tester] are used to compare student result
      with solution result. The first {!S.result} is the student
-     output and the second one is the solution output.  *)
+     output and the second one is the solution output. *)
   type 'a tester =
     'a Ty.ty -> 'a result -> 'a result -> Learnocaml_report.t
 
-  (* TODO *)
+  (** Functions of type [postcond] are used to verify that student result
+     satisfies a postcondition. *)
   type 'a postcond =
     'a Ty.ty -> 'a result -> Learnocaml_report.t
 
@@ -236,7 +237,8 @@ module type S = sig
   type io_tester =
     string -> string -> Learnocaml_report.t
 
-  (* TODO *)
+  (** Functions of type [io_postcond] are used to verify that student
+     standard out or standard error channels satisfy a postcondition. *)
   type io_postcond =
     string -> Learnocaml_report.t
 
@@ -672,7 +674,11 @@ module type S = sig
       ?sampler : (unit -> 'a) ->
       ('a -> 'b) Ty.ty -> string -> 'a list -> Learnocaml_report.t
 
-    (* TODO *)
+    (** [test_function_1_against_postcond postcond ty name tests] tests that
+       the function named [name] statisfies the postcondition [postcond].
+
+     See {{!optional_arguments_sec} this section} for information
+       about optional arguments. *)
     val test_function_1_against_postcond :
       ?gen: int ->
       ?test_stdout: io_postcond ->
@@ -767,7 +773,11 @@ module type S = sig
       ?sampler : (unit -> 'a * 'b) ->
                  ('a -> 'b -> 'c) Ty.ty -> string -> ('a * 'b) list -> Learnocaml_report.t
 
-    (* TODO *)
+    (** [test_function_2_against_postcond postcond ty name tests] tests that
+       the function named [name] statisfies the postcondition [postcond].
+
+     See {{!optional_arguments_sec} this section} for information
+       about optional arguments. *)
     val test_function_2_against_postcond :
       ?gen: int ->
       ?test_stdout: io_postcond ->
@@ -865,7 +875,11 @@ module type S = sig
       -> string -> ('a * 'b * 'c) list
       -> Learnocaml_report.t
 
-    (* TODO *)
+    (** [test_function_3_against_postcond postcond ty name tests] tests that
+       the function named [name] statisfies the postcondition [postcond].
+
+     See {{!optional_arguments_sec} this section} for information
+       about optional arguments. *)
     val test_function_3_against_postcond :
       ?gen: int ->
       ?test_stdout: io_postcond ->
@@ -962,7 +976,11 @@ module type S = sig
       -> ('a -> 'b -> 'c -> 'd -> 'e) Ty.ty -> string
       -> ('a * 'b * 'c * 'd) list -> Learnocaml_report.t
 
-    (* TODO *)
+    (** [test_function_4_against_postcond postcond ty name tests] tests that
+       the function named [name] statisfies the postcondition [postcond].
+
+     See {{!optional_arguments_sec} this section} for information
+       about optional arguments. *)
     val test_function_4_against_postcond :
       ?gen: int ->
       ?test_stdout: io_postcond ->

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -670,7 +670,7 @@ module type S = sig
       ('a -> 'b) Ty.ty -> string -> 'a list -> Learnocaml_report.t
 
     (** [test_function_1_against_postcond postcond ty name tests] tests that
-       the function named [name] statisfies the postcondition [postcond].
+       the function named [name] satisfies the postcondition [postcond].
 
      See {{!optional_arguments_sec} this section} for information
        about optional arguments. *)
@@ -770,7 +770,7 @@ module type S = sig
                  ('a -> 'b -> 'c) Ty.ty -> string -> ('a * 'b) list -> Learnocaml_report.t
 
     (** [test_function_2_against_postcond postcond ty name tests] tests that
-       the function named [name] statisfies the postcondition [postcond].
+       the function named [name] satisfies the postcondition [postcond].
 
      See {{!optional_arguments_sec} this section} for information
        about optional arguments. *)
@@ -873,7 +873,7 @@ module type S = sig
       -> Learnocaml_report.t
 
     (** [test_function_3_against_postcond postcond ty name tests] tests that
-       the function named [name] statisfies the postcondition [postcond].
+       the function named [name] satisfies the postcondition [postcond].
 
      See {{!optional_arguments_sec} this section} for information
        about optional arguments. *)
@@ -975,7 +975,7 @@ module type S = sig
       -> ('a * 'b * 'c * 'd) list -> Learnocaml_report.t
 
     (** [test_function_4_against_postcond postcond ty name tests] tests that
-       the function named [name] statisfies the postcondition [postcond].
+       the function named [name] satisfies the postcondition [postcond].
 
      See {{!optional_arguments_sec} this section} for information
        about optional arguments. *)

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -227,10 +227,18 @@ module type S = sig
   type 'a tester =
     'a Ty.ty -> 'a result -> 'a result -> Learnocaml_report.t
 
+  (* TODO *)
+  type 'a postcond =
+    'a Ty.ty -> 'a result -> Learnocaml_report.t
+
   (** Functions of type [io_tester] are used to compare student
      standard out or standard error channels with solution ones. *)
   type io_tester =
     string -> string -> Learnocaml_report.t
+
+  (* TODO *)
+  type io_postcond =
+    string -> Learnocaml_report.t
 
   (** The exception [Timeout limit] is raised by [run_timeout]. Thus, the
       functions [exec] and [result] can return [Error (Timeout limit)].
@@ -663,6 +671,17 @@ module type S = sig
                 -> Learnocaml_report.t) ->
       ?sampler : (unit -> 'a) ->
       ('a -> 'b) Ty.ty -> string -> 'a list -> Learnocaml_report.t
+
+    (* TODO *)
+    val test_function_1_against_postcond :
+      ?gen: int ->
+      ?test_stdout: io_postcond ->
+      ?test_stderr: io_postcond ->
+      ?before_reference : ('a -> unit) ->
+      ?before_user : ('a -> unit) ->
+      ?after : ('a -> ('b * string * string) -> Learnocaml_report.t) ->
+      ?sampler : (unit -> 'a) ->
+      'b postcond -> ('a -> 'b) Ty.ty -> string -> 'a list -> Learnocaml_report.t
 
     (** {3 Binary functions }*)
 


### PR DESCRIPTION
Hi,

This fixes #223 .

It adds `test_function_X_against_postcond` functions, which are taking in particular an argument of type `'a Ty.ty -> 'a result -> Learnocaml_report.t`, that is, a function that is capable to produce a report from the student code output.

Maybe something of type `'a Ty.ty -> 'a result -> bool` will be more user friendly, but it is difficult to control how many point you give.