### PR TITLE
fix(omd): Update override_url with htmlentities

### DIFF
--- a/src/repo/learnocaml_exercise.ml
+++ b/src/repo/learnocaml_exercise.ml
@@ -324,11 +324,13 @@ module File = struct
            None
          else
            let title_url =
-             if title <> "" then Printf.sprintf {| title="%s"|} title else "" in
+             if title <> "" then Printf.sprintf {| title="%s"|}
+                               (Omd_utils.htmlentities ~md:true title) else "" in
            let html =
              Printf.sprintf
               {|<a href="%s" target="_blank" rel="noopener noreferrer"%s>%s</a>|}
-              href title_url (Omd_backend.html_of_md s) in
+              (Omd_utils.htmlentities ~md:true href) title_url
+                 (Omd_backend.html_of_md s) in
            Some html
          else None
     | _ -> None in


### PR DESCRIPTION
The goal here was to handle escaped characters in URL.