### PR TITLE
Fix CI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ lessons and tutorials.
 
 A demo is available at: [http://learn-ocaml.hackojo.org/].
 
-![Build status logo](https://travis-ci.org/ocaml-sf/learn-ocaml.svg)
+[![Build Status](https://travis-ci.org/ocaml-sf/learn-ocaml.svg?branch=master)](https://travis-ci.org/ocaml-sf/learn-ocaml)
 
 Howtos
 ------

--- a/src/utils/learnocaml_partition_create.ml
+++ b/src/utils/learnocaml_partition_create.ml
@@ -50,7 +50,7 @@ let partition_by_grade funname =
   let rec get_relative_section = function
     | [] -> []
     | (Message _)::xs -> get_relative_section xs
-    | (Section (t,res))::xs ->
+    | (Section (t,res))::xs | (SectionMin (t,res, _))::xs ->
        match t with
        | Text _::Code  fn::_ ->
           if fn = funname
@@ -62,6 +62,7 @@ let partition_by_grade funname =
     let aux acc =
       function
       | Section (_,s) -> get_grade s
+      | SectionMin (_, s, min) -> max (get_grade s) min
       | Message (_,s) ->
          match s with
          | Success i -> acc + i


### PR DESCRIPTION
Dear @yurug, it seems current master [didn't build anymore](https://travis-ci.org/ocaml-sf/learn-ocaml) because combining #292 and #287 led to some non exhaustive pattern-matching.

This small PR solves this (please review whether my fix is reasonable). It also updates the Travis CI markdown badge to make it "clickable".