### PR TITLE
support for test code reuse

### DIFF
--- a/docs/howto-write-exercises.md
+++ b/docs/howto-write-exercises.md
@@ -32,15 +32,15 @@ to get the files for step 1, and replace `step-1` by `step-2` to
 get the files for the second step, and so on and so forth.
 
 ## The tutorials
-[Step 0 : Preliminaries](../tutorials/step-0)
+[Step 0 : Preliminaries](tutorials/step-0.md)
 	
 - Structure of an exercise
 	
 - Purpose of each file
 	
-[Step 1: Create a trivial exercise](../tutorials/step-1)
+[Step 1: Create a trivial exercise](tutorials/step-1.md)
       
-[Step 2: Basic grading by comparison with your solution](../tutorials/step-2)
+[Step 2: Basic grading by comparison with your solution](tutorials/step-2.md)
 
 - Simple example to grade by comparison with a solution
 
@@ -48,21 +48,26 @@ get the files for the second step, and so on and so forth.
 
 - With multiple arguments functions
 
-[Step 3: Grading with generators for Ocaml built-in types](../tutorials/step-3)
+[Step 3: Grading with generators for Ocaml built-in types](tutorials/step-3.md)
 
 - Generate tests by using the pre-construct samplers 
 
 - Generate tests by defining its own sampler 
 
-[Step 4: Grading with generators for user-defined types](../tutorials/step-4)
+[Step 4: Grading with generators for user-defined types](tutorials/step-4.md)
 
 - Generate tests for non-parametric user-defined types 
 	
 - Generate tests for parametric user-defined types 
 
-[Step 5 : More test functions](../tutorials/step-5)
+[Step 5 : More test functions](tutorials/step-5.md)
 	
-[Step 6 : Grading functions for variables](../tutorials/step-6)
-	
-[Step 7 : Introspection of students code](../tutorials/step-7)
+[Step 6 : Grading functions for variables](tutorials/step-6.md)
     
+[Step 7 : Modifying the comparison functions (testers) with the optional arguments [~test], [~test_stdout], [~test_stderr]](tutorials/step-7.md)
+
+[Step 8 : Reusing the grader code](tutorials/step-8.md)
+
+- Separating the grader code
+
+[Step 9 : Introspection of students code](tutorials/step-9.md)    

--- a/docs/tutorials/step-8.md
+++ b/docs/tutorials/step-8.md
@@ -46,7 +46,7 @@ Let's write an exercise dedicated to *Peano numbers*. Here is the structure of t
 │   │   ├── depend.txt
 │   │   │ ...
 ```
-The exercise **peano** follows the classical format : **prelude.ml**, **prepare.ml**, **solution.ml**, **template.ml** and **test.ml**. It comprises moreover several dependencies (**check.ml**, **samples.ml**, **add.ml** and **odd_even.ml**) which are declared as follow in **depend.txt**:
+The exercise **peano** follows the classical format : **prelude.ml**, **prepare.ml**, **solution.ml**, **template.ml** and **test.ml**. It also includes several dependencies (**check.ml**, **samples.ml**, **add.ml** and **odd_even.ml**) which are declared as follows in **depend.txt**:
 
 ```txt
 ../lib/check.mli
@@ -164,6 +164,5 @@ module Odd_even : sig val test : unit -> Report.t end
 ```
 
 In the end, this feature can provide an increased comfort for writing large automated graders and for reusing them in other exercises.
-
 
 

--- a/docs/tutorials/step-8.md
+++ b/docs/tutorials/step-8.md
@@ -16,7 +16,7 @@ Each declaration in **depend.txt** is a single line containing the relative path
 
 By default each dependency *foo.ml* is isolated in a module *Foo*, which can be constrained by the content of an optional signature file *foo.mli*. Furthermore, we can add an annotation `@included` at the beginning of a file *foo.ml* to denote that all the bindings of *foo.ml* are evaluated in the toplevel environment (and not in a module *Foo*). 
 
-Note that when you edited an *.ml* or *.mli* dependency file which is not defined at the root of your exercice directory, the change will not be applied. In this case a simple shell command `$ touch test.ml` refresh the exercise.
+Dependencies that are not defined at the root of the exercise repository are ignored by the build system: therefore, if you modify them, do not forget to refresh the timestamp of `test.ml` (using `touch` for instance).
 
 ### A complete example
 
@@ -164,7 +164,6 @@ module Odd_even : sig val test : unit -> Report.t end
 ```
 
 In the end, this feature can provide an increased comfort for writing large automated graders and for reusing them in other exercises.
-
 
 
 

--- a/docs/tutorials/step-8.md
+++ b/docs/tutorials/step-8.md
@@ -14,7 +14,7 @@ It is possible to extend this environment by declaring some other user-defined m
 
 Each declaration in **depend.txt** is a single line containing the relative path of an *.ml* or *.mli* file. The order of the *.ml* declarations specifies the order in which each module is loaded in the grading environment.
 
-By default each dependency *foo.ml* is isolated in a module *Foo*, which can be constrained by the content of an optional signature file *foo.mli*. Furthermore, we can add an annotation `@included` at the beginning of a file *foo.ml* to denote that all the bindings of *foo.ml* are evaluated in the toplevel environment (and not in a module *Foo*). 
+By default each dependency *foo.ml* is isolated in a module *Foo*, which can be constrained by the content of an optional signature file *foo.mli*. Furthermore, we can add an annotation `[@@@included]` at the beginning of a file *foo.ml* to denote that all the bindings of *foo.ml* are evaluated in the toplevel environment (and not in a module *Foo*). 
 
 Dependencies that are not defined at the root of the exercise repository are ignored by the build system: therefore, if you modify them, do not forget to refresh the timestamp of `test.ml` (using `touch` for instance).
 
@@ -39,7 +39,7 @@ Let's write an exercise dedicated to *Peano numbers*. Here is the structure of t
 │   │   ├── template.ml
 │   │   ├── test.ml
 │   │   └── tests
-│   │   │   ├── samples.ml
+│   │       ├── samples.ml
 │   │       ├── add.ml
 │   │       └── odd_even.ml
 │   ├── an-other-exercise
@@ -126,10 +126,10 @@ let test () =
     [%ty : peano -> bool ] "even"
     [ Z ; S(Z) ; S(S(Z)) ]
 ```
-Remember that **Test_lib** internally requires a user-defined sampler `sample_peano : unit -> peano` to generate value of type `peano`. This sampler has to be present in the toplevel environment -- and not in a module -- in order to be found by the introspection primitives during grading. Therefore, we define this sampler in a file starting with the annotation `@included`.
-- **samples.ml**:
+Remember that **Test_lib** internally requires a user-defined sampler `sample_peano : unit -> peano` to generate value of type `peano`. This sampler has to be present in the toplevel environment -- and not in a module -- in order to be found by the introspection primitives during grading. Therefore, we define this sampler in a file starting with the annotation `[@@@included]`.
+- **tests/samples.ml**:
 ```ocaml
-@included
+[@@@included]
 
 let sample_peano () =
   let rec aux = function
@@ -138,7 +138,7 @@ let sample_peano () =
   in aux (Random.int 42)
 ```
 
-Finally, **test.ml** will be evaluated in the following environment:
+Finally, the content of **test.ml** will be evaluated in the following environment:
 
 ```ocaml
 val print_html : 'a -> 'b

--- a/docs/tutorials/step-8.md
+++ b/docs/tutorials/step-8.md
@@ -1,8 +1,10 @@
 # Step 8: Reusing the grader code
 
-This step explains how to separate the grader code, and eventually reuse it in other exercises. 
+This step explains how to separate the grader code, and eventually reuse it in
+other exercises. 
 
-During the grading, the file **test.ml** is evaluated in an environment that contains notably: 
+During the grading, the file **test.ml** is evaluated in an environment that
+contains notably: 
 - **prelude.ml** and **prepare.ml** ;
 - the student code isolated in a module `Code` ;
 - **solution.ml** in a module `Solution` ;
@@ -10,17 +12,27 @@ During the grading, the file **test.ml** is evaluated in an environment that con
 
 ### Separating the grader code
 
-It is possible to extend this environment by declaring some other user-defined modules in an optional file **depend.txt**, located in the exercise directory.
+It is possible to extend this environment by declaring some other user-defined
+modules in an optional file **depend.txt**, located in the exercise directory.
 
-Each declaration in **depend.txt** is a single line containing the relative path of an *.ml* or *.mli* file. The order of the *.ml* declarations specifies the order in which each module is loaded in the grading environment.
+Each declaration in **depend.txt** is a single line containing the relative path
+of an *.ml* or *.mli* file. The order of the *.ml* declarations specifies the
+order in which each module is loaded in the grading environment.
 
-By default each dependency *foo.ml* is isolated in a module *Foo*, which can be constrained by the content of an optional signature file *foo.mli*. Furthermore, we can add an annotation `[@@@included]` at the beginning of a file *foo.ml* to denote that all the bindings of *foo.ml* are evaluated in the toplevel environment (and not in a module *Foo*). 
+By default each dependency *foo.ml* is isolated in a module *Foo*, which can be
+constrained by the content of an optional signature file *foo.mli*. Furthermore,
+an annotation `[@@@included]` can be used at the beginning of a file *foo.ml* to
+denote that all the bindings of *foo.ml* are evaluated in the toplevel
+environment (and not in a module *Foo*). 
 
-Dependencies that are not defined at the root of the exercise repository are ignored by the build system: therefore, if you modify them, do not forget to refresh the timestamp of `test.ml` (using `touch` for instance).
+Dependencies that are not defined at the root of the exercise repository are
+ignored by the build system: therefore, if you modify them, do not forget to
+refresh the timestamp of `test.ml` (using `touch` for instance).
 
 ### A complete example
 
-Let's write an exercise dedicated to *Peano numbers*. Here is the structure of the exercise:
+Let's write an exercise dedicated to *Peano numbers*. Here is the structure of
+the exercise:
 
 ```
 .
@@ -46,7 +58,10 @@ Let's write an exercise dedicated to *Peano numbers*. Here is the structure of t
 │   │   ├── depend.txt
 │   │   │ ...
 ```
-The exercise **peano** follows the classical format : **prelude.ml**, **prepare.ml**, **solution.ml**, **template.ml** and **test.ml**. It also includes several dependencies (**check.ml**, **samples.ml**, **add.ml** and **odd_even.ml**) which are declared as follows in **depend.txt**:
+The exercise **peano** follows the classical format : **prelude.ml**,
+**prepare.ml**, **solution.ml**, **template.ml** and **test.ml**.
+It also includes several dependencies (**check.ml**, **samples.ml**, **add.ml**
+and **odd_even.ml**) which are declared as follows in **depend.txt**:
 
 ```txt
 ../lib/check.mli
@@ -86,10 +101,11 @@ and even = function
 - **test.ml**
 ```ocaml
 let () =
-  Check.safe_set_result [ Add.test ; Odd_even.test ]
+Check.safe_set_result [ Add.test ; Odd_even.test ]
 ```
 
-Note that **test.ml** is very compact because it simply combines functions defined in separated files.
+Note that **test.ml** is very compact because it simply combines functions
+defined in separated files.
 
 - **../lib/check.ml**:
 ```ocaml
@@ -97,11 +113,11 @@ open Test_lib
 open Report
 
 let safe_set_result tests =
-  set_result @@
-  ast_sanity_check code_ast @@ fun () ->
-    List.mapi (fun i test -> 
-                Section ([ Text ("Question " ^ string_of_int i ^ ":") ],
-                         test ())) tests
+set_result @@
+ast_sanity_check code_ast @@ fun () ->
+List.mapi (fun i test -> 
+Section ([ Text ("Question " ^ string_of_int i ^ ":") ],
+test ())) tests
 ```
 - **../lib/check.mli**:
 ```ocaml
@@ -111,50 +127,55 @@ val safe_set_result : (unit -> Report.t) list -> unit
 - **tests/add.ml**: 
 ```ocaml
 let test () =
-  Test_lib.test_function_2_against_solution
-    [%ty : peano -> peano -> peano ] "add"
-    [ (Z, Z) ; (S(Z), S(S(Z))) ]
+Test_lib.test_function_2_against_solution
+[%ty : peano -> peano -> peano ] "add"
+[ (Z, Z) ; (S(Z), S(S(Z))) ]
 ```
 - **tests/odd_even.ml** :
 ```ocaml
 let test () =
-  Test_lib.test_function_1_against_solution
-    [%ty : peano -> bool ] "odd"
-    [ Z ; S(Z) ; S(S(Z)) ] 
-  @
-  Test_lib.test_function_1_against_solution
-    [%ty : peano -> bool ] "even"
-    [ Z ; S(Z) ; S(S(Z)) ]
+Test_lib.test_function_1_against_solution
+[%ty : peano -> bool ] "odd"
+[ Z ; S(Z) ; S(S(Z)) ] 
+@
+Test_lib.test_function_1_against_solution
+[%ty : peano -> bool ] "even"
+[ Z ; S(Z) ; S(S(Z)) ]
 ```
-Remember that **Test_lib** internally requires a user-defined sampler `sample_peano : unit -> peano` to generate value of type `peano`. This sampler has to be present in the toplevel environment -- and not in a module -- in order to be found by the introspection primitives during grading. Therefore, we define this sampler in a file starting with the annotation `[@@@included]`.
+Remember that **Test_lib** internally requires a user-defined sampler
+`sample_peano : unit -> peano` to generate value of type `peano`. This sampler
+has to be present in the toplevel environment -- and not in a module -- in order
+to be found by the introspection primitives during grading. Therefore,
+we define this sampler in a file starting with the annotation `[@@@included]`.
 - **tests/samples.ml**:
 ```ocaml
 [@@@included]
 
 let sample_peano () =
-  let rec aux = function
-  | 0 -> Z
-  | n -> S (aux (n-1)) 
-  in aux (Random.int 42)
+let rec aux = function
+| 0 -> Z
+| n -> S (aux (n-1)) 
+in aux (Random.int 42)
 ```
 
-Finally, the content of **test.ml** will be evaluated in the following environment:
+Finally, the content of **test.ml** will be evaluated in the following
+environment:
 
 ```ocaml
 val print_html : 'a -> 'b
 type peano = Z | S of peano
 module Code :
-  sig
-    val add : peano -> peano -> peano
-    val odd : peano -> bool
-    val even : peano -> bool
-  end
+sig
+val add : peano -> peano -> peano
+val odd : peano -> bool
+val even : peano -> bool
+end
 module Solution :
-  sig
-    val add : peano -> peano -> peano
-    val odd : peano -> bool
-    val even : peano -> bool
-  end
+sig
+val add : peano -> peano -> peano
+val odd : peano -> bool
+val even : peano -> bool
+end
 module Test_lib : Test_lib.S
 module Report = Learnocaml_report
 module Check : sig val check_all : (unit -> Report.t) list -> unit end
@@ -163,6 +184,7 @@ module Add : sig val test : unit -> Report.t end
 module Odd_even : sig val test : unit -> Report.t end
 ```
 
-In the end, this feature can provide an increased comfort for writing large automated graders and for reusing them in other exercises.
+In the end, this feature can provide an increased comfort for writing large a
+utomated graders and for reusing them in other exercises.
 
 

--- a/docs/tutorials/step-8.md
+++ b/docs/tutorials/step-8.md
@@ -1,0 +1,172 @@
+# Step 8: Reusing the grader code
+
+This step explains how to separate the grader code, and eventually reuse it in other exercises. 
+
+During the grading, the file **test.ml** is evaluated in an environment that contains notably: 
+- **prelude.ml** and **prepare.ml** ;
+- the student code isolated in a module `Code` ;
+- **solution.ml** in a module `Solution` ;
+- the grading modules **Introspection**, **Report** and **Test_lib**.
+
+### Separating the grader code
+
+It is possible to extend this environment by declaring some other user-defined modules in an optional file **depend.txt**, located in the exercise directory.
+
+Each declaration in **depend.txt** is a single line containing the relative path of an *.ml* or *.mli* file. The order of the *.ml* declarations specifies the order in which each module is loaded in the grading environment.
+
+By default each dependency *foo.ml* is isolated in a module *Foo*, which can be constrained by the content of an optional signature file *foo.mli*. Furthermore, we can add an annotation `@included` at the beginning of a file *foo.ml* to denote that all the bindings of *foo.ml* is are evaluated in the toplevel environment (and not in a module *Foo*). 
+
+Note that when you edited an *.ml* or *.mli* dependency file which is not defined at the root of your exercice directory, the change will not be applied. In this case a simple shell command `$ touch test.ml` refresh the exercise.
+
+### A complete example
+
+Let's write an exercise dedicated to *Peano numbers*. Here is the structure of the exercise:
+
+```
+.
+├── exercises
+│   ├── index.json
+│   └── lib
+│   │   ├── check.ml
+│   │   └── check.mli
+│   ├── peano
+│   │   ├── depend.txt
+│   │   ├── descr.md
+│   │   ├── meta.json
+│   │   ├── prelude.ml
+│   │   ├── prepare.ml
+│   │   ├── solution.ml
+│   │   ├── template.ml
+│   │   ├── test.ml
+│   │   └── tests
+│   │   │   ├── samples.ml
+│   │       ├── add.ml
+│   │       └── odd_even.ml
+│   ├── an-other-exercise
+│   │   ├── depend.txt
+│   │   │ ...
+```
+The exercise **peano** follows the classical format : **prelude.ml**, **prepare.ml**, **solution.ml**, **template.ml** and **test.ml**. It comprises moreover several dependencies (**check.ml**, **samples.ml**, **add.ml** and **odd_even.ml**) which are declared as follow in **depend.txt**:
+
+```txt
+../lib/check.mli
+../lib/check.ml    # a comment
+
+tests/samples.ml
+tests/add.ml
+tests/odd_even.ml
+``` 
+
+Here is in details the source code of the exercise :
+
+- **descr.md**
+
+> * implement the function `add : peano -> peano -> peano` ; 
+> * implement the functions `odd : peano -> bool` and `even : peano -> bool`.
+
+- **prelude.ml**
+```ocaml
+type peano = Z | S of peano
+```
+
+- **solution.ml**
+```ocaml
+let rec add n = function
+| Z -> n
+| S m -> S (add n m)
+
+let rec odd = function
+| Z -> false 
+| S n -> even n
+and even = function
+| Z -> true
+| S n -> odd n
+```
+
+- **test.ml**
+```ocaml
+let () =
+  Check.safe_set_result [ Add.test ; Odd_even.test ]
+```
+
+Note that **test.ml** is very compact because it simply combines functions defined in separated files.
+
+- **../lib/check.ml**:
+```ocaml
+open Test_lib
+open Report
+
+let safe_set_result tests =
+  set_result @@
+  ast_sanity_check code_ast @@ fun () ->
+    List.mapi (fun i test -> 
+                Section ([ Text ("Question " ^ string_of_int i ^ ":") ],
+                         test ())) tests
+```
+- **../lib/check.mli**:
+```ocaml
+val safe_set_result : (unit -> Report.t) list -> unit
+```
+
+- **tests/add.ml**: 
+```ocaml
+let test () =
+  Test_lib.test_function_2_against_solution
+    [%ty : peano -> peano -> peano ] "add"
+    [ (Z, Z) ; (S(Z), S(S(Z))) ]
+```
+- **tests/odd_even.ml** :
+```ocaml
+let test () =
+  Test_lib.test_function_1_against_solution
+    [%ty : peano -> bool ] "odd"
+    [ Z ; S(Z) ; S(S(Z)) ] 
+  @
+  Test_lib.test_function_1_against_solution
+    [%ty : peano -> bool ] "even"
+    [ Z ; S(Z) ; S(S(Z)) ]
+```
+Remember that **Test_lib** internally requires a user-defined sampler `sample_peano : unit -> peano` to generate value of type `peano`. This sampler has to be present in the toplevel environment -- and not in a module -- in order to be found by the introspection primitives during grading. Therefore, we define this sampler in a file starting by the annotation `@included`.
+- **samples.ml**:
+```ocaml
+@included
+
+let sample_peano () =
+  let rec aux = function
+  | 0 -> Z
+  | n -> S (aux (n-1)) 
+  in aux (Random.int 42)
+```
+
+Finally, **test.ml** will be evaluated in the following environment:
+
+```ocaml
+val print_html : 'a -> 'b
+type peano = Z | S of peano
+module Code :
+  sig
+    val add : peano -> peano -> peano
+    val odd : peano -> bool
+    val even : peano -> bool
+  end
+module Solution :
+  sig
+    val add : peano -> peano -> peano
+    val odd : peano -> bool
+    val even : peano -> bool
+  end
+module Test_lib : Test_lib.S
+module Report = Learnocaml_report
+module Check : sig val check_all : (unit -> Report.t) list -> unit end
+val sample_peano : unit -> peano
+module Add : sig val test : unit -> Report.t end
+module Odd_even : sig val test : unit -> Report.t end
+```
+
+In the end, this feature can provide an increased comfort for writing large automated graders and for reusing them in other exercises.
+
+
+
+
+
+

--- a/docs/tutorials/step-8.md
+++ b/docs/tutorials/step-8.md
@@ -14,7 +14,7 @@ It is possible to extend this environment by declaring some other user-defined m
 
 Each declaration in **depend.txt** is a single line containing the relative path of an *.ml* or *.mli* file. The order of the *.ml* declarations specifies the order in which each module is loaded in the grading environment.
 
-By default each dependency *foo.ml* is isolated in a module *Foo*, which can be constrained by the content of an optional signature file *foo.mli*. Furthermore, we can add an annotation `@included` at the beginning of a file *foo.ml* to denote that all the bindings of *foo.ml* is are evaluated in the toplevel environment (and not in a module *Foo*). 
+By default each dependency *foo.ml* is isolated in a module *Foo*, which can be constrained by the content of an optional signature file *foo.mli*. Furthermore, we can add an annotation `@included` at the beginning of a file *foo.ml* to denote that all the bindings of *foo.ml* are evaluated in the toplevel environment (and not in a module *Foo*). 
 
 Note that when you edited an *.ml* or *.mli* dependency file which is not defined at the root of your exercice directory, the change will not be applied. In this case a simple shell command `$ touch test.ml` refresh the exercise.
 
@@ -164,7 +164,6 @@ module Odd_even : sig val test : unit -> Report.t end
 ```
 
 In the end, this feature can provide an increased comfort for writing large automated graders and for reusing them in other exercises.
-
 
 
 

--- a/docs/tutorials/step-8.md
+++ b/docs/tutorials/step-8.md
@@ -126,7 +126,7 @@ let test () =
     [%ty : peano -> bool ] "even"
     [ Z ; S(Z) ; S(S(Z)) ]
 ```
-Remember that **Test_lib** internally requires a user-defined sampler `sample_peano : unit -> peano` to generate value of type `peano`. This sampler has to be present in the toplevel environment -- and not in a module -- in order to be found by the introspection primitives during grading. Therefore, we define this sampler in a file starting by the annotation `@included`.
+Remember that **Test_lib** internally requires a user-defined sampler `sample_peano : unit -> peano` to generate value of type `peano`. This sampler has to be present in the toplevel environment -- and not in a module -- in order to be found by the introspection primitives during grading. Therefore, we define this sampler in a file starting with the annotation `@included`.
 - **samples.ml**:
 ```ocaml
 @included
@@ -164,7 +164,6 @@ module Odd_even : sig val test : unit -> Report.t end
 ```
 
 In the end, this feature can provide an increased comfort for writing large automated graders and for reusing them in other exercises.
-
 
 
 

--- a/src/grader/grading.ml
+++ b/src/grader/grading.ml
@@ -156,15 +156,33 @@ let get_grade
           match Filename.extension path with
           | ".mli" -> load_dependencies ((modname,content) :: signatures) fs
           | ".ml" -> 
+            let included,content = 
+              (* the first line of an .ml file can contain an annotation     *)
+              (* @included which denotes that this file has to be included   *)
+              (* directly in the toplevel environment, and not in an module. *)
+              match String.index_opt content '\n' with
+              | None -> (false,content)
+              | Some i -> 
+                (match String.trim (String.sub content 0 i) with 
+                 | "@included" -> 
+                    let content' = String.sub content i @@ 
+                                   (String.length content - i)
+                    in (true,content')
+                 | _ -> (false,content))
+            in
             (handle_error (internal_error [%i"while loading user dependencies"]) @@
-             let use_mod = 
-               Toploop_ext.use_mod_string ~print_outcome ~ppf_answer ~modname in
-             match List.assoc_opt modname signatures with 
-             | Some sig_code -> use_mod ~sig_code content
-             | None -> use_mod content); 
-             load_dependencies signatures fs
+             match included with
+             | true -> Toploop_ext.use_string ~print_outcome ~ppf_answer 
+                                  ~filename:(Filename.basename path) content 
+             | false ->
+               let use_mod = 
+                 Toploop_ext.use_mod_string ~print_outcome ~ppf_answer ~modname in
+               match List.assoc_opt modname signatures with 
+               | Some sig_code -> use_mod ~sig_code content
+               | None -> use_mod content); 
+               load_dependencies signatures fs
           | _ -> failwith ("uninterpreted dependency \"" ^ path ^
-                           "\".file extension expected : .ml or .mli") in 
+                           "\", file extension expected : .ml or .mli") in 
           load_dependencies [] files
       in
 

--- a/src/grader/grading.ml
+++ b/src/grader/grading.ml
@@ -156,19 +156,16 @@ let get_grade
             List.partition (fun (s,_) -> match Filename.extension s with
                                          | ".ml" -> true
                                          | ".mli" -> false
-                                         | _ -> failwith "depend.txt (1)") mods 
+                                         | _ -> failwith ("uninterpreted dependency \"" ^ s ^
+                                                          "\".file extension expected : .ml or .mli")) mods 
         in
         let insert_dependencies_in_env (current_path,structure) =
           let name = String.capitalize_ascii (Filename.(remove_extension (basename current_path))) in
-          handle_error (internal_error [%i"while loading users dependencies"]) @@
+          handle_error (internal_error [%i"while loading user dependencies"]) @@
+          let use_mod = Toploop_ext.use_mod_string ~print_outcome ~ppf_answer ~modname:name in
           match List.find_opt (fun (path,_) -> path = current_path ^ "i") mli_files with 
-          | Some (_,signature) -> Toploop_ext.use_mod_string ~print_outcome ~ppf_answer 
-                                    ~modname:name 
-                                    ~sig_code:signature 
-                                    structure
-          | None -> Toploop_ext.use_mod_string ~print_outcome ~ppf_answer 
-                      ~modname:name 
-                      structure
+          | Some (_,signature) -> use_mod ~sig_code:signature structure
+          | None -> use_mod structure
           in
         List.iter insert_dependencies_in_env ml_files
 

--- a/src/grader/grading.ml
+++ b/src/grader/grading.ml
@@ -157,14 +157,14 @@ let get_grade
           | ".mli" -> load_dependencies ((modname,content) :: signatures) fs
           | ".ml" -> 
             let included,content = 
-              (* the first line of an .ml file can contain an annotation     *)
-              (* @included which denotes that this file has to be included   *)
-              (* directly in the toplevel environment, and not in an module. *)
+              (* the first line of an .ml file can contain an annotation       *)
+              (* [@@@included] which denotes that this file has to be included *)
+              (* directly in the toplevel environment, and not in an module.   *)
               match String.index_opt content '\n' with
               | None -> (false,content)
               | Some i -> 
                 (match String.trim (String.sub content 0 i) with 
-                 | "@included" -> 
+                 | "[@@@included]" -> 
                     let content' = String.sub content i @@ 
                                    (String.length content - i)
                     in (true,content')

--- a/src/repo/learnocaml_exercise.ml
+++ b/src/repo/learnocaml_exercise.ml
@@ -210,10 +210,8 @@ module File = struct
           | None -> line
           | Some index -> String.sub line 0 index in
     let lines = String.split_on_char '\n' txt in
-    List.filter (function "" -> false | _ -> true) @@
-    List.map (fun line -> String.trim @@
-                          remove_comment ~start:'#' @@ 
-                          remove_comment ~start:';' line) lines
+    List.filter ((<>) "") @@
+    List.map (fun line -> String.trim (remove_comment ~start:'#' line)) lines
 
   let dependencies = function
     | None -> []

--- a/src/repo/learnocaml_exercise.ml
+++ b/src/repo/learnocaml_exercise.ml
@@ -191,7 +191,7 @@ module File = struct
      }
 
   let depend =
-    { key = "../depend.txt" ; ciphered = false ;
+    { key = "depend.txt" ; ciphered = false ;
       decode = (fun v -> Some v) ; 
       encode = (function 
                 | None -> "" (* no `depend` ~ empty `depend` *)

--- a/src/repo/learnocaml_exercise.mli
+++ b/src/repo/learnocaml_exercise.mli
@@ -67,10 +67,10 @@ module File : sig
   val descr: (string * string) list file
 
   (** Returns the (public) [../depend.txt] *)
-  val depend: string file
+  val depend: string option file
 
   (** Returns the (public) dependencies *)
-  val dependencies: string -> string file list
+  val dependencies: string option -> string file list
 
   (** Returns the key of a file *)
   val key : 'a file -> string

--- a/src/repo/learnocaml_exercise.mli
+++ b/src/repo/learnocaml_exercise.mli
@@ -66,6 +66,14 @@ module File : sig
   (** Returns the (public) [descr.html] *)
   val descr: (string * string) list file
 
+  (** Returns the (public) [../depend.txt] *)
+  val depend: string file
+
+  (** Returns the (public) dependencies *)
+  val dependencies: string -> string file list
+
+  (** Returns the key of a file *)
+  val key : 'a file -> string
 end
 
 (** Access a field from the exercise, using the [t] representation, without **

--- a/src/repo/learnocaml_exercise.mli
+++ b/src/repo/learnocaml_exercise.mli
@@ -30,14 +30,20 @@ module File : sig
   (** Get was called on a missing undefaulted field *)
   exception Missing_file of string
 
-  (** Access a field in an exercise, may raise [Missing_field] *)
+  (** Access a field in an exercise, may raise [Missing_file] *)
   val get: 'a file -> files -> 'a
+
+  (** Access an optional field in an exercise *)
+  val get_opt : 'a option file -> files -> 'a option
 
   (** Check the existence of a field in an exercise *)
   val has: 'a file -> files -> bool
 
   (** Access a field in an exercise *)
   val set: 'a file -> 'a -> files -> files
+
+  (** Returns the key (i.e. then name) of a file *)
+  val key: 'a file -> string
 
   (** Learnocaml_exercise id accessor *)
   val id: id file
@@ -66,14 +72,11 @@ module File : sig
   (** Returns the (public) [descr.html] *)
   val descr: (string * string) list file
 
-  (** Returns the (public) [../depend.txt] *)
+  (** Returns the (public) depend file *)
   val depend: string option file
 
   (** Returns the (public) dependencies *)
   val dependencies: string option -> string file list
-
-  (** Returns the key of a file *)
-  val key : 'a file -> string
 end
 
 (** Access a field from the exercise, using the [t] representation, without **

--- a/src/repo/learnocaml_exercise.mli
+++ b/src/repo/learnocaml_exercise.mli
@@ -75,7 +75,8 @@ module File : sig
   (** Returns the (public) depend file *)
   val depend: string option file
 
-  (** Returns the (public) dependencies *)
+  (** [dependencies txt] create the (private, already deciphered) dependencies 
+      declared in [txt] *)
   val dependencies: string option -> string file list
 end
 

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -919,6 +919,10 @@ msgstr "Lancement du banc de test."
 msgid "while testing your solution"
 msgstr "lors du test de la solution utilisateur"
 
+#: src/grader/grading.ml:173,43--80
+msgid "while loading user dependencies"
+msgstr "lors du chargement des dépendances"
+
 #~ msgid "No description available."
 #~ msgstr "Aucune description."
 


### PR DESCRIPTION
**about https://github.com/ocaml-sf/learn-ocaml/issues/169  and  https://github.com/ocaml-sf/learn-ocaml/issues/174.**

This PR offers a support for test code reuse.

It allows the programmer to add an optional file called **depend.txt** (in the **exercises** directory) which declares a list of dependencies as follows :

```
../lib/m1.ml   # just a comment
../lib/m1.mli

../lib/m2.ml
```

Thus, these ml and mli files are copied, ciphered and will be loaded in the toplevel during the grading, just before **test.ml**. It is therefore possible to use the modules *M1* and *M2* in **test.ml** and, furthermore, to use *M1* in *M2*.
