### PR TITLE
Learnocaml_store: refactor {get_from,write_to}_file

### DIFF
--- a/src/main/learnocaml_main.ml
+++ b/src/main/learnocaml_main.ml
@@ -266,12 +266,10 @@ let main o =
        let server_config = o.repo_dir/"server_config.json"
        and www_server_config = o.app_dir/"server_config.json" in
        let module ServerData = Learnocaml_data.Server in
-       let module ServerStore = Learnocaml_store.Server in
        Random.self_init ();
        Lwt.catch
          (fun () ->
-           let enc = ServerData.enc_init in
-           ServerStore.get_from_file ~enc server_config
+           Learnocaml_store.get_from_file ServerData.enc_init server_config
            >|= fun pre_config ->
            match pre_config.ServerData.secret with
              | None -> None
@@ -281,7 +279,7 @@ let main o =
            | exn -> Lwt.fail exn) 
        >>= fun secret ->
          let json_config = ServerData.default ?secret () in
-         ServerStore.write_to_file json_config www_server_config
+         Learnocaml_store.write_to_file ServerData.enc json_config www_server_config
        >>= fun () ->
        let if_enabled opt dir f = (match opt with
            | None ->

--- a/src/state/learnocaml_store.ml
+++ b/src/state/learnocaml_store.ml
@@ -28,6 +28,14 @@ module Json_codec = struct
     | `Null -> ""
     | _ -> assert false
 end
+let get_from_file enc p =
+  Lwt_io.(with_file ~mode: Input p read) >|=
+    Json_codec.decode enc
+
+let write_to_file enc s p =
+  let open Lwt_io in
+  let s = Json_codec.encode enc s in
+  with_file ~mode:output p @@ fun oc -> write oc s
 
 let sanitise_path prefix subpath =
   let rec resolve acc = function
@@ -44,8 +52,7 @@ let sanitise_path prefix subpath =
 
 let read_static_file path enc =
   let path = String.split_on_char '/' path in
-  Lwt_io.(with_file ~mode: Input (sanitise_path !static_dir path) read) >|=
-  Json_codec.decode enc
+  get_from_file enc (sanitise_path !static_dir path)
 
 let with_git_register =
   let dir_mutex = Lwt_utils.gen_mutex_table () in
@@ -138,11 +145,6 @@ module Playground = struct
 end
 
 module Server = struct
-
-  let get_from_file ?(enc = Server.enc) p =
-    Lwt_io.(with_file ~mode: Input p read) >|=
-      Json_codec.decode enc
-
   let get () =
     Lwt.catch
       (fun () -> read_static_file Learnocaml_index.server_config_path Server.enc)
@@ -151,11 +153,6 @@ module Server = struct
         | Unix.Unix_error (Unix.ENOENT,_,_) -> Lwt.return @@ Server.default ()
         | e -> raise e
       )
-
-  let write_to_file ?(enc = Server.enc) s p =
-    let open Lwt_io in
-    let s = Json_codec.encode enc s in
-    with_file ~mode:output p @@ fun oc -> write oc s
 end
 
 module Tutorial = struct
@@ -201,8 +198,7 @@ module Exercise = struct
     let tbl = lazy (
       let tbl = Hashtbl.create 223 in
       Lwt.catch (fun () ->
-          Lwt_io.(with_file ~mode:Input (store_file ()) read) >|=
-          Json_codec.decode (J.list enc) >|= fun l ->
+          get_from_file (J.list enc) (store_file ()) >|= fun l ->
           List.iter (fun st -> Hashtbl.add tbl st.id st) l;
           tbl)
       @@ function
@@ -414,9 +410,7 @@ module Save = struct
 
   let get token =
     Token.find_save token >>= function
-    | Some save ->
-        Lwt_io.with_file ~mode:Lwt_io.Input save @@ fun chan ->
-        Lwt_io.read chan >|= Json_codec.decode (J.option enc)
+    | Some save -> get_from_file (J.option enc) save
     | None -> Lwt.return_none
 
   let set token save =
@@ -500,9 +494,8 @@ module Student = struct
     let store_file () = Filename.concat !sync_dir "students.json"
 
     let load () =
-      Lwt.catch (fun () ->
-          Lwt_io.(with_file ~mode:Input (store_file ()) read) >|=
-          Json_codec.decode store_enc)
+      Lwt.catch
+        (fun () -> get_from_file store_enc (store_file ()))
         (function
           | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return Token.Map.empty
           | e -> Lwt.fail e)

--- a/src/state/learnocaml_store.mli
+++ b/src/state/learnocaml_store.mli
@@ -20,6 +20,8 @@ val sync_dir: string ref
 
 (** Used both for file i/o and request handling *)
 module Json_codec: Learnocaml_api.JSON_CODEC
+val get_from_file : 'a Json_encoding.encoding -> string -> 'a Lwt.t
+val write_to_file : 'a Json_encoding.encoding -> 'a -> string -> unit Lwt.t
 
 (* [sanitise_path prefix subdir] simplifies "." and ".." references in [subdir],
    and returns the concatenation, but guaranteeing the result remains below
@@ -56,11 +58,7 @@ module Playground: sig
 end
 
 module Server : sig
-  val get_from_file : ?enc:Server.config Json_encoding.encoding ->
-                      string -> Server.config Lwt.t
   val get : unit -> Server.config Lwt.t
-  val write_to_file : ?enc:Server.config Json_encoding.encoding ->
-                      Server.config -> string -> unit Lwt.t
 end
 
 module Tutorial: sig


### PR DESCRIPTION
The same operations of file+json (de)serialization were used many times in the Learnocaml_store module.

This PR refactors it into generic operations used within the module,
and also by learnocaml_main as a client (to (de)serialize configuration values).