### PR TITLE
Correct install_printer

### DIFF
--- a/src/grader/dune
+++ b/src/grader/dune
@@ -58,6 +58,7 @@
        %{ocaml-config:standard_library}/camlinternalLazy.cmi
        %{ocaml-config:standard_library}/camlinternalMod.cmi
        %{ocaml-config:standard_library}/camlinternalOO.cmi
+       %{ocaml-config:standard_library}/compiler-libs/topdirs.cmi
        %{ocaml-config:standard_library}/char.cmi
        %{ocaml-config:standard_library}/complex.cmi
        %{ocaml-config:standard_library}/digest.cmi


### PR DESCRIPTION
Hi,
this PR allows the toplevel to support the `#install_printer` directive.

Correct the missing dependency : `Topdirs.printer_type_new`.