### PR TITLE
Move to dune 1.7

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
-(ignored_subdirs (docker _obuild www sync demo-repository))
+(dirs :standard \ docker _obuild www sync demo-repository)
 
 (rule
  (targets VERSION)

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.0)
+(lang dune 1.7)
 (name learn-ocaml)
 (version 0.11)

--- a/learn-ocaml-client.opam
+++ b/learn-ocaml-client.opam
@@ -21,7 +21,7 @@ depends: [
   "asak"
   "cohttp" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
-  "ssl" {= "0.5.4"}
+  "ssl" {= "0.5.5"}
   "digestif" {>= "0.7.1"}
   "dune" {= "2.0.1"}
   "ezjsonm"

--- a/learn-ocaml-client.opam
+++ b/learn-ocaml-client.opam
@@ -22,16 +22,16 @@ depends: [
   "cohttp" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
   "digestif" {>= "0.7.1"}
-  "dune" {>= "1.7"}
+  "dune" {= "2.0.1"}
   "ezjsonm"
-  "lwt" {>= "3.2.0"}
+  "lwt" {>= "4.0.0"}
   "lwt_ssl"
   "ocaml" {= "4.05.0"}
   "ocamlfind" {build}
   "ocp-indent-nlfork"
   "ocp-ocamlres" {>= "0.4"}
   "ocplib-json-typed" {= "0.6"}
-  "ipaddr" {>= "2.8.0" }
+  "ipaddr" {= "2.8.0" }
   "cstruct" {>= "3.3.0"}
   "ppx_tools"
   "ppx_sexp_conv" {= "v0.9.0"}

--- a/learn-ocaml-client.opam
+++ b/learn-ocaml-client.opam
@@ -21,6 +21,7 @@ depends: [
   "asak"
   "cohttp" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
+  "ssl" {= "0.5.4"}
   "digestif" {>= "0.7.1"}
   "dune" {= "2.0.1"}
   "ezjsonm"

--- a/learn-ocaml-client.opam
+++ b/learn-ocaml-client.opam
@@ -22,9 +22,9 @@ depends: [
   "cohttp" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
   "digestif" {>= "0.7.1"}
-  "dune" {>= "1.1.1"}
+  "dune" {>= "1.7"}
   "ezjsonm"
-  "lwt" {>= "3.2.0" & < "4.0.0"}
+  "lwt" {>= "3.2.0"}
   "lwt_ssl"
   "ocaml" {= "4.05.0"}
   "ocamlfind" {build}

--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -23,9 +23,9 @@ depends: [
   "conf-git"
   "decompress" {= "0.8.1"}
   "digestif" {>= "0.7.1"}
-  "dune" {>= "1.7"}
+  "dune" {= "2.0.1"}
   "easy-format" {>= "1.3.0" }
-  "ipaddr" {>= "2.8.0" }
+  "ipaddr" {= "2.8.0" }
   "ezjsonm"
   "js_of_ocaml" {>= "3.3.0"}
   "js_of_ocaml-compiler" {>= "3.3.0"}
@@ -33,7 +33,7 @@ depends: [
   "js_of_ocaml-ppx"
   "js_of_ocaml-toplevel"
   "js_of_ocaml-tyxml"
-  "lwt" {>= "3.2.0"}
+  "lwt" {>= "4.0.0"}
   "lwt_react"
   "lwt_ssl"
   "magic-mime"

--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -36,7 +36,7 @@ depends: [
   "lwt" {>= "4.0.0"}
   "lwt_react"
   "lwt_ssl"
-  "ssl" {= "0.5.4"}
+  "ssl" {= "0.5.5"}
   "magic-mime"
   "markup"
   "ocaml" {= "4.05.0"}

--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -36,6 +36,7 @@ depends: [
   "lwt" {>= "4.0.0"}
   "lwt_react"
   "lwt_ssl"
+  "ssl" {= "0.5.4"}
   "magic-mime"
   "markup"
   "ocaml" {= "4.05.0"}

--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -18,11 +18,12 @@ depends: [
   "base64"
   "cmdliner"
   "cohttp" {>= "1.0.0" & < "2.0.0"}
+  "cohttp-lwt" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}
   "conf-git"
   "decompress" {= "0.8.1"}
   "digestif" {>= "0.7.1"}
-  "dune" {>= "1.1.1"}
+  "dune" {>= "1.7"}
   "easy-format" {>= "1.3.0" }
   "ipaddr" {>= "2.8.0" }
   "ezjsonm"
@@ -32,7 +33,7 @@ depends: [
   "js_of_ocaml-ppx"
   "js_of_ocaml-toplevel"
   "js_of_ocaml-tyxml"
-  "lwt" {>= "3.2.0" & < "4.0.0"}
+  "lwt" {>= "3.2.0"}
   "lwt_react"
   "lwt_ssl"
   "magic-mime"

--- a/learn-ocaml.opam.locked
+++ b/learn-ocaml.opam.locked
@@ -101,7 +101,7 @@ depends: [
   "rresult" {= "0.6.0"}
   "seq" {= "0.2.2"}
   "sexplib" {= "v0.9.3"}
-  "ssl" {= "0.5.4"}
+  "ssl" {= "0.5.5"}
   "stdio" {= "v0.9.1"}
   "stdlib-shims" {= "0.1.0"}
   "stringext" {= "1.6.0"}

--- a/learn-ocaml.opam.locked
+++ b/learn-ocaml.opam.locked
@@ -8,15 +8,25 @@ authors: [
   "Louis Gesbert (OCamlPro)"
   "Pierrick Couderc (OCamlPro)"
 ]
-maintainer: "Louis Gesbert"
+maintainer: "Yann Régis-Gianas"
 license: "MIT"
 homepage: "https://github.com/ocaml-sf/learn-ocaml"
 bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
 dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
 depends: [
+  "asak" {= "0.2"}
+  "astring" {= "0.8.4"}
   "base" {= "v0.9.4"}
+  "base-bigarray" {= "base"}
+  "base-bytes" {= "base"}
+  "base-num" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
   "base64" {= "2.3.0"}
-  "cmdliner" {= "1.0.3"}
+  "bigarray-compat" {= "1.0.0"}
+  "biniou" {= "1.2.1"}
+  "checkseum" {= "0.1.0"}
+  "cmdliner" {= "1.0.4"}
   "cohttp" {= "1.1.1"}
   "cohttp-lwt" {= "1.1.1"}
   "cohttp-lwt-unix" {= "1.1.1"}
@@ -24,15 +34,24 @@ depends: [
   "conduit-lwt" {= "1.3.0"}
   "conduit-lwt-unix" {= "1.3.0"}
   "conf-git" {= "1.0"}
-  "conf-libev" {= "4-11"}
-  "conf-openssl" {= "1"}
-  "cstruct" {= "3.3.0"}
+  "conf-libssl" {= "1"}
+  "conf-m4" {= "1"}
+  "conf-pkg-config" {= "1.2"}
+  "conf-which" {= "1"}
+  "cppo" {= "1.6.6"}
+  "cstruct" {= "5.0.0"}
   "decompress" {= "0.8.1"}
-  "digestif" {= "0.7.1"}
-  "dune" {= "1.6.3"}
-  "easy-format" {= "1.3.1"}
-  "ezjsonm" {= "0.6.0"}
+  "digestif" {= "0.8.0-1"}
+  "dune" {= "2.0.1"}
+  "easy-format" {= "1.3.2"}
+  "eqaf" {= "0.7"}
+  "ezjsonm" {= "1.1.0"}
+  "fieldslib" {= "v0.9.0"}
+  "fmt" {= "0.8.8"}
+  "fpath" {= "0.7.2"}
+  "hex" {= "1.4.0"}
   "ipaddr" {= "2.8.0"}
+  "jbuilder" {= "1.0+beta20.2"}
   "js_of_ocaml" {= "3.3.0"}
   "js_of_ocaml-compiler" {= "3.3.0"}
   "js_of_ocaml-lwt" {= "3.3.0"}
@@ -40,33 +59,62 @@ depends: [
   "js_of_ocaml-toplevel" {= "3.3.0"}
   "js_of_ocaml-tyxml" {= "3.3.0"}
   "jsonm" {= "1.0.1"}
-  "lwt" {= "3.3.0"}
-  "lwt_react" {= "1.1.1"}
-  "lwt_ssl" {= "1.1.2"}
-  "magic-mime" {= "1.1.1"}
-  "markup" {= "0.8.0"}
+  "logs" {= "0.7.0"}
+  "lwt" {= "4.2.1"}
+  "lwt_react" {= "1.1.3"}
+  "lwt_ssl" {= "1.1.3"}
+  "magic-mime" {= "1.1.2"}
+  "markup" {= "0.8.2"}
+  "mmap" {= "1.1.0"}
+  "num" {= "0"}
   "ocaml" {= "4.05.0"}
-  "ocamlfind" {= "1.8.0"}
-  "ocp-indent-nlfork" {= "1.5.3"}
+  "ocaml-compiler-libs" {= "v0.9.0"}
+  "ocaml-migrate-parsetree" {= "1.7.3"}
+  "ocaml-secondary-compiler" {= "4.08.1-1"}
+  "ocamlbuild" {= "0.14.0"}
+  "ocamlfind" {= "1.8.1"}
+  "ocamlfind-secondary" {= "1.8.1"}
+  "ocp-indent-nlfork" {= "1.5.4"}
   "ocp-ocamlres" {= "0.4"}
   "ocplib-json-typed" {= "0.6"}
-  "odoc" {= "1.3.0"}
+  "odoc" {= "1.5.1"}
   "omd" {= "1.3.1"}
-  "pprint" {= "20180528"}
-  "ppx_cstruct" {= "3.3.0"}
+  "optint" {= "0.0.2"}
+  "pprint" {= "20200410"}
+  "ppx_ast" {= "v0.9.1"}
+  "ppx_core" {= "v0.9.3"}
+  "ppx_cstruct" {= "5.0.0"}
+  "ppx_derivers" {= "1.2.1"}
+  "ppx_driver" {= "v0.9.2"}
+  "ppx_fields_conv" {= "v0.9.0"}
+  "ppx_metaquot" {= "v0.9.0"}
+  "ppx_optcomp" {= "v0.9.0"}
+  "ppx_sexp_conv" {= "v0.9.0"}
   "ppx_tools" {= "5.0+4.05.0"}
+  "ppx_tools_versioned" {= "5.4.0"}
+  "ppx_traverse_builtins" {= "v0.9.0"}
+  "ppx_type_conv" {= "v0.9.1"}
+  "re" {= "1.9.0"}
   "react" {= "1.2.1"}
   "reactiveData" {= "0.2.1"}
-  "ssl" {= "0.5.7"}
-  "tyxml" {= "4.3.0"}
+  "result" {= "1.5"}
+  "rresult" {= "0.6.0"}
+  "seq" {= "0.2.2"}
+  "sexplib" {= "v0.9.3"}
+  "ssl" {= "0.5.5"}
+  "stdio" {= "v0.9.1"}
+  "stdlib-shims" {= "0.1.0"}
+  "stringext" {= "1.6.0"}
+  "topkg" {= "1.0.1"}
+  "tyxml" {= "4.4.0"}
+  "uchar" {= "0.0.2"}
   "uri" {= "1.9.7"}
-  "uutf" {= "1.0.1"}
-  "yojson" {= "1.5.0"}
-  "asak" {= "0.1"}
+  "uutf" {= "1.0.2"}
+  "yojson" {= "1.7.0"}
 ]
 build: [
   [make "static"]
-  ["dune" "build" "-p" name]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 install: [
   ["mkdir" "-p" "%{_:share}%"]

--- a/learn-ocaml.opam.locked
+++ b/learn-ocaml.opam.locked
@@ -101,7 +101,7 @@ depends: [
   "rresult" {= "0.6.0"}
   "seq" {= "0.2.2"}
   "sexplib" {= "v0.9.3"}
-  "ssl" {= "0.5.5"}
+  "ssl" {= "0.5.4"}
   "stdio" {= "v0.9.1"}
   "stdlib-shims" {= "0.1.0"}
   "stringext" {= "1.6.0"}

--- a/src/ace-lib/ace.ml
+++ b/src/ace-lib/ace.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Ace_types
 
 let iter_option f = function

--- a/src/ace-lib/ace.mli
+++ b/src/ace-lib/ace.mli
@@ -6,6 +6,8 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
+
 (** Editor *)
 
 type 'a editor

--- a/src/ace-lib/ace_types.mli
+++ b/src/ace-lib/ace_types.mli
@@ -6,6 +6,8 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
+
 class type token = object
   method value : Js.js_string Js.t Js.prop
   method _type : Js.js_string Js.t Js.prop

--- a/src/ace-lib/ocaml_mode.ml
+++ b/src/ace-lib/ocaml_mode.ml
@@ -7,7 +7,7 @@
  * included LICENSE file for details. *)
 
 open Js_utils
-
+open Js_of_ocaml
 open Lwt.Infix
 
 let debug_indent = ref 0

--- a/src/ace-lib/ocaml_mode.mli
+++ b/src/ace-lib/ocaml_mode.mli
@@ -6,6 +6,8 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
+
 type editor
 
 type loc = Ace.loc = {

--- a/src/app/learnocaml_common.ml
+++ b/src/app/learnocaml_common.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Js_utils
 open Lwt.Infix
 open Learnocaml_data
@@ -80,8 +81,8 @@ let fatal ?(title=[%i"INTERNAL ERROR"]) message =
         div in
   Manip.replaceChildren div [
     H.div [
-      H.h3 [ H.pcdata titletext ];
-      H.div [ H.p [ H.pcdata (String.trim message) ] ];
+      H.h3 [ H.txt titletext ];
+      H.div [ H.p [ H.txt (String.trim message) ] ];
     ]
   ]
 
@@ -94,7 +95,7 @@ let box_button txt f =
         match Manip.by_id dialog_layer_id with
         | Some div -> Manip.removeChild Manip.Elt.body div; false
         | None -> (); false)
-  ] [ H.pcdata txt ]
+  ] [ H.txt txt ]
 
 let close_button txt =
   box_button txt @@ fun () -> ()
@@ -112,7 +113,7 @@ let ext_alert ~title ?(buttons = [close_button [%i"OK"]]) message =
         div in
   Manip.replaceChildren div [
     H.div [
-      H.h3 [ H.pcdata title ];
+      H.h3 [ H.txt title ];
       H.div message;
       H.div ~a:[ H.a_class ["buttons"] ] buttons;
     ]
@@ -131,7 +132,7 @@ let lwt_alert ~title ~buttons message =
   waiter
 
 let alert ?(title=[%i"ERROR"]) ?buttons message =
-  ext_alert ~title ?buttons [ H.p [H.pcdata (String.trim message)] ]
+  ext_alert ~title ?buttons [ H.p [H.txt (String.trim message)] ]
 
 let confirm ~title ?(ok_label=[%i"OK"]) ?(cancel_label=[%i"Cancel"]) contents f =
   ext_alert ~title contents ~buttons:[
@@ -287,8 +288,8 @@ let button ~container ~theme ?group ?state ~icon lbl cb =
   let button =
     H.(button [
         img ~alt:"" ~src:("/icons/icon_" ^ icon ^ "_" ^ theme ^ ".svg") () ;
-        pcdata " " ;
-        span ~a:[ a_class [ "label" ] ] [ pcdata lbl ]
+        txt " " ;
+        span ~a:[ a_class [ "label" ] ] [ txt lbl ]
       ]) in
   Manip.Ev.onclick button
     (fun _ ->
@@ -329,7 +330,7 @@ let dropdown ~id ~title items =
     in
     H.div ~a: [H.a_class ["dropdown_btn"]] [
       H.button ~a: [H.a_onclick toggle]
-        (title @ [H.pcdata " \xe2\x96\xb4" (* U+25B4 *)]);
+        (title @ [H.txt " \xe2\x96\xb4" (* U+25B4 *)]);
       H.div ~a: [H.a_id id; H.a_class ["dropdown_content"]] items
     ]
 
@@ -343,10 +344,10 @@ let render_rich_text ?on_runnable_clicked text =
     | [] -> List.rev acc
     | Text text :: rest ->
         render
-          (H.pcdata text :: acc)
+          (H.txt text :: acc)
           rest
     | Code { code ; runnable } :: rest ->
-        let elt = H.code [ H.pcdata code ] in
+        let elt = H.code [ H.txt code ] in
         (match runnable, on_runnable_clicked with
          | true, Some cb ->
              Manip.addClass elt "runnable" ;
@@ -360,7 +361,7 @@ let render_rich_text ?on_runnable_clicked text =
     | Image _ :: _ -> assert false
     | Math code :: rest ->
         render
-          (H.pcdata ("`" ^ code ^ "`") :: acc)
+          (H.txt ("`" ^ code ^ "`") :: acc)
           rest in
   (render [] text
    :> [< Html_types.phrasing > `Code `Em `PCDATA ] H.elt list)
@@ -404,8 +405,8 @@ let rec retrieve ?ignore req =
   | Ok x -> Lwt.return x
   | Error e ->
       lwt_alert ~title:[%i"REQUEST ERROR"] [
-        H.p [H.pcdata [%i"Could not retrieve data from server"]];
-        H.code [H.pcdata (Server_caller.string_of_error e)];
+        H.p [H.txt [%i"Could not retrieve data from server"]];
+        H.code [H.txt (Server_caller.string_of_error e)];
       ] ~buttons:(
         ([%i"Retry"], (fun () -> retrieve req)) ::
         (match ignore with
@@ -444,8 +445,8 @@ let rec sync_save token save_file =
       Lwt.return save
   | Error e ->
       lwt_alert ~title:[%i"SYNC FAILED"] [
-        H.p [H.pcdata [%i"Could not synchronise save with the server"]];
-        H.code [H.pcdata (Server_caller.string_of_error e)];
+        H.p [H.txt [%i"Could not synchronise save with the server"]];
+        H.code [H.txt (Server_caller.string_of_error e)];
       ] ~buttons:[
         [%i"Retry"], (fun () -> sync_save token save_file);
         [%i"Ignore"], (fun () -> Lwt.return save_file);
@@ -663,7 +664,7 @@ let string_of_date ?(time=false) t =
 let date ?(time=false) t =
   let date = new%js Js.date_fromTimeValue (t *. 1000.) in
   H.time ~a:[ H.a_datetime (Js.to_string date##toISOString) ] [
-    H.pcdata
+    H.txt
       (Js.to_string (if time then date##toLocaleString
                      else date##toLocaleDateString))
   ]
@@ -674,7 +675,7 @@ let tag_span tag =
   in
   H.span ~a:[H.a_class ["tag"];
              H.a_style ("background-color: "^color)]
-    [H.pcdata tag]
+    [H.txt tag]
 
 let get_worker_code name =
   let worker_url = ref None in
@@ -868,7 +869,7 @@ module Editor_button (E : Editor_info) = struct
   editor_button
     ~icon: "cleanup" [%i"Reset"] @@ fun () ->
     confirm ~title:[%i"START FROM SCRATCH"]
-      [H.pcdata [%i"This will discard all your edits. Are you sure?"]]
+      [H.txt [%i"This will discard all your edits. Are you sure?"]]
       (fun () ->
          Ace.set_contents E.ace template);
     Lwt.return ()
@@ -943,21 +944,21 @@ let setup_prelude_pane ace prelude =
          | "hidden" -> false
          | _ -> failwith "Bad format for argument prelude.") in
   let prelude_btn = button [] in
-  let prelude_title = h1 [ pcdata [%i"OCaml prelude"] ;
+  let prelude_title = h1 [ txt [%i"OCaml prelude"] ;
                            prelude_btn ] in
   let prelude_container =
     pre ~a: [ a_class [ "toplevel-code" ] ]
       (Learnocaml_toplevel_output.format_ocaml_code prelude) in
   let update () =
     if !state then begin
-        Manip.replaceChildren prelude_btn [ pcdata ("↳ "^[%i"Hide"]) ] ;
+        Manip.replaceChildren prelude_btn [ txt ("↳ "^[%i"Hide"]) ] ;
         Manip.SetCss.display prelude_container "" ;
         Manip.SetCss.top editor_pane "193px" ; (* 150 + 43 *)
         Manip.SetCss.bottom editor_pane "40px" ;
         Ace.resize ace true;
         set_arg "prelude" "shown"
       end else begin
-        Manip.replaceChildren prelude_btn [ pcdata ("↰ "^[%i"Show"]) ] ;
+        Manip.replaceChildren prelude_btn [ txt ("↰ "^[%i"Show"]) ] ;
         Manip.SetCss.display prelude_container "none" ;
         Manip.SetCss.top editor_pane "43px" ;
         Manip.SetCss.bottom editor_pane "40px" ;
@@ -978,7 +979,7 @@ let get_token () =
     retrieve (Learnocaml_api.Nonce ())
     >>= fun nonce ->
     ask_string ~title:"Secret"
-      [H.pcdata [%i"Enter the secret"]]
+      [H.txt [%i"Enter the secret"]]
     >>= fun secret ->
     retrieve
       (Learnocaml_api.Create_token (Sha.sha512 (nonce ^ Sha.sha512 secret), None, None))
@@ -1002,8 +1003,8 @@ module Display_exercise =
       | Some descr ->
          div ~a:[ a_class [ "descr" ] ] [
              h2 ~a:[ a_class [ "learnocaml-exo-meta-category" ] ]
-               [ pcdata ex_meta.Meta.title ] ;
-             p [ pcdata descr ]
+               [ txt ex_meta.Meta.title ] ;
+             p [ txt descr ]
            ]
 
     let display_stars ex_meta =
@@ -1018,8 +1019,8 @@ module Display_exercise =
       in
       div ~a:[ a_class [ "stars" ] ] [
           p [
-              pcdata [%i "Difficulty:"] ;
-              pcdata " "; (* Put no whitespace in translation strings
+              txt [%i "Difficulty:"] ;
+              txt " "; (* Put no whitespace in translation strings
                              (the colon is mandatory, though, given
                              the conventions are different in English
                              and French, for example). *)
@@ -1032,7 +1033,7 @@ module Display_exercise =
       let open Learnocaml_data.Exercise in
       let kind_repr = string_of_exercise_kind ex_meta.Meta.kind in
       div ~a:[ a_class [ "length" ] ] [
-          p [ pcdata (Format.sprintf [%if "Kind: %s"] kind_repr) ]
+          p [ txt (Format.sprintf [%if "Kind: %s"] kind_repr) ]
         ]
 
     let display_exercise_meta id meta content_id =
@@ -1049,10 +1050,10 @@ module Display_exercise =
       Manip.replaceChildren content [ descr ];
       Lwt.return ()
 
-    let display_list ?(sep=Tyxml_js.Html5.pcdata ", ") l =
+    let display_list ?(sep=Tyxml_js.Html5.txt ", ") l =
       let open Tyxml_js.Html5 in
       let rec gen acc = function
-        | [] -> [ pcdata "" ]
+        | [] -> [ txt "" ]
         | a :: [] -> a :: acc
         | a :: ((_ :: _) as rem) ->
            gen (sep :: (a  :: acc)) rem
@@ -1087,7 +1088,7 @@ module Display_exercise =
       Manip.replaceChildren content
         (display_list @@
            List.map (fun ex_id ->
-               exercise_link ex_id [Tyxml_js.Html5.pcdata ex_id]) exs);
+               exercise_link ex_id [Tyxml_js.Html5.txt ex_id]) exs);
       Lwt.return ()
 
     let display_link onclick content_id value =
@@ -1102,15 +1103,15 @@ module Display_exercise =
         else
           ignore (onclick cid);
         Manip.removeChildren exp;
-        Manip.appendChild exp (pcdata (if !displayed then "[-]" else "[+]"));
+        Manip.appendChild exp (txt (if !displayed then "[-]" else "[+]"));
         displayed := not !displayed;
         true
       in
       div [ p ~a:[ a_class [ "learnocaml-exo-expandable-link" ] ;
                    a_onclick onclick ] [
                 span ~a:[ a_id expand_id ;
-                          a_class ["expand-sign"] ] [ pcdata "[+]" ] ;
-                pcdata value ] ;
+                          a_class ["expand-sign"] ] [ txt "[+]" ] ;
+                txt value ] ;
             div ~a:[ a_id cid ;
                      a_class [ "learnocaml-exo-meta-category" ] ]
               []
@@ -1126,12 +1127,12 @@ module Display_exercise =
     let display_authors caption_text authors =
       let open Tyxml_js.Html5 in
       let author (name, mail) =
-        span [ pcdata name ;
-               pcdata " <" ;
-               a ~a:[ a_href ("mailto:" ^ mail) ] [ pcdata mail ] ;
-               pcdata ">" ;
+        span [ txt name ;
+               txt " <" ;
+               a ~a:[ a_href ("mailto:" ^ mail) ] [ txt mail ] ;
+               txt ">" ;
           ] in
-      span [ pcdata caption_text; pcdata " " ]
+      span [ txt caption_text; txt " " ]
       :: (display_list @@ List.map author authors)
 
     let add_map_set sk id map =
@@ -1152,7 +1153,7 @@ module Display_exercise =
       | [] -> None
       | skills ->
          Some (caption,
-               display_list ~sep:(H.pcdata "") @@
+               display_list ~sep:(H.txt "") @@
                  List.map (fun s ->
                      display_skill_link
                        (try SSet.elements (SMap.find s map) with Not_found -> [])
@@ -1169,7 +1170,7 @@ module Display_exercise =
         (List.rev exos)
       |> function
         | [] -> None
-        | l -> Some (caption, display_list ~sep:(H.pcdata "") l)
+        | l -> Some (caption, display_list ~sep:(H.txt "") l)
 
     let display_meta token ex_meta id =
       let open Learnocaml_data.Exercise in
@@ -1200,19 +1201,19 @@ module Display_exercise =
       Manip.replaceChildren tab @@
         Tyxml_js.Html5.([
               h1 ~a:[ a_class [ "learnocaml-exo-meta-title" ] ]
-                [ pcdata [%i "Metadata" ] ] ;
+                [ txt [%i "Metadata" ] ] ;
               div ~a:[ a_id "learnocaml-exo-content-meta" ] @@
                 [ display_descr ex_meta ;
                   display_stars ex_meta ;
                   display_kind ex_meta ;
-                  p [ pcdata ident ] ;
+                  p [ txt ident ] ;
                   (match authors with Some a -> p a | None -> div [])
                 ] @ List.map
                       (function
                        | Some (title, values) ->
                           div (h2 ~a:[ a_class
                                          [ "learnocaml-exo-meta-category-title" ] ]
-                                 [ pcdata title ] :: values)
+                                 [ txt title ] :: values)
                        | None -> div [])
                       [ focus ; requirements ; backward ; forward ]
         ])

--- a/src/app/learnocaml_common.mli
+++ b/src/app/learnocaml_common.mli
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Learnocaml_data
 
 val find_div_or_append_to_body : string -> [> Html_types.div ] Tyxml_js.Html.elt

--- a/src/app/learnocaml_common.mli
+++ b/src/app/learnocaml_common.mli
@@ -183,7 +183,7 @@ val toplevel_launch :
   (unit -> unit) ->
   button_group -> string -> Learnocaml_toplevel.t Lwt.t
 
-val mouseover_toggle_signal : 'a Tyxml_js.Html5.elt -> 'b -> ('b option -> 'c) -> unit
+val mouseover_toggle_signal : 'a Tyxml_js.Html5.elt -> 'b -> ('b option -> unit) -> unit
 
 val ace_display :
   [< Html_types.div ] Tyxml_js.To_dom.elt -> (string -> unit) * (unit -> unit)
@@ -209,7 +209,7 @@ end
 module Editor_button (E : Editor_info) : sig
   val cleanup : string -> unit
   val download : string -> unit
-  val eval : Learnocaml_toplevel.t -> (string -> 'a) -> unit
+  val eval : Learnocaml_toplevel.t -> (string -> unit) -> unit
   val sync : Token.t Lwt.t -> Learnocaml_data.SMap.key -> unit
 end
 

--- a/src/app/learnocaml_description_main.ml
+++ b/src/app/learnocaml_description_main.ml
@@ -1,3 +1,4 @@
+open Js_of_ocaml
 open Js_utils
 open Lwt.Infix
 open Learnocaml_common
@@ -36,7 +37,7 @@ let () =
          (* display exercise questions *)
          let text_iframe = Dom_html.createIframe Dom_html.document in
          Manip.replaceChildren text_container
-           Tyxml_js.Html5.[ h1 [ pcdata ex_meta.title ] ;
+           Tyxml_js.Html5.[ h1 [ txt ex_meta.title ] ;
                             Tyxml_js.Of_dom.of_iFrame text_iframe ] ;
          Js.Opt.case
            (text_iframe##.contentDocument)
@@ -51,4 +52,4 @@ let () =
      with Not_found ->
        Lwt.return @@
          Manip.replaceChildren text_container
-           Tyxml_js.Html5.[ h1 [ pcdata "Error: Missing token" ] ]
+           Tyxml_js.Html5.[ h1 [ txt "Error: Missing token" ] ]

--- a/src/app/learnocaml_exercise_main.ml
+++ b/src/app/learnocaml_exercise_main.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Js_utils
 open Lwt.Infix
 open Learnocaml_common
@@ -26,7 +27,7 @@ let check_if_need_refresh () =
     and refresh () = Dom_html.window##.location##reload
     and cancel_label = [%i "I will do it myself!"]
     and message = [%i "The server has been updated, please refresh the page to make sure you are using the latest version of Learn-OCaml server (none of your work will be lost)."] in
-    let contents = [ H.p [H.pcdata (String.trim message) ] ] in
+    let contents = [ H.p [H.txt (String.trim message) ] ] in
   confirm ~title ~ok_label ~cancel_label contents refresh
 
 let get_grade =
@@ -48,17 +49,17 @@ let display_report exo report =
   if grade >= 100 then begin
     Manip.addClass report_button "success" ;
     Manip.replaceChildren report_button
-      Tyxml_js.Html5.[ pcdata [%i"Report"] ]
+      Tyxml_js.Html5.[ txt [%i"Report"] ]
   end else if grade = 0 then begin
     Manip.addClass report_button "failure" ;
     Manip.replaceChildren report_button
-      Tyxml_js.Html5.[ pcdata [%i"Report"] ]
+      Tyxml_js.Html5.[ txt [%i"Report"] ]
   end else begin
     Manip.addClass report_button "partial" ;
     let pct = Format.asprintf "%2d%%" grade in
     Manip.replaceChildren report_button
-      Tyxml_js.Html5.[ pcdata [%i"Report"] ;
-                       span ~a: [ a_class [ "score" ] ] [ pcdata pct ]]
+      Tyxml_js.Html5.[ txt [%i"Report"] ;
+                       span ~a: [ a_class [ "score" ] ] [ txt pct ]]
   end ;
   let report_container = find_component "learnocaml-exo-tab-report" in
   Manip.setInnerHtml report_container
@@ -169,7 +170,7 @@ let () =
   let text_container = find_component "learnocaml-exo-tab-text" in
   let text_iframe = Dom_html.createIframe Dom_html.document in
   Manip.replaceChildren text_container
-    Tyxml_js.Html5.[ h1 [ pcdata ex_meta.Exercise.Meta.title ] ;
+    Tyxml_js.Html5.[ h1 [ txt ex_meta.Exercise.Meta.title ] ;
                      Tyxml_js.Of_dom.of_iFrame text_iframe ] ;
   (* ---- editor pane --------------------------------------------------- *)
   let editor, ace = setup_editor solution in
@@ -199,7 +200,7 @@ let () =
   end ;
   let messages = Tyxml_js.Html5.ul [] in
   let callback text =
-    Manip.appendChild messages Tyxml_js.Html5.(li [ pcdata text ]) in
+    Manip.appendChild messages Tyxml_js.Html5.(li [ txt text ]) in
   let worker =
     ref (get_grade ~callback exo)
   in
@@ -213,17 +214,17 @@ let () =
     >>= fun () ->
     let aborted, abort_message =
       let t, u = Lwt.task () in
-      let btn = Tyxml_js.Html5.(button [ pcdata [%i"abort"] ]) in
+      let btn = Tyxml_js.Html5.(button [ txt [%i"abort"] ]) in
       Manip.Ev.onclick btn (fun _ -> Lwt.wakeup u () ; true) ;
       let div =
         Tyxml_js.Html5.(div ~a: [ a_class [ "dialog" ] ]
-                          [ pcdata [%i"Grading is taking a lot of time, "] ;
+                          [ txt [%i"Grading is taking a lot of time, "] ;
                             btn ;
-                            pcdata " ?" ]) in
+                            txt " ?" ]) in
       Manip.SetCss.opacity div (Some "0") ;
       t, div in
     Manip.replaceChildren messages
-      Tyxml_js.Html5.[ li [ pcdata [%i"Launching the grader"] ] ] ;
+      Tyxml_js.Html5.[ li [ txt [%i"Launching the grader"] ] ] ;
     let submit_report = not !is_readonly in (* Don't count the grading time *)
     show_loading ~id:"learnocaml-exo-loading" [ messages ; abort_message ]
     @@ fun () ->

--- a/src/app/learnocaml_index_main.ml
+++ b/src/app/learnocaml_index_main.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Js_utils
 open Lwt
 open Learnocaml_data
@@ -58,7 +59,7 @@ module El = struct
   end
 end
 
-let show_loading msg = show_loading ~id:El.loading_id H.[ul [li [pcdata msg]]]
+let show_loading msg = show_loading ~id:El.loading_id H.[ul [li [txt msg]]]
 
 let exercises_tab token _ _ () =
   show_loading [%i"Loading exercises"] @@ fun () ->
@@ -109,22 +110,22 @@ let exercises_tab token _ _ () =
               a ~a:[ a_href ("/exercises/" ^ Url.urlencode exercise_id ^ "/") ;
                      a_class [ "exercise" ] ] [
                 div ~a:[ a_class [ "descr" ] ] (
-                  h1 [ pcdata title ] ::
+                  h1 [ txt title ] ::
                   begin match short_description with
                     | None -> []
-                    | Some text -> [ pcdata text ]
+                    | Some text -> [ txt text ]
                   end
                 );
-                div ~a:[ a_class [ "time-left" ] ] [H.pcdata time_left];
+                div ~a:[ a_class [ "time-left" ] ] [H.txt time_left];
                 div ~a:[ Tyxml_js.R.Html5.a_class status_classes_signal ] [
                   stars_div stars;
                   div ~a:[ a_class [ "length" ] ] [
                     match kind with
-                    | Exercise.Meta.Project -> pcdata [%i"project"]
-                    | Exercise.Meta.Problem -> pcdata [%i"problem"]
-                    | Exercise.Meta.Exercise -> pcdata [%i"exercise"] ] ;
+                    | Exercise.Meta.Project -> txt [%i"project"]
+                    | Exercise.Meta.Problem -> txt [%i"problem"]
+                    | Exercise.Meta.Exercise -> txt [%i"exercise"] ] ;
                   div ~a:[ a_class [ "score" ] ] [
-                    Tyxml_js.R.Html5.pcdata pct_text_signal
+                    Tyxml_js.R.Html5.txt pct_text_signal
                   ]
                 ] ] ::
               acc)
@@ -134,7 +135,7 @@ let exercises_tab token _ _ () =
           List.fold_left
             (fun acc (_, Exercise.Index.{ title ; contents }) ->
                format_contents (succ lvl)
-                 (h ~a:[ a_class [ "pack" ] ] [ pcdata title ] :: acc)
+                 (h ~a:[ a_class [ "pack" ] ] [ txt title ] :: acc)
                  contents)
             acc groups in
     List.rev (format_contents 1 [] index) in
@@ -142,7 +143,7 @@ let exercises_tab token _ _ () =
     match format_exercise_list
             Learnocaml_local_storage.(retrieve all_exercise_states)
     with
-    | [] -> H.div [H.pcdata [%i"No open exercises at the moment"]]
+    | [] -> H.div [H.txt [%i"No open exercises at the moment"]]
     | l -> H.div ~a:[H.a_id El.Dyn.exercise_list_id] l
   in
     Manip.appendChild El.content list_div;
@@ -161,10 +162,10 @@ let playground_tab _ _ () =
       a ~a:[ a_href ("/playground/" ^ Url.urlencode id ^ "/") ;
              a_class [ "exercise" ] ] [
           div ~a:[ a_class [ "descr" ] ] (
-              h1 [ pcdata title ] ::
+              h1 [ txt title ] ::
                 begin match short_description with
                 | None -> []
-                | Some text -> [ pcdata text ]
+                | Some text -> [ txt text ]
                 end
             );
         ]
@@ -187,7 +188,7 @@ let lessons_tab select (arg, set_arg, _delete_arg) () =
       (fun (lesson_id, lesson_title) ->
          lesson_id,
          Tyxml_js.Html5.
-           (option ~a: [ a_value lesson_id ] (pcdata lesson_title)))
+           (option ~a: [ a_value lesson_id ] (txt lesson_title)))
       index in
   let prev_and_next id =
     let rec loop = function
@@ -336,7 +337,7 @@ let tryocaml_tab select (arg, set_arg, _delete_arg) () =
       (fun { Tutorial.Index.name; title } ->
          name,
          H.option ~a: [ H.a_value name ]
-           (H.pcdata (extract_text_from_rich_text title)))
+           (H.txt (extract_text_from_rich_text title)))
       index in
   let selector =
     Tyxml_js.Html5.(select (snd (List.split options))) in
@@ -418,7 +419,7 @@ let tryocaml_tab select (arg, set_arg, _delete_arg) () =
                 Tyxml_js.Html5.p
                   (render_rich_text ~on_runnable_clicked text)
             | Code_block { code ; runnable } ->
-                let elt = Tyxml_js.Html.pre [ Tyxml_js.Html.pcdata code ] in
+                let elt = Tyxml_js.Html.pre [ Tyxml_js.Html.txt code ] in
                 if runnable then begin
                   Manip.addClass elt "runnable" ;
                   Manip.Ev.onclick elt (fun _ -> on_runnable_clicked code ; true)
@@ -522,9 +523,9 @@ let token_disp_div token =
 
 let show_token_dialog token =
   ext_alert ~title:[%i"Your Learn-OCaml token"] [
-    H.p [H.pcdata [%i"Your token is displayed below. It identifies you and \
+    H.p [H.txt [%i"Your token is displayed below. It identifies you and \
                       allows to share your workspace between devices."]];
-    H.p [H.pcdata [%i"Please write it down."]];
+    H.p [H.txt [%i"Please write it down."]];
     H.div ~a:[H.a_style "text-align: center;"] [token_disp_div token];
   ]
 
@@ -567,8 +568,8 @@ let init_token_dialog () =
             Lwt.return_none
         | Error e ->
             lwt_alert ~title:[%i"REQUEST ERROR"] [
-              H.p [H.pcdata [%i"Could not retrieve data from server"]];
-              H.code [H.pcdata (Server_caller.string_of_error e)];
+              H.p [H.txt [%i"Could not retrieve data from server"]];
+              H.code [H.txt (Server_caller.string_of_error e)];
             ] ~buttons:[
               [%i"Retry"], (fun () -> login_token ());
               [%i"Cancel"], (fun () -> Lwt.return_none);
@@ -673,7 +674,7 @@ let () =
     Manip.removeChildren El.content ;
     let div =
       Tyxml_js.Html5.(div ~a: [ a_class [ "placeholder" ] ])
-        Tyxml_js.Html5.[ div [ pcdata [%i"Choose an activity."] ]] in
+        Tyxml_js.Html5.[ div [ txt [%i"Choose an activity."] ]] in
     Manip.removeChildren El.content ;
     Manip.appendChild El.content div ;
     delete_arg "activity"
@@ -704,7 +705,7 @@ let () =
     Manip.removeChildren container ;
     List.map
       (fun (id, (name, callback)) ->
-         let btn = Tyxml_js.Html5.(button [ pcdata name]) in
+         let btn = Tyxml_js.Html5.(button [ txt name]) in
          let div = ref None in
          let args = ref [] in
          let rec select () =
@@ -799,7 +800,7 @@ let () =
                 a backup."])
     >|= fun s ->
     confirm ~title:[%i"Logout"] ~ok_label:[%i"Logout"]
-      [H.p [H.pcdata s];
+      [H.p [H.txt s];
        H.div ~a:[H.a_style "text-align: center;"]
          [token_disp_div (get_stored_token ())]]
       (fun () ->

--- a/src/app/learnocaml_local_storage.ml
+++ b/src/app/learnocaml_local_storage.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Learnocaml_data
 
 type 'a storage_key =

--- a/src/app/learnocaml_partition_view.ml
+++ b/src/app/learnocaml_partition_view.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Js_utils
 open Lwt
 open Learnocaml_data
@@ -35,7 +36,7 @@ let open_tok tok =
 let list_of_tok =
   List.map @@ fun x ->
     let tok = Token.to_string x in
-    H.a ~a:[H.a_onclick (fun _ -> open_tok tok)] [H.pcdata (tok ^ " ")]
+    H.a ~a:[H.a_onclick (fun _ -> open_tok tok)] [H.txt (tok ^ " ")]
 
 let rec render_tree =
   let open Asak.Wtree in
@@ -43,10 +44,10 @@ let rec render_tree =
   | Leaf xs ->
      [H.p ~a:[ H.a_onclick (fun _ ->
                    set_selected_class (Some xs); true)]
-        [H.pcdata ("Leaf with " ^ string_of_int (List.length xs) ^ " student(s)")]]
+        [H.txt ("Leaf with " ^ string_of_int (List.length xs) ^ " student(s)")]]
   | Node (f,l,r) ->
      [
-       H.p [ H.pcdata ("Node " ^ string_of_int f) ]
+       H.p [ H.txt ("Node " ^ string_of_int f) ]
      ;  H.ul [
             H.li (render_tree l)
           ; H.li (render_tree r)
@@ -62,7 +63,7 @@ let render_trees xs =
       ^ " (" ^ string_of_int (weight_of_tree List.length t) ^ " students)" in
     i+1,
     H.li
-      ( H.pcdata str
+      ( H.txt str
       :: render_tree t)
     :: acc
   in
@@ -71,7 +72,7 @@ let render_trees xs =
 let render_classes xs =
   let aux (grade,values) acc =
     let str = string_of_int grade ^ "pts :" in
-    H.p [H.pcdata str] ::
+    H.p [H.txt str] ::
       H.ul (render_trees values) ::
         acc
   in List.fold_right aux xs []
@@ -96,14 +97,14 @@ let exercises_tab part =
         part.partition_by_grade in
     string_of_int s
     ^ " codes implemented the function with the right type." in
-  H.p (H.pcdata not_graded :: list_of_tok part.not_graded)
-  :: H.p ( H.pcdata bad_type :: list_of_tok part.bad_type)
-  :: H.p [H.pcdata total_sum]
+  H.p (H.txt not_graded :: list_of_tok part.not_graded)
+  :: H.p ( H.txt bad_type :: list_of_tok part.bad_type)
+  :: H.p [H.txt total_sum]
   :: render_classes part.partition_by_grade
 
 let _class_selection_updater =
   let previous = ref None in
-  let of_repr repr = [H.code [H.pcdata repr]] in
+  let of_repr repr = [H.code [H.txt repr]] in
   let onclick p tok repr =
      H.a_onclick @@
        fun _ ->
@@ -118,7 +119,7 @@ let _class_selection_updater =
     let strtok = Token.to_string tok in
     H.li
       ~a:[ onclick p tok repr ; H.a_ondblclick (fun _ -> open_tok strtok)]
-      [H.pcdata strtok; p] in
+      [H.txt strtok; p] in
   let mkfirst (tok,repr) =
     let p =  H.p (of_repr repr) in
     previous := Some p;

--- a/src/app/learnocaml_playground_main.ml
+++ b/src/app/learnocaml_playground_main.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Js_utils
 open Lwt.Infix
 open Learnocaml_common

--- a/src/app/learnocaml_student_view.ml
+++ b/src/app/learnocaml_student_view.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Js_utils
 open Lwt
 open Learnocaml_data
@@ -143,22 +144,22 @@ let exercises_tab assignments answers =
                 H.a_onclick (fun _ ->
                     set_selected_exercise (Some id);
                     true) ] [
-        H.td ~a:[ H.a_class ["exercise-id"] ] [ H.pcdata id ];
+        H.td ~a:[ H.a_class ["exercise-id"] ] [ H.txt id ];
         H.td ~a:[ H.a_class ["exercise-title"] ]
-          [ H.pcdata meta.Exercise.Meta.title ];
+          [ H.txt meta.Exercise.Meta.title ];
         H.td ~a:[ H.a_class ["exercise-kind"] ] [
-          H.pcdata (string_of_exercise_kind meta.Exercise.Meta.kind);
+          H.txt (string_of_exercise_kind meta.Exercise.Meta.kind);
         ];
         H.td ~a:[ H.a_class ["exercise-stars"] ]
           [ stars_div meta.Exercise.Meta.stars ];
         H.td ~a:[ H.a_class ["grade"]; grade_sty grade ] [
           match grade with
-          | None -> H.pcdata ""
-          | Some g -> H.pcdata (Printf.sprintf "%d%%" g)
+          | None -> H.txt ""
+          | Some g -> H.txt (Printf.sprintf "%d%%" g)
         ];
         H.td ~a:[ H.a_class ["last-updated"] ] [
           match mtime with
-          | None -> H.pcdata ""
+          | None -> H.txt ""
           | Some t -> date ~time:true t
         ];
       ]
@@ -208,30 +209,30 @@ let exercises_tab assignments answers =
         let text =
           match assg with
           | Some (start, _) when start > now ->
-              [H.pcdata [%i"Future assignment (starting "];
+              [H.txt [%i"Future assignment (starting "];
                date start;
-               H.pcdata ")"]
+               H.txt ")"]
           | Some (_, stop) when stop < now ->
-              [H.pcdata [%i"Terminated assignment ("];
+              [H.txt [%i"Terminated assignment ("];
                date stop;
-               H.pcdata ")"]
+               H.txt ")"]
           | Some (_, stop) ->
-              [H.pcdata [%i"Ongoing assignment (due "];
+              [H.txt [%i"Ongoing assignment (due "];
                date stop;
-               H.pcdata ")"]
+               H.txt ")"]
           | None ->
-              [H.pcdata [%i"Open exercises"]];
+              [H.txt [%i"Open exercises"]];
         in
         H.tr ~a:[ H.a_class ["learnocaml-assignment-line"];
                   grade_sty (Some (int_of_float avg_grade)) ] [
           H.th ~a:[ H.a_scope `Rowgroup; H.a_colspan 4 ] text;
           H.th ~a:[ H.a_scope `Rowgroup;
                     H.a_class ["grade"] ] [
-            H.pcdata (Printf.sprintf "%01.1f%%" avg_grade)
+            H.txt (Printf.sprintf "%01.1f%%" avg_grade)
           ];
           H.th ~a:[ H.a_scope `Rowgroup;
                     H.a_class ["last-updated"] ] [
-            match mtime with Some t -> date ~time:true t | None -> H.pcdata "";
+            match mtime with Some t -> date ~time:true t | None -> H.txt "";
           ];
         ] ::
         lines,
@@ -240,7 +241,7 @@ let exercises_tab assignments answers =
       assignments
   in
   match assg_lines with
-  | [] -> Lwt.return (H.pcdata "No assigned or open exercises found", None)
+  | [] -> Lwt.return (H.txt "No assigned or open exercises found", None)
   | lines ->
       let lines, sighandlers = List.split lines in
       Lwt.return (H.table (List.concat lines), Some sighandlers)
@@ -276,7 +277,7 @@ let stats_tab assignments answers =
       (0, 0, 0, SMap.empty, SMap.empty)
       assignments
   in
-  let item ?(indent=0) ?(fmt = H.pcdata) lbl title v =
+  let item ?(indent=0) ?(fmt = H.txt) lbl title v =
     H.tr ~a:[H.a_title title] [
       H.td ~a:[H.a_class ["stats-label"];
                H.a_style ("padding-left:"^string_of_int (indent * 8)^"px")]
@@ -288,7 +289,7 @@ let stats_tab assignments answers =
     let cls = H.a_class ["grade"; "stats-pct"] in
     if y = 0 then
       H.div ~a:[cls; H.a_style ("background-color:"^grade_color None)]
-        [H.pcdata "--%"]
+        [H.txt "--%"]
     else
     let r = 100. *. float_of_int x /. float_of_int y in
     let color = grade_color (Some (int_of_float r)) in
@@ -299,9 +300,9 @@ let stats_tab assignments answers =
     in
     H.div ~a:[H.a_class ["grade"; "stats-pct"];
                H.a_style background]
-      [H.pcdata (Printf.sprintf "%02.1f%%" r)]
+      [H.txt (Printf.sprintf "%02.1f%%" r)]
   in [
-    H.h3 [H.pcdata [%i"Student stats"]];
+    H.h3 [H.txt [%i"Student stats"]];
     H.table ~a:[H.a_class ["student-stats"]] begin
       [
         item [%i"completion"]
@@ -317,7 +318,7 @@ let stats_tab assignments answers =
       @
       (if SMap.is_empty by_focus then [] else
        H.tr [H.th ~a:[H.a_colspan 2]
-               [H.pcdata [%i"success over exercises training skills"]]] ::
+               [H.txt [%i"success over exercises training skills"]]] ::
        List.map (fun (sk, (tot, count)) ->
            let i =
              item ~indent:1 ~fmt:tag_span sk
@@ -331,7 +332,7 @@ let stats_tab assignments answers =
       @
       (if SMap.is_empty by_prereq then [] else
        H.tr [H.th ~a:[H.a_colspan 2]
-               [H.pcdata [%i"success over exercises requiring skills"]]] ::
+               [H.txt [%i"success over exercises requiring skills"]]] ::
        List.map (fun (sk, (tot, count)) ->
            let i =
              item ~indent:1 ~fmt:tag_span sk
@@ -378,7 +379,7 @@ let restore_report_button () =
   Manip.removeClass report_button "failure";
   Manip.removeClass report_button "partial";
   Manip.replaceChildren report_button
-    Tyxml_js.Html5.[ pcdata [%i"Report"] ]
+    Tyxml_js.Html5.[ txt [%i"Report"] ]
 
 let display_report exo report =
   let score, _failed = Report.result report in
@@ -391,17 +392,17 @@ let display_report exo report =
   if grade >= 100 then begin
     Manip.addClass report_button "success" ;
     Manip.replaceChildren report_button
-      Tyxml_js.Html5.[ pcdata [%i"Report"] ]
+      Tyxml_js.Html5.[ txt [%i"Report"] ]
   end else if grade = 0 then begin
     Manip.addClass report_button "failure" ;
     Manip.replaceChildren report_button
-      Tyxml_js.Html5.[ pcdata [%i"Report"] ]
+      Tyxml_js.Html5.[ txt [%i"Report"] ]
   end else begin
     Manip.addClass report_button "partial" ;
     let pct = Format.asprintf "%2d%%" grade in
     Manip.replaceChildren report_button
-      Tyxml_js.Html5.[ pcdata [%i"Report"] ;
-                       span ~a: [ a_class [ "score" ] ] [ pcdata pct ]]
+      Tyxml_js.Html5.[ txt [%i"Report"] ;
+                       span ~a: [ a_class [ "score" ] ] [ txt pct ]]
   end ;
   Manip.setInnerHtml El.Tabs.(report.tab)
     (Format.asprintf "%a" Report.(output_html ~bare: true) report) ;
@@ -419,7 +420,7 @@ let clear_tabs () =
 let update_text_tab meta exo =
   let text_iframe = Dom_html.createIframe Dom_html.document in
   Manip.replaceChildren El.Tabs.(text.tab) [
-    H.h1 [H.pcdata meta.Exercise.Meta.title];
+    H.h1 [H.txt meta.Exercise.Meta.title];
     Tyxml_js.Of_dom.of_iFrame text_iframe
   ];
   Js.Opt.case
@@ -438,11 +439,11 @@ let update_report_tab exo ans =
        | Some g when g <> grade ->
            Manip.appendChildFirst El.Tabs.(report.tab)
              (H.div ~a:[H.a_class ["warning"]]
-                [H.pcdata [%i"GRADE DOESN'T MATCH: cheating suspected"]])
+                [H.txt [%i"GRADE DOESN'T MATCH: cheating suspected"]])
        | _ -> ())
   | None ->
       Manip.replaceChildren El.Tabs.(report.tab)
-        [H.div [H.pcdata [%i"No report available"]]]
+        [H.div [H.txt [%i"No report available"]]]
 
 let update_tabs meta exo ans =
   update_text_tab meta exo;

--- a/src/app/learnocaml_teacher_tab.ml
+++ b/src/app/learnocaml_teacher_tab.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Js_utils
 open Lwt
 open Learnocaml_data
@@ -35,7 +36,7 @@ let filter_input input_id list_id apply_fun =
           apply_fun "";
           true);
     ]
-      [H.pcdata "\xe2\x9c\x96" (* U+2716 heavy multiplication x *)];
+      [H.txt "\xe2\x9c\x96" (* U+2716 heavy multiplication x *)];
   ]
 
 let tag_addremove list_id placeholder add_fun remove_fun =
@@ -57,13 +58,13 @@ let tag_addremove list_id placeholder add_fun remove_fun =
       H.a_onclick (fun _ev ->
           add_fun (get_input_list ());
           true)
-    ] [ H.pcdata "\xe2\x9e\x95" (* U+2795 heavy plus sign *) ];
+    ] [ H.txt "\xe2\x9e\x95" (* U+2795 heavy plus sign *) ];
     H.button ~a:[
       H.a_class ["addremove"];
       H.a_onclick (fun _ev ->
           remove_fun (get_input_list ());
           true);
-    ] [ H.pcdata "\xe2\x9e\x96" (* U+2796 heavy minus sign *) ];
+    ] [ H.txt "\xe2\x9e\x96" (* U+2796 heavy minus sign *) ];
   ]
 
 let rec teacher_tab token _select _params () =
@@ -196,7 +197,7 @@ let rec teacher_tab token _select _params () =
               ] [
                 H.td [];
                 H.th ~a:[H.a_colspan 10; indent_style group_level]
-                  [H.pcdata g.Exercise.Index.title];
+                  [H.txt g.Exercise.Index.title];
               ] :: acc
             in
             mk_table (group_level + 1) acc status g.Exercise.Index.contents)
@@ -210,7 +211,7 @@ let rec teacher_tab token _select _params () =
             let open_partition_ () =
               Lwt.async (fun () ->
                 ask_string ~title:"Choose a function name"
-                  [H.pcdata @@ "Choose a function name to partition codes from "^ id ^": "]
+                  [H.txt @@ "Choose a function name to partition codes from "^ id ^": "]
                 >|= fun funname ->
                 let _win =
                   window_open
@@ -238,11 +239,11 @@ let rec teacher_tab token _select _params () =
             ] [
               auto_checkbox_td ();
               H.td ~a:[indent_style group_level]
-                [ H.pcdata meta.Exercise.Meta.title ];
+                [ H.txt meta.Exercise.Meta.title ];
               H.td ~a:[H.a_class ["skills-prereq"]]
                 (List.map tag_span skills_prereq @
                  if skills_prereq <> [] || skills_focus <> []
-                 then [H.pcdata "\xe2\x87\xa2"]
+                 then [H.txt "\xe2\x87\xa2"]
                  (* U+21E2, rightwards dashed arrow *)
                  else []);
               H.td ~a:[H.a_class ["skills-focus"]]
@@ -257,7 +258,7 @@ let rec teacher_tab token _select _params () =
                     | ES.Assigned _ -> "exo_assigned", [%i"Assigned"]
                   else "exo_assigned", [%i"Assigned"]
                 in
-                H.span ~a:[H.a_class [cls]] [H.pcdata text]
+                H.span ~a:[H.a_class [cls]] [H.txt text]
               ];
             ] :: acc)
           acc exlist
@@ -315,7 +316,7 @@ let rec teacher_tab token _select _params () =
       !toggle_selected_exercises ~force:false ~update:true hidden
   in
   let exercises_list_div =
-    H.div ~a:[H.a_id "exercises_list"] [H.pcdata [%i"Loading..."]]
+    H.div ~a:[H.a_id "exercises_list"] [H.txt [%i"Loading..."]]
   in
   let exercise_skills_list_id = "exercise_skills_list" in
   let exercises_div =
@@ -324,7 +325,7 @@ let rec teacher_tab token _select _params () =
         H.a_onclick (fun _ ->
             !toggle_selected_exercises (all_exercises !exercises_index);
             true);
-      ] [H.pcdata [%i"Exercises"]; H.pcdata " \xe2\x98\x90" (* U+2610 *)]
+      ] [H.txt [%i"Exercises"]; H.txt " \xe2\x98\x90" (* U+2610 *)]
     in
     H.div ~a:[H.a_id "exercises_pane"; H.a_class ["learnocaml_pane"]] [
       H.div ~a:[H.a_id "exercises_filter_box"] [
@@ -335,7 +336,7 @@ let rec teacher_tab token _select _params () =
     ]
   in
   let students_list_div =
-    H.div ~a:[H.a_id "students_list"] [H.pcdata [%i"Loading..."]];
+    H.div ~a:[H.a_id "students_list"] [H.txt [%i"Loading..."]];
   in
   let student_tags_list_id = "student_tags_list" in
   let sort_type = [`Nick; `Token; `Date; `Tags] in
@@ -357,7 +358,7 @@ let rec teacher_tab token _select _params () =
   in
   let html_token tk =
     H.span ~a:[H.a_class ["learnocaml_token"]]
-      [H.pcdata (Token.to_string tk)]
+      [H.txt (Token.to_string tk)]
   in
   let make_student_line ?(selected=false) st contents =
     let open_student_tab =
@@ -389,7 +390,7 @@ let rec teacher_tab token _select _params () =
   let anystudents_line =
     make_student_line `Any [
       H.td ~a:[H.a_colspan 10; H.a_class ["future_students"]] [
-        H.pcdata [%i"any future students"]
+        H.txt [%i"any future students"]
       ];
     ]
   in
@@ -435,7 +436,7 @@ let rec teacher_tab token _select _params () =
             (`Token  st.Student.token) [
             H.td [html_token st.Student.token];
             H.td (match st.Student.nickname with
-                | Some n -> [H.pcdata n]
+                | Some n -> [H.txt n]
                 | _ -> []);
             H.td (List.map tag_span (SSet.elements st.Student.tags));
             try find_component (student_progression_id st.Student.token)
@@ -453,7 +454,7 @@ let rec teacher_tab token _select _params () =
     Manip.replaceSelf (find_component student_tags_list_id)
       (H.datalist ~a:[H.a_id student_tags_list_id] ~children:(
           `Options
-            (SSet.fold (fun tag acc -> H.option (H.pcdata tag) :: acc)
+            (SSet.fold (fun tag acc -> H.option (H.txt tag) :: acc)
                !all_student_tags []
             ))
           ())
@@ -537,8 +538,8 @@ let rec teacher_tab token _select _params () =
             !toggle_selected_students all;
             true
           );
-      ] [H.pcdata [%i"Students"];
-         H.pcdata " \xe2\x98\x90" (* U+2610 ballot box *)]
+      ] [H.txt [%i"Students"];
+         H.txt " \xe2\x98\x90" (* U+2610 ballot box *)]
     in
     H.div ~a:[H.a_id "students_pane"; H.a_class ["learnocaml_pane"]] [
       H.div ~a:[H.a_id "students_filter_box"] [
@@ -547,19 +548,19 @@ let rec teacher_tab token _select _params () =
           student_tags_list_id set_student_filtering;
         H.div ~a:[H.a_class ["filler_h"]] [];
         H.label ~a:[H.a_label_for "student_sort"]
-          [H.pcdata [%i"Sort by"]];
+          [H.txt [%i"Sort by"]];
         H.select ~a:[
           H.a_id "student_sort";
           H.a_oninput (fun _ev -> fill_students_pane (); true);
         ] [
           H.option ~a:[H.a_value (sort_to_str `Nick); H.a_selected ()]
-            (H.pcdata [%i"Nickname"]);
+            (H.txt [%i"Nickname"]);
           H.option ~a:[H.a_value (sort_to_str `Token)]
-            (H.pcdata [%i"Token"]);
+            (H.txt [%i"Token"]);
           H.option ~a:[H.a_value (sort_to_str `Date)]
-            (H.pcdata [%i"Creation date"]);
+            (H.txt [%i"Creation date"]);
           H.option ~a:[H.a_value (sort_to_str `Tags)]
-            (H.pcdata [%i"Tags"]);
+            (H.txt [%i"Tags"]);
         ]
       ];
       H.fieldset ~legend [ students_list_div ];
@@ -586,7 +587,7 @@ let rec teacher_tab token _select _params () =
     Manip.replaceSelf (find_component exercise_skills_list_id)
       (H.datalist ~a:[H.a_id exercise_skills_list_id] ~children:(
           `Options
-            (SSet.fold (fun skill acc -> H.option (H.pcdata skill) :: acc)
+            (SSet.fold (fun skill acc -> H.option (H.txt skill) :: acc)
                !all_exercise_skills []
             ))
           ());
@@ -661,11 +662,11 @@ let rec teacher_tab token _select _params () =
     ] [
       H.td [date ("start_"^hid) id start];
       H.td [date ("stop_"^hid) id stop];
-      H.td [H.pcdata n_exos];
-      H.td [H.pcdata n_students];
+      H.td [H.txt n_exos];
+      H.td [H.txt n_students];
       H.td ~a:[H.a_onclick (fun _ -> !assignment_remove id; false);
                H.a_class ["remove-cross"]]
-        [H.pcdata "\xe2\x9c\x96" (* U+2716 heavy multiplication x *)];
+        [H.txt "\xe2\x9c\x96" (* U+2716 heavy multiplication x *)];
       (* todo: add common tags *)
     ]
   in
@@ -713,7 +714,7 @@ let rec teacher_tab token _select _params () =
       assignment_line id
     in
     let new_assg_id = "new_assignment" in
-    let new_assg_button = H.button [H.pcdata [%i"New assignment"]] in
+    let new_assg_button = H.button [H.txt [%i"New assignment"]] in
     let table = H.table [] in
     let new_assg_line =
       H.tr ~a:[
@@ -816,7 +817,7 @@ let rec teacher_tab token _select _params () =
           in
           !exercise_status_change (htbl_keys selected_exercises) fstat;
           true)
-    ] [H.pcdata [%i"Open/Close"]];
+    ] [H.txt [%i"Open/Close"]];
   in
   let exercise_control_div =
     H.div ~a:[H.a_id "exercise_controls"] [
@@ -825,7 +826,7 @@ let rec teacher_tab token _select _params () =
       tag_addremove exercise_skills_list_id [%i"required skills"]
         (add_requirements) (remove_requirements);
       H.div ~a:[H.a_id "skills-arrow"]
-        [H.pcdata "\xe2\x87\xa2"]; (* U+21E2, rightwards dashed arrow *)
+        [H.txt "\xe2\x87\xa2"]; (* U+21E2, rightwards dashed arrow *)
       tag_addremove exercise_skills_list_id [%i"trained skills"]
         (add_focus) (remove_focus);
     ]
@@ -835,7 +836,7 @@ let rec teacher_tab token _select _params () =
   let control_div =
     H.div ~a:[H.a_id "control_pane"] [
       H.fieldset
-        ~legend:(H.legend [H.pcdata [%i"Assignments"]])
+        ~legend:(H.legend [H.txt [%i"Assignments"]])
         [assignments_div];
     ]
   in
@@ -918,13 +919,13 @@ let rec teacher_tab token _select _params () =
         H.a_id "button_apply";
         (* H.a_disabled (); *)
         H.a_onclick (fun _ -> apply_changes (); true);
-      ] [H.pcdata [%i"Apply"]];
-      dropdown ~id:"teacher-actions" ~title:[H.pcdata [%i"Actions"]] [
+      ] [H.txt [%i"Apply"]];
+      dropdown ~id:"teacher-actions" ~title:[H.txt [%i"Actions"]] [
         H.ul [
           H.li ~a: [ H.a_onclick (fun _ -> Lwt.async action_new_token; true) ]
-            [ H.pcdata [%i"Create new teacher token"] ];
+            [ H.txt [%i"Create new teacher token"] ];
           H.li ~a: [ H.a_onclick (fun _ -> Lwt.async action_csv_export; true) ]
-            [ H.pcdata [%i"Download student data as CSV"] ];
+            [ H.txt [%i"Download student data as CSV"] ];
         ]
       ];
     ]
@@ -1096,7 +1097,7 @@ let rec teacher_tab token _select _params () =
       (Manip.replaceChildren status_text_div [];
        Manip.removeClass status_text_div "warning")
     else
-      (Manip.replaceChildren status_text_div [H.pcdata [%i"Unsaved changes"]];
+      (Manip.replaceChildren status_text_div [H.txt [%i"Unsaved changes"]];
        Manip.addClass status_text_div "warning")
   end;
   toggle_selected_exercises := begin

--- a/src/app/server_caller.ml
+++ b/src/app/server_caller.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Lwt.Infix
 
 (*

--- a/src/grader/dune
+++ b/src/grader/dune
@@ -9,7 +9,7 @@
 
 (rule
  (targets learnocaml_report.odoc)
- (deps .learnocaml_report.objs/learnocaml_report.cmti)
+ (deps .learnocaml_report.objs/byte/learnocaml_report.cmti)
  (action (run odoc compile --package learn-ocaml %{deps} -o %{targets}))
 )
 
@@ -35,12 +35,12 @@
 
 (rule
  (targets test_lib.odoc)
- (deps .testing.objs/test_lib.cmti)
+ (deps .testing.objs/byte/test_lib.cmti)
  (action (run odoc compile --package learn-ocaml %{deps} -o %{targets}))
 )
 
-(rule
- (alias doc)
+(alias
+ (name doc)
  (action (progn (run mkdir -p doc)
                 (run odoc html %{dep:learnocaml_report.odoc} -o %{workspace_root}/_doc/_html)
                 (run odoc html %{dep:test_lib.odoc} -o %{workspace_root}/_doc/_html)))

--- a/src/grader/dune
+++ b/src/grader/dune
@@ -39,8 +39,8 @@
  (action (run odoc compile --package learn-ocaml %{deps} -o %{targets}))
 )
 
-(alias
- (name doc)
+(rule
+ (alias doc)
  (action (progn (run mkdir -p doc)
                 (run odoc html %{dep:learnocaml_report.odoc} -o %{workspace_root}/_doc/_html)
                 (run odoc html %{dep:test_lib.odoc} -o %{workspace_root}/_doc/_html)))
@@ -106,12 +106,12 @@
         %{ocaml-config:standard_library}/compiler-libs/location.cmi
         %{ocaml-config:standard_library}/compiler-libs/parse.cmi)
        (:generated-cmis
-        ../ppx-metaquot/.ty.objs/ty.cmi
-        ../ppx-metaquot/.fun_ty.objs/fun_ty.cmi
-        .testing.objs/introspection_intf.cmi
-        .learnocaml_report.objs/learnocaml_report.cmi
-        .testing.objs/test_lib.cmi
-        .testing.objs/mutation_test.cmi))
+        ../ppx-metaquot/.ty.objs/byte/ty.cmi
+        ../ppx-metaquot/.fun_ty.objs/byte/fun_ty.cmi
+        .testing.objs/byte/introspection_intf.cmi
+        .learnocaml_report.objs/byte/learnocaml_report.cmi
+        .testing.objs/byte/test_lib.cmi
+        .testing.objs/byte/mutation_test.cmi))
  (action (with-stdout-to %{targets}
            (run ocp-ocamlres -format ocamlres %{compiler-cmis} %{generated-cmis})))
 )
@@ -131,6 +131,7 @@
           Grading)
  (preprocess (per_module ((pps ppx_ocplib_i18n learnocaml_ppx_metaquot) Grading)))
 )
+
 
 (library
  (name grading_cli)

--- a/src/grader/grader_jsoo_worker.ml
+++ b/src/grader/grader_jsoo_worker.ml
@@ -6,6 +6,8 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
+
 let get_grade ?callback exo solution =
   let path = "/grading_cmis" in
   let root =

--- a/src/grader/grading_jsoo.ml
+++ b/src/grader/grading_jsoo.ml
@@ -10,6 +10,7 @@ exception Timeout
 
 open Grader_jsoo_messages
 open Lwt.Infix
+open Js_of_ocaml
 
 let get_grade
     ?(worker_js_file = "/js/learnocaml-grader-worker.js")

--- a/src/repo/dune
+++ b/src/repo/dune
@@ -5,7 +5,7 @@
           Learnocaml_exercise)
  (libraries ocplib-json-typed
             learnocaml_xor
-	    omd
+            omd
             lwt
             ezjsonm)
 )
@@ -16,6 +16,7 @@
  (modules Learnocaml_tutorial_parser)
  (libraries learnocaml_repository
             learnocaml_data
+            lwt.unix
             markup
             omd)
 )
@@ -41,7 +42,7 @@
  (modules Learnocaml_process_common
           Learnocaml_process_exercise_repository
           Learnocaml_process_tutorial_repository
-	  Learnocaml_process_playground_repository)
+    Learnocaml_process_playground_repository)
  (libraries ezjsonm
             str
             lwt.unix

--- a/src/repo/learnocaml_tutorial_parser.ml
+++ b/src/repo/learnocaml_tutorial_parser.ml
@@ -8,7 +8,6 @@
 
 open Learnocaml_data
 open Tutorial
-
 open Lwt.Infix
 
 let lines_margin lines =

--- a/src/state/learnocaml_api.ml
+++ b/src/state/learnocaml_api.ml
@@ -339,7 +339,7 @@ module Server (Json: JSON_CODEC) (Rh: REQUEST_HANDLER) = struct
                Static ["exercise.html"] |> k
            | _ ->
               Static ("static"::path) |> k)
-      | `GET, ("description"::path), _token ->
+      | `GET, ("description"::_), _token ->
          (* match token with
           | None -> Invalid_request "Missing token" |> k *)
           Static ["description.html"] |> k

--- a/src/toplevel/learnocaml_toplevel.ml
+++ b/src/toplevel/learnocaml_toplevel.ml
@@ -262,9 +262,9 @@ let make_timeout_popup
   let countdown = ref countdown in
   let btn_continue =
     let label = Format.asprintf [%if"%d seconds!"] refill_step in
-    button [ pcdata label ] in
+    button [ txt label ] in
   let btn_stop =
-    button [ pcdata [%i"Kill it!"] ] in
+    button [ txt [%i"Kill it!"] ] in
   Manip.Ev.onclick btn_continue
     (fun _ -> countdown := !countdown + refill_step ; true) ;
   Manip.Ev.onclick btn_stop
@@ -274,15 +274,15 @@ let make_timeout_popup
   let dialog =
     div ~a: [ a_class [ "dialog-container" ] ]
       [ div ~a: [ a_class [ "dialog" ] ]
-          [ h1 [ pcdata [%i"Infinite loop?"] ] ;
+          [ h1 [ txt [%i"Infinite loop?"] ] ;
             div ~a: [ a_class [ "message" ] ]
-              [ pcdata [%i"The toplevel has not been responding for "] ;
+              [ txt [%i"The toplevel has not been responding for "] ;
                 clock_span ;
-                pcdata [%i" seconds."] ;
+                txt [%i" seconds."] ;
                 br () ;
-                pcdata [%i"It will be killed in "] ;
+                txt [%i"It will be killed in "] ;
                 countdown_span ;
-                pcdata [%i" seconds."] ] ;
+                txt [%i" seconds."] ] ;
             div ~a: [ a_class [ "buttons" ] ]
               [ btn_continue ; btn_stop ] ] ] in
   Lwt.catch
@@ -292,9 +292,9 @@ let make_timeout_popup
        let rec loop () =
          let elapsed = int_of_float (Sys.time () -. t0) in
          Manip.replaceChildren clock_span
-           [ pcdata (string_of_int elapsed) ] ;
+           [ txt (string_of_int elapsed) ] ;
          Manip.replaceChildren countdown_span
-           [ pcdata (string_of_int (!countdown - elapsed)) ] ;
+           [ txt (string_of_int (!countdown - elapsed)) ] ;
          if elapsed >= !countdown then begin
            Manip.removeChild container dialog ;
            Lwt.return ()
@@ -311,9 +311,9 @@ let make_flood_popup
   let open Tyxml_js.Html5 in
   let answer = ref None in
   let btn_continue =
-    button [ pcdata [%i"Show anyway!"] ] in
+    button [ txt [%i"Show anyway!"] ] in
   let btn_stop =
-    button [ pcdata [%i"Hide output!"] ] in
+    button [ txt [%i"Hide output!"] ] in
   Manip.Ev.onclick btn_continue
     (fun _ -> answer := Some false ; true) ;
   Manip.Ev.onclick btn_stop
@@ -322,21 +322,21 @@ let make_flood_popup
   let dialog =
     div ~a: [ a_class [ "dialog-container" ] ]
       [ div ~a: [ a_class [ "dialog" ] ]
-          [ h1 [ pcdata [%i"Flooded output!"] ] ;
+          [ h1 [ txt [%i"Flooded output!"] ] ;
             div ~a: [ a_class [ "message" ] ]
-              [ pcdata (Printf.sprintf
+              [ txt (Printf.sprintf
                           [%if"Your code is flooding the %s channel."] name) ;
                 br ();
-                pcdata [%i"It has already printed "] ;
+                txt [%i"It has already printed "] ;
                 qty_span ;
-                pcdata [%i" bytes."] ] ;
+                txt [%i" bytes."] ] ;
             div ~a: [ a_class [ "buttons" ] ]
               [ btn_continue ; btn_stop ] ] ] in
   Manip.appendChild container dialog ;
   on_show () ;
   let rec loop () =
     Manip.replaceChildren qty_span
-      [ pcdata (string_of_int (amount ())) ] ;
+      [ txt (string_of_int (amount ())) ] ;
     match !answer with
     | Some ans ->
         Manip.removeChild container dialog ;

--- a/src/toplevel/learnocaml_toplevel_input.ml
+++ b/src/toplevel/learnocaml_toplevel_input.ml
@@ -6,6 +6,8 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
+
 let indent_caml s in_lines =
   let output = {
     IndentPrinter.debug = false;

--- a/src/toplevel/learnocaml_toplevel_output.ml
+++ b/src/toplevel/learnocaml_toplevel_output.ml
@@ -6,6 +6,8 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
+
 type block =
   | Html of string * [ `Div ] Tyxml_js.Html5.elt
   | Std of (string * [ `Out | `Err ]) list ref * [ `Pre ] Tyxml_js.Html5.elt
@@ -63,9 +65,9 @@ let rec pretty_html
   List.map
     (function
       | String text ->
-          pcdata text
+          txt text
       | Ref n ->
-          span ~a: [ a_class [ "ref" ] ] [ pcdata (string_of_int n) ]
+          span ~a: [ a_class [ "ref" ] ] [ txt (string_of_int n) ]
       | Class (cls, [ Class (cls', [ Class (cls'', toks) ]) ]) ->
           span ~a: [ a_class [ cls ; cls' ; cls'' ] ] (pretty_html toks)
       | Class (cls, [ Class (cls', toks) ]) ->
@@ -161,7 +163,7 @@ let output_std ?phrase output (str, chan) =
         buf, pre in
   let cls = match chan with `Err -> "stderr" | `Out -> "stdout" in
   Js_utils.Manip.appendChild pre
-    (Tyxml_js.Html5.(span ~a: [ a_class [ cls ] ] [ pcdata str ])) ;
+    (Tyxml_js.Html5.(span ~a: [ a_class [ cls ] ] [ txt str ])) ;
   buf := (str, chan) :: !buf ;
   scroll output
 
@@ -289,7 +291,7 @@ let hilight cls output u locs lbl =
 let output_error ?phrase output error =
   let { Toploop_results.locs ; msg ; if_highlight } = error in
   let content =
-    [ Tyxml_js.Html5.pcdata
+    [ Tyxml_js.Html5.txt
         (match phrase with None -> msg | Some _ -> if_highlight) ] in
   let pre =
     Tyxml_js.Html5.(pre ~a: [ a_class [ "toplevel-error" ] ]) content in
@@ -305,7 +307,7 @@ let output_warning ?phrase output warning =
   | None, _ | _, [] ->
       let pre =
         Tyxml_js.Html5.(pre ~a: [ a_class [ "toplevel-warning" ] ]
-                          [ pcdata msg ]) in
+                          [ txt msg ]) in
       insert output ?phrase (Warning (0, warning, pre)) pre
   | Some phrase, _ ->
       phrase.warnings <- phrase.warnings + 1 ;
@@ -314,9 +316,9 @@ let output_warning ?phrase output warning =
       let pre =
         Tyxml_js.Html5.(pre ~a: [ a_class [ "toplevel-warning" ] ]
                           [ span ~a: [ a_class [ "ref" ] ]
-                              [ pcdata (string_of_int phrase.warnings) ] ;
-                            pcdata ":" ;
-                            pcdata if_highlight ]) in
+                              [ txt (string_of_int phrase.warnings) ] ;
+                            txt ":" ;
+                            txt if_highlight ]) in
       insert output ~phrase (Warning (phrase.warnings, warning, pre)) pre
 
 let clear output =

--- a/src/toplevel/learnocaml_toplevel_worker_caller.ml
+++ b/src/toplevel/learnocaml_toplevel_worker_caller.ml
@@ -6,6 +6,8 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
+
 let debug = ref false
 
 let (>>=) = Lwt.bind

--- a/src/toplevel/learnocaml_toplevel_worker_main.ml
+++ b/src/toplevel/learnocaml_toplevel_worker_main.ml
@@ -6,6 +6,7 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
 open Learnocaml_toplevel_worker_messages
 
 let debug = ref false

--- a/src/toplevel/learnocaml_toplevel_worker_messages.mli
+++ b/src/toplevel/learnocaml_toplevel_worker_messages.mli
@@ -8,6 +8,8 @@
 
 (** Types of the messages exchanged with a toplevel in a Web Worker. *)
 
+open Js_of_ocaml
+
 type _ host_msg =
   | Init : unit host_msg
   | Reset : unit host_msg

--- a/src/toploop/toploop_jsoo.ml
+++ b/src/toploop/toploop_jsoo.ml
@@ -7,6 +7,7 @@
  * included LICENSE file for details. *)
 
 open Js_of_ocaml_compiler
+open Js_of_ocaml
 
 let split_primitives p =
   let len = String.length p in

--- a/src/utils/js_utils.ml
+++ b/src/utils/js_utils.ml
@@ -1228,6 +1228,6 @@ let worker_with_code code =
   let url = Dom_html.window##._URL##createObjectURL blob in
   Worker.create (Js.to_string url)
 
-let worker url =
+let _worker url =
   let open Lwt.Infix in
   Lwt_request.get ?headers:None ~url ~args:[] >|= worker_with_code

--- a/src/utils/js_utils.ml
+++ b/src/utils/js_utils.ml
@@ -16,6 +16,8 @@
  * You should have received a copy of the GNU Library General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *)
 
+open Js_of_ocaml
+
 let doc = Dom_html.document
 let window = Dom_html.window
 (* let loc = Js.Unsafe.variable "location" *)
@@ -423,9 +425,9 @@ module Manip = struct
       elt##.onscroll := (bool_cb f)
     let onreturn elt f =
       let f ev =
-	let key = ev##.keyCode in
-	if key = 13 then f ev;
-	true in
+  let key = ev##.keyCode in
+  if key = 13 then f ev;
+  true in
       onkeydown elt f
     let onchange elt f =
       let elt = get_elt_input "Ev.onchange" elt in

--- a/src/utils/js_utils.mli
+++ b/src/utils/js_utils.mli
@@ -16,6 +16,8 @@
  * You should have received a copy of the GNU Library General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *)
 
+open Js_of_ocaml
+
 val alert: string -> unit
 val confirm: string -> bool
 

--- a/src/utils/lwt_request.ml
+++ b/src/utils/lwt_request.ml
@@ -6,6 +6,8 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+open Js_of_ocaml
+
 exception Request_failed of (int * string)
 
 let url_encode_list l =
@@ -20,7 +22,7 @@ let get ?(headers=[]) ~url ~args =
     | _ -> url ^ "?" ^ (url_encode_list args) in
   req##(_open (Js.string "GET") (Js.string url) (Js._true));
   req##(setRequestHeader (Js.string "Content-type")
-			 (Js.string "application/x-www-form-urlencoded"));
+       (Js.string "application/x-www-form-urlencoded"));
   List.iter (fun (n, v) -> req##(setRequestHeader (Js.string n) (Js.string v)))
     headers;
   let callback () =
@@ -29,11 +31,11 @@ let get ?(headers=[]) ~url ~args =
     | 204 -> Lwt.wakeup w ""
     | code (* including 0 *) ->
         Lwt.wakeup_exn w
-	        (Request_failed (code, Js.to_string req##.responseText)) in
+          (Request_failed (code, Js.to_string req##.responseText)) in
   req##.onreadystatechange := Js.wrap_callback
       (fun _ -> (match req##.readyState with
-	     XmlHttpRequest.DONE -> callback ()
-	   | _ -> ()));
+       XmlHttpRequest.DONE -> callback ()
+     | _ -> ()));
   req##(send (Js.null));
   Lwt.on_cancel res (fun () -> req##abort);
   res
@@ -46,7 +48,7 @@ let post ?(headers=[]) ?(get_args=[]) ~url ~body =
     | _ -> url ^ "?" ^ (url_encode_list get_args) in
   req##(_open (Js.string "POST") (Js.string url) (Js._true));
   req##(setRequestHeader (Js.string "Content-type")
-			 (Js.string "application/x-www-form-urlencoded"));
+       (Js.string "application/x-www-form-urlencoded"));
   List.iter (fun (n, v) -> req##(setRequestHeader (Js.string n) (Js.string v)))
     headers;
   let callback () =
@@ -54,12 +56,12 @@ let post ?(headers=[]) ?(get_args=[]) ~url ~body =
     | 200 -> Lwt.wakeup w (Js.to_string req##.responseText)
     | 204 -> Lwt.wakeup w ""
     | code (* including 0 *) -> Lwt.wakeup_exn w
-	  (Request_failed (code, Js.to_string req##.responseText))
+    (Request_failed (code, Js.to_string req##.responseText))
   in
   req##.onreadystatechange := Js.wrap_callback
       (fun _ -> (match req##.readyState with
-	     XmlHttpRequest.DONE -> callback ()
-	   | _ -> ()));
+       XmlHttpRequest.DONE -> callback ()
+     | _ -> ()));
   let body = Js.Opt.map (Js.Opt.option body) Js.string in
   req##(send body);
   Lwt.on_cancel res (fun () -> req##abort);


### PR DESCRIPTION
Hi,
this PR moves the dune-project from 1.6.3 to 1.7.
For a future feature, dune needs to support `dune lang 1.7` to allow to use `virtual_modules` stanza.


This PR changes the following things:
* dependency requirements:
  * dune must be >= dune `1.7`
  * ipaddr is fixed to `2.8.0` to avoid dependency conflicts
  *  lwt is moved to `4.0.0`
* support js_of_ocaml `3.3` and  tyxml `4.4.0` and update files to work with
* remove unused variable errors that stops the compilation with dune new version
