### PR TITLE
fix(dune): Avoid ANSI char issues in `opam show … > VERSION`

### DIFF
--- a/dune
+++ b/dune
@@ -3,7 +3,7 @@
 (rule
  (targets VERSION)
  (action (with-stdout-to %{targets}
-           (run opam show ./%{dep:./learn-ocaml.opam} -f version --normalise)))
+           (run opam show --color=never ./%{dep:./learn-ocaml.opam} -f version --normalise)))
 )
 
 (env


### PR DESCRIPTION
fix: update dune file to avoid problems with ANSI char with opam show command