### PR TITLE
Update README.md & docs/index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Howtos
 * [How to write exercises?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-write-exercises.md)
 * [How to submit an exercise to the global corpus?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-submit-an-exercise.md)
 * [How to deploy an instance of Learn OCaml?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-deploy-a-learn-ocaml-instance.md)
+* [How to deploy Learn-OCaml statically?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-deploy-learn-ocaml-statically.md)
 
 Contacts
 --------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is Learn-OCaml, a platform for learning the OCaml language,
 featuring a Web toplevel, an exercise environment, and a directory of
 lessons and tutorials.
 
-A demo is available at: (http://learn-ocaml.hackojo.org/).
+A demo is available [online](https://ocaml-sf.org/learn-ocaml-public/).
 
 [![CI](https://github.com/ocaml-sf/learn-ocaml/workflows/CI/badge.svg?branch=master)](https://github.com/ocaml-sf/learn-ocaml/actions?query=workflow%3ACI)
 [![macOS](https://github.com/ocaml-sf/learn-ocaml/workflows/macOS/badge.svg?branch=master)](https://github.com/ocaml-sf/learn-ocaml/actions?query=workflow%3AmacOS)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ Howtos
 * [How to write exercises?](./howto-write-exercises.md)
 * [How to submit an exercise to the global corpus?](./howto-submit-an-exercise.md)
 * [How to deploy an instance of Learn OCaml?](./howto-deploy-a-learn-ocaml-instance.md)
+* [How to deploy Learn-OCaml statically?](./howto-deploy-learn-ocaml-statically.md)
 
 Contacts
 --------

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ This is Learn-OCaml, a platform for learning the OCaml language,
 featuring a Web toplevel, an exercise environment, and a directory of
 lessons and tutorials.
 
-A demo is available at [online](https://ocaml-sf.org/learn-ocaml-public/).
+A demo is available [online](https://ocaml-sf.org/learn-ocaml-public/).
 
 [![CI](https://github.com/ocaml-sf/learn-ocaml/workflows/CI/badge.svg?branch=master)](https://github.com/ocaml-sf/learn-ocaml/actions?query=workflow%3ACI)
 [![macOS](https://github.com/ocaml-sf/learn-ocaml/workflows/macOS/badge.svg?branch=master)](https://github.com/ocaml-sf/learn-ocaml/actions?query=workflow%3AmacOS)


### PR DESCRIPTION
Cc @yurug 

This small PR:

* updates one link in README.md
* and is a follow-up of https://github.com/ocaml-sf/learn-ocaml/pull/368 (the "static deployment" doc was not mentioned in the index)

-----

BTW, you might want to also add other links (in another PR / commit…)? as these pages are not "indexed" for the moment:

- https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-practice-ocaml.md
- https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/tutorials/step-0.md … step-9.md
- https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/exercises_tests.md

(but regarding [docs/exercises_format.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/exercises_format.md) : it is already mentioned in [step-0.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/tutorials/step-0.md))