### PR TITLE
Update the markdown-to-html transformation so links open a new tab

### DIFF
--- a/demo-repository/exercises/demo2/descr.md
+++ b/demo-repository/exercises/demo2/descr.md
@@ -1,4 +1,4 @@
-
+[ceci est un lien](http://google.com)
 This exercise is just another demo for the exercise environment.
 <a href="" onclick="top.location='/exercises/demo/';">Test</a>
 

--- a/demo-repository/exercises/demo2/descr.md
+++ b/demo-repository/exercises/demo2/descr.md
@@ -1,4 +1,4 @@
-The following example link will open another tab/window: [OCaml](https://ocaml.org/).  
+The following example link will open another tab/window: [OCaml](https://ocaml.org "External link")  
 This exercise is just another demo for the exercise environment.  
 <a href="" onclick="top.location='/exercises/demo/';">Test</a>
 

--- a/demo-repository/exercises/demo2/descr.md
+++ b/demo-repository/exercises/demo2/descr.md
@@ -1,5 +1,5 @@
-[ceci est un lien](http://google.com)
-This exercise is just another demo for the exercise environment.
+The following example link will open another tab/window: [OCaml](https://ocaml.org/).  
+This exercise is just another demo for the exercise environment.  
 <a href="" onclick="top.location='/exercises/demo/';">Test</a>
 
 <details>

--- a/learn-ocaml-client.opam
+++ b/learn-ocaml-client.opam
@@ -17,7 +17,7 @@ depends: [
   "base" {>= "v0.9.4"}
   "base64"
   "cmdliner"
-  "omd"
+  "omd" {<= "1.3.1"}
   "asak"
   "cohttp" {>= "1.0.0" & < "2.0.0"}
   "cohttp-lwt-unix" {>= "1.0.0" & < "2.0.0"}

--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -46,7 +46,7 @@ depends: [
   "ocp-ocamlres" {>= "0.4"}
   "ocplib-json-typed" {= "0.6"}
   "odoc" {build & >= "1.3.0"}
-  "omd"
+  "omd" {<= "1.3.1"}
   "pprint"
   "ppx_cstruct"
   "ppx_tools"

--- a/src/repo/learnocaml_exercise.ml
+++ b/src/repo/learnocaml_exercise.ml
@@ -317,17 +317,20 @@ module File = struct
               descrs := (lang, f raw) :: !descrs;
               return ()
       in
-      let open Omd_representation in
-      let override_url = function
-    | Url(href,s,title) ->
-       Some ( let title_url =
-                if title <> ""
-                then
-                  Printf.sprintf {| title="%s"|} title
-                else "" in
-              Printf.sprintf
+  let override_url = function
+    | Omd_representation.Url(href,s,title) ->
+       if String.length href > 0 then
+         if Char.equal (String.get href 0) '#' then
+           None
+         else
+           let title_url =
+             if title <> "" then Printf.sprintf {| title="%s"|} title else "" in
+           let html =
+             Printf.sprintf
               {|<a href="%s" target="_blank" rel="noopener noreferrer"%s>%s</a>|}
-              href title_url (Omd_backend.html_of_md s))
+              href title_url (Omd_backend.html_of_md s) in
+           Some html
+         else None
     | _ -> None in
       let markdown_to_html md =
         Omd.(md |> of_string |> to_html ~override:override_url)

--- a/src/repo/learnocaml_exercise.ml
+++ b/src/repo/learnocaml_exercise.ml
@@ -317,8 +317,20 @@ module File = struct
               descrs := (lang, f raw) :: !descrs;
               return ()
       in
+      let open Omd_representation in
+      let override_url = function
+    | Url(href,s,title) ->
+       Some ( let title_url =
+                if title <> ""
+                then
+                  Printf.sprintf {| title="%s"|} title
+                else "" in
+              Printf.sprintf
+              {|<a href="%s" target="_blank" rel="noopener noreferrer"%s>%s</a>|}
+              href title_url (Omd_backend.html_of_md s))
+    | _ -> None in
       let markdown_to_html md =
-        Omd.(md |> of_string |> to_html)
+        Omd.(md |> of_string |> to_html ~override:override_url)
       in
       let read_descrs () =
         let langs = [] in


### PR DESCRIPTION
 feat: update the transformation from markdown to html which allow to open in a new tab when clicking on a link