### PR TITLE
Fix CI (Downgrade cstruct in learn-ocaml-client.opam)

### DIFF
--- a/learn-ocaml-client.opam
+++ b/learn-ocaml-client.opam
@@ -32,7 +32,7 @@ depends: [
   "ocp-ocamlres" {= "0.4"}
   "ocplib-json-typed" {= "0.6"}
   "ipaddr" {= "2.8.0" }
-  "cstruct" {= "5.0.0"}
+  "cstruct" {= "3.3.0"}
   "ppx_tools"
 ]
 build: [


### PR DESCRIPTION
Hi @yurug, I'm sorry but it seems there was a remaining issue :/
https://travis-ci.org/ocaml-sf/learn-ocaml/jobs/647706577

So the downgrade of `cstruct` to 5.0.0 in learn-ocaml-client.opam was not enough, as learn-ocaml.opam appears to transitively require `cstruct.3.3.0`.

Hopefully that will be very fine now - anyway, let's wait for the CI to be green :)