### PR TITLE
Update step-3.md: markup error in http://ocaml-sf.org/learn-ocaml/tutorials/step-3.html

### DIFF
--- a/docs/tutorials/step-3.md
+++ b/docs/tutorials/step-3.md
@@ -84,7 +84,7 @@ let exercise_3 =
   `exercises/advanced-examples-step-3` directory (branch: step-3).
 
 There is nothing new to learn in this part, there are only more
-examples of how to build a sampler for more complexed types. In
+examples of how to build a sampler for more complexe types. In
 particular, there are examples with:
 
 * list
@@ -104,7 +104,6 @@ let exercise_2 =
     ~sampler:(fun () -> (Random.int 10, Random.int 10))
     []
 ```
-
 * type option
 ```ocaml
 let exercise_3 =
@@ -124,9 +123,7 @@ let exercise_4 =
     ~sampler:sampler_4
     []
 ```
-
 * functional type
-
 ```ocaml
 let sampler_5 () =
   let sampler_f () = match Random.int 3 with
@@ -144,9 +141,7 @@ let exercise_5 =
     []
 
 ```
-
 * array
-
 ```ocaml
 let sampler_6 =
   sample_array ~min_size:1 ~max_size:10 sample_int
@@ -158,7 +153,3 @@ let exercise_6 =
     ~sampler:sampler_6
     []
 ```
-
-
-
-


### PR DESCRIPTION
Hello there,
I just discovered this amazing project, and I'm reading the documentation.
Congrats everybody for this really great project :clap:!

On http://ocaml-sf.org/learn-ocaml/tutorials/step-3.html there is an error on line
    type option ```ocam
![Capture d’écran_2021-02-17_08-39-03](https://user-images.githubusercontent.com/11994719/108171994-8cb9fa00-70fc-11eb-9726-77045ebb945c.png)

I'm no sure if this PR fixes it though, I didn't understand why the markup could be wrong.

Regards, -- @Naereen