### PR TITLE
Refactor Learnocaml_data.Server

### DIFF
--- a/src/main/learnocaml_main.ml
+++ b/src/main/learnocaml_main.ml
@@ -269,17 +269,13 @@ let main o =
        Random.self_init ();
        Lwt.catch
          (fun () ->
-           Learnocaml_store.get_from_file ServerData.enc_init server_config
-           >|= fun pre_config ->
-           match pre_config.ServerData.secret with
-             | None -> None
-             | Some x -> Some (Sha.sha512 x))
+           Learnocaml_store.get_from_file ServerData.preconfig_enc server_config)
          (function 
-           | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return None
+           | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return ServerData.empty_preconfig
            | exn -> Lwt.fail exn) 
-       >>= fun secret ->
-         let json_config = ServerData.default ?secret () in
-         Learnocaml_store.write_to_file ServerData.enc json_config www_server_config
+       >>= fun preconfig ->
+         let json_config = ServerData.build_config preconfig in
+         Learnocaml_store.write_to_file ServerData.config_enc json_config www_server_config
        >>= fun () ->
        let if_enabled opt dir f = (match opt with
            | None ->

--- a/src/state/dune
+++ b/src/state/dune
@@ -9,7 +9,8 @@
  (wrapped false)
  (modules Learnocaml_data)
  (libraries asak
-	    learnocaml_toplevel_history
+            sha
+            learnocaml_toplevel_history
             learnocaml_report
             learnocaml_repository)
 )
@@ -21,7 +22,7 @@
  (modules Learnocaml_version Learnocaml_api)
  (libraries ocplib-json-typed
             ezjsonm
-	    conduit
+            conduit
             learnocaml_data)
 )
 

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -121,17 +121,24 @@ module Student: sig
 end
 
 module Server : sig
+  (* preconfig: the type of configuration files in the corpus repository,
+     where users can pre-set some of the server settings. *)
+  type preconfig = {
+    secret : string option;
+  }
+  val empty_preconfig : preconfig
+
+  (* config: the type of configuration of a running server, generated
+     from the preconfig during the 'build' stage. *)
   type config = {
     secret : string option; (* maybe a secret *)
-    server_id : int (* random integer generated each building time *)
-    }
+    server_id : int; (* random integer generated each building time *)
+  }
 
-  val default: ?secret:string -> unit -> config
+  val build_config : preconfig -> config
 
-  (* only used in the building case to generate a random server_id *)
-  val enc_init: config Json_encoding.encoding
-
-  val enc: config Json_encoding.encoding
+  val preconfig_enc: preconfig Json_encoding.encoding
+  val config_enc: config Json_encoding.encoding
 end
 
 module Exercise: sig

--- a/src/state/learnocaml_store.ml
+++ b/src/state/learnocaml_store.ml
@@ -147,10 +147,11 @@ end
 module Server = struct
   let get () =
     Lwt.catch
-      (fun () -> read_static_file Learnocaml_index.server_config_path Server.enc)
+      (fun () -> read_static_file Learnocaml_index.server_config_path Server.config_enc)
       (fun e ->
         match e with
-        | Unix.Unix_error (Unix.ENOENT,_,_) -> Lwt.return @@ Server.default ()
+        | Unix.Unix_error (Unix.ENOENT,_,_) ->
+           Lwt.return @@ Server.build_config Server.empty_preconfig
         | e -> raise e
       )
 end


### PR DESCRIPTION
This PR sits on top of #324, so it would be easier to review if #324 was merged.

---

The previous API (from #286) was unclear; I couldn't understand the role of
enc_init without reading the client code, and it was not clear how to
extend server configuration with new fields. After the refactoring,
it's clear that adding a new field requires thinking about whether it
should be part of the preconfig or not -- and it could be optional in
the preconfig and mandatory in the config, etc.