### PR TITLE
repo: fix repo generation when an exercise has multiple subdirectories

### DIFF
--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -228,9 +228,11 @@ let main dest_dir =
              spawn_grader
          in
          listmap (fun (id, ex_dir, exercise, json_path, changed, dump_outputs,dump_reports) ->
+             let dst_ex_dir = String.concat Filename.dir_sep [dest_dir; "static"; id] in
+             Lwt_utils.mkdir_p dst_ex_dir >>= fun () ->
                Lwt_stream.iter_p (fun base ->
                  let d = Filename.concat ex_dir base in
-                 let dst = String.concat Filename.dir_sep [dest_dir; "static"; id; base] in
+                 let dst = String.concat Filename.dir_sep [dst_ex_dir; base] in
                  if Sys.is_directory d && base.[0] <> '.' then
                    (Lwt_utils.mkdir_p (Filename.dirname dst) >>= fun () ->
                     Lwt_utils.copy_tree d dst)


### PR DESCRIPTION
When an exercise is copied to the destination directory, its
subdirectories (and their parents) are copied concurrently.  This is
not an issue when there is only one subdirectory to copy, but not when
there is multiple subdirectories.  In this case, for each subdirectory
of the exercise, `mkdir_p' will check if the parent directory exists.
As it does not, they will all attempt to create the parent.  One of
those will succeed, and the rest will fail with EEXIST.

This solves this issue by creating the exercise's destination
directory before creating subdirectories.

This fixes #305.