### PR TITLE
Add a regression test for `learn-ocaml build'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ static/dune
 
 translations/*.pot
 **/.merlin
+
+tests/corpuses/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ language: c
     - make docker-images
   script:
     - sh -c 'docker run --rm -v $(pwd)/demo-repository:/repository learn-ocaml -- build'
-    - cd tests; sh -c ./runtests.sh
+    - cd tests
+    - mkdir corpuses; cd corpuses; git clone https://github.com/ocaml-sf/learn-ocaml-corpus
+    - cd ..; sh -c ./runtests.sh
 
 .macos: &MACOS
   os: osx


### PR DESCRIPTION
Commit 5a661e4 ("repo: fix repo generation when an exercise has multiple subdirectories", 2020-05-26) fixed the issue #305, but it did not add any regression test to the test suite to ensure that the behaviour of `learn-ocaml build' stayed correct.

This series cleans up a bit `runtests.sh`, adds such a test, and makes Travis to check `learn-ocaml build' against learn-ocaml-corpus.

This patch series keeps the general behaviour of `runtests.sh` -- perhaps in the future, it could be changed to have a [TAP](https://testanything.org/)-compliant output, or allow it to run without docker?