### PR TITLE
fix: runtime error in docker packaging

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - '**'
+  schedule:
+    # test master every Saturday at 08:00 UTC
+    - cron: '0 8 * * 6'
 
 jobs:
   build_test_server:

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # deploy master every Saturday at 08:00 UTC
+    - cron: '0 8 * * 6'
 jobs:
   push_server:
     name: Push learn-ocaml image to Docker Hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam2:alpine-3.7 as compilation
+FROM ocaml/opam:alpine-3.13-ocaml-4.05 as compilation
 LABEL Description="learn-ocaml building" Vendor="OCamlPro"
 
 WORKDIR learn-ocaml
@@ -28,7 +28,7 @@ RUN cat /proc/cpuinfo /proc/meminfo
 RUN opam install . --destdir /home/opam/install-prefix --locked
 
 
-FROM alpine:3.7 as client
+FROM alpine:3.13 as client
 
 RUN apk update \
   && apk add ncurses-libs libev dumb-init openssl \
@@ -50,7 +50,7 @@ LABEL org.opencontainers.image.url="https://ocaml-sf.org/"
 LABEL org.opencontainers.image.vendor="The OCaml Software Foundation"
 
 
-FROM alpine:3.7 as program
+FROM alpine:3.13 as program
 
 RUN apk update \
   && apk add ncurses-libs libev dumb-init git openssl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN opam install . --destdir /home/opam/install-prefix --locked
 FROM alpine:3.7 as client
 
 RUN apk update \
-  && apk add ncurses-libs libev dumb-init \
+  && apk add ncurses-libs libev dumb-init openssl \
   && addgroup learn-ocaml \
   && adduser learn-ocaml -DG learn-ocaml
 
@@ -53,7 +53,7 @@ LABEL org.opencontainers.image.vendor="The OCaml Software Foundation"
 FROM alpine:3.7 as program
 
 RUN apk update \
-  && apk add ncurses-libs libev dumb-init git \
+  && apk add ncurses-libs libev dumb-init git openssl \
   && addgroup learn-ocaml \
   && adduser learn-ocaml -DG learn-ocaml
 

--- a/Dockerfile.test-client
+++ b/Dockerfile.test-client
@@ -51,7 +51,7 @@ LABEL org.label-schema.build-date="${BUILD_DATE}" \
   org.label-schema.schema-version="1.0"
 
 RUN apk update \
-  && apk add ncurses-libs libev dumb-init \
+  && apk add ncurses-libs libev dumb-init openssl \
   && addgroup learn-ocaml \
   && adduser learn-ocaml -DG learn-ocaml
 

--- a/Dockerfile.test-client
+++ b/Dockerfile.test-client
@@ -1,7 +1,7 @@
 # This Dockerfile is useful for testing purposes
 # to ensure learn-ocaml-client can be built alone from learn-ocaml-client.opam
 
-FROM ocaml/opam2:alpine-3.7 as compilation
+FROM ocaml/opam:alpine-3.13-ocaml-4.05 as compilation
 LABEL Description="learn-ocaml building" Vendor="OCamlPro"
 
 WORKDIR learn-ocaml
@@ -34,7 +34,7 @@ RUN opam install learn-ocaml-client --destdir /home/opam/install-prefix \
   && ls -l /home/opam/install-prefix/bin/learn-ocaml-client
 
 
-FROM alpine:3.7 as client
+FROM alpine:3.13 as client
 
 ARG BUILD_DATE
 ARG VCS_BRANCH


### PR DESCRIPTION
Hi @yurug,

This PR (that makes some alpine dependency explicit) should fix the issue currently observed with the [CI build of branch master](https://github.com/ocaml-sf/learn-ocaml/actions/runs/574189523).

 feel free to merge it if the CI passes anew.

### Details

* Add missing Alpine package
  href: https://pkgs.alpinelinux.org/package/v3.7/main/x86_64/openssl

* Avoid runtime errors:
  Error loading shared library libssl.so.1.0.0: No such file or directory (needed by /usr/bin/learn-ocaml)
  Error loading shared library libcrypto.so.1.0.0: No such file or directory (needed by /usr/bin/learn-ocaml)
  […]

* Ensure this patch is future-proof (instead of adding `libssl1.0`), see: https://github.com/eclipse/mosquitto/issues/1711#issuecomment-637987176

BTW: later on (after some testing), we may also want to bump the version of the Alpine distribution…