### PR TITLE
Fix learn-ocaml-client regression after PR #320

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,9 +43,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Build Docker images
         run: "make docker-images"
-      # unneeded
-      # - name: Run learn-ocaml build on demo-repository
-      #   run: "docker run --rm -v $(pwd)/demo-repository:/repository learn-ocaml -- build"
       - name: Pull server_image
         if: ${{ matrix.server_image != 'learn-ocaml' }}
         run: "docker pull ${{ matrix.server_image }} && docker tag ${{ matrix.server_image }} learn-ocaml"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,9 +22,36 @@ jobs:
         run: "make docker-images"
       - name: Run learn-ocaml build on demo-repository
         run: "docker run --rm -v $(pwd)/demo-repository:/repository learn-ocaml -- build"
-      - name: Clone learn-ocaml-corpus
+      - name: Clone learn-ocaml-corpus inside tests/corpuses
         run: "mkdir tests/corpuses && cd tests/corpuses && git clone --depth=1 https://github.com/ocaml-sf/learn-ocaml-corpus.git && cd ../.."
-      - name: Run learn-ocaml build on learn-ocaml-corpus
+      - name: Run tests
+        run: "cd tests && bash -c ./runtests.sh"
+
+  client_using_other_server:
+    name: Build learn-ocaml-client and run quick tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        server_image:
+          - 'ocamlsf/learn-ocaml:0.12'
+          - 'learn-ocaml'  # use learn-ocaml image built from master
+    env:
+      USE_CLIENT_IMAGE: 'true'
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Build Docker images
+        run: "make docker-images"
+      # unneeded
+      # - name: Run learn-ocaml build on demo-repository
+      #   run: "docker run --rm -v $(pwd)/demo-repository:/repository learn-ocaml -- build"
+      - name: Pull server_image
+        if: ${{ matrix.server_image != 'learn-ocaml' }}
+        run: "docker pull ${{ matrix.server_image }} && docker tag ${{ matrix.server_image }} learn-ocaml"
+      - name: Print images metadata
+        run: "docker inspect -f '{{json .Config.Labels}}' learn-ocaml-client learn-ocaml | jq"
+      - name: Run tests
         run: "cd tests && bash -c ./runtests.sh"
 
   build_extra_tests:

--- a/src/repo/learnocaml_exercise.ml
+++ b/src/repo/learnocaml_exercise.ml
@@ -37,8 +37,8 @@ let encoding =
        (req "test" string)
        (req "solution" string)
        (req "max-score" int)
-       (req  "depend" (option string))
-       (req  "dependencies" (list string)))
+       (opt "depend" (string))
+       (dft "dependencies" (list string) []))
 
 (* let meta_from_string m =
  *   Ezjsonm.from_string m

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -176,12 +176,16 @@ handle_subdir () {
 
     # Get the token from the docker logs
     token=$(docker logs "$SERVERID" | \
-                grep -A 1 -e 'teacher token.*:' | tail -n 1 | \
-                sed -e 's/^.*[:-] //')
-
+                grep -e 'Initial teacher token created:' | \
+                sed -e 's/^.*: //' | tr -d '[:space:]')
     if [ -z "$token" ]; then
-        red "Failed to get teacher token"
-        clean_fail
+        token=$(docker logs "$SERVERID" | \
+                grep -A 1 -e 'Found the following teacher tokens:' | tail -n 1 | \
+                sed -e 's/^.*- //' | tr -d '[:space:]')
+        if [ -z "$token" ]; then
+            red "Failed to get teacher token"
+            clean_fail
+        fi
     fi
 
     # init config

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -55,7 +55,8 @@ run_server () {
 learn-ocaml --sync-dir=/sync --repo=/repository build serve")
 
     # Wait for the server to be initialized
-    sleep 2
+    ./wait-for-it.sh localhost:8080 -s -t 10 -- echo 'learn-ocaml started.'
+    # in case of timeout, return exit code 124 (<> 0)
 
     if [ "$(docker ps -q)" == "" ]; then
 	red "PROBLEM, server is not running.\n"
@@ -77,8 +78,6 @@ learn-ocaml --sync-dir=/sync --repo=/repository build serve")
           -v "$(pwd)"/"$dir":/home/learn-ocaml/actual \
           learn-ocaml-client /bin/sh)
 
-        # Wait for the client to be initialized
-        sleep 2
         if [ "$(docker ps -q -f name=client)" == "" ]; then
             red "PROBLEM, client is not running.\n"
 

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -51,8 +51,8 @@ run_server () {
       -v "$(pwd)"/"$dir":/home/learn-ocaml/actual \
       -v "$SYNC":/sync -v "$REPO":/repository \
       learn-ocaml /bin/sh \
-        -c "learn-ocaml --sync-dir=/sync --repo=/repository build && 
-learn-ocaml --sync-dir=/sync --repo=/repository build serve")
+        -c "learn-ocaml --sync-dir=/sync --repo=/repository build &&
+learn-ocaml --sync-dir=/sync --repo=/repository serve")
 
     # Wait for the server to be initialized
     ./wait-for-it.sh localhost:8080 -s -t 10 -- echo 'learn-ocaml started.'

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -2,12 +2,25 @@
 
 let count=0
 
-# If the first argument is "set", the script will replace all the expected 
+# If the first argument is "set", the script will replace all the expected
 # answers by the response of the server. It is useful when you need to
 # initialize a set of tests.
 
+# If the environment variable $USE_CLIENT_IMAGE is set to "true", then
+# the script will use both images learn-ocaml and learn-ocaml-client,
+# instead of the mere learn-ocaml image. It is useful for testing
+# cross-version compatibility.
+
 SETTER=0
 if [ "$1" == "set" ]; then SETTER=1; fi
+
+use_client_image () {
+    if [ "$USE_CLIENT_IMAGE" = "true" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
 
 # print in green $1
 green () {
@@ -19,6 +32,12 @@ red () {
     echo -e "\e[31m$1\e[0m"
 }
 
+if use_client_image; then
+    green "Running tests with BOTH images (learn-ocaml, learn-ocaml-client)"
+else
+    green "Running tests with single image learn-ocaml"
+fi
+
 # run a server in a docker container
 run_server () {
     SYNC="$(pwd)"/"$dir"/sync
@@ -28,7 +47,7 @@ run_server () {
     chmod o+w "$dir"/sync
 
     # Run the server in background
-    SERVERID=$(docker run --entrypoint '' -d \
+    SERVERID=$(docker run --entrypoint '' -d -p 8080:8080 \
       -v "$(pwd)"/"$dir":/home/learn-ocaml/actual \
       -v "$SYNC":/sync -v "$REPO":/repository \
       learn-ocaml /bin/sh \
@@ -50,6 +69,25 @@ learn-ocaml --sync-dir=/sync --repo=/repository build serve")
 	docker rm "$SERVERID" > /dev/null
 	exit 1
     fi
+
+    if use_client_image; then
+        # Run the client in background
+        CLIENTID=$(docker run --entrypoint '' -d -it --name=client \
+          --add-host host.docker.internal:host-gateway \
+          -v "$(pwd)"/"$dir":/home/learn-ocaml/actual \
+          learn-ocaml-client /bin/sh)
+
+        # Wait for the client to be initialized
+        sleep 2
+        if [ "$(docker ps -q -f name=client)" == "" ]; then
+            red "PROBLEM, client is not running.\n"
+
+            red "LOGS:"
+            docker logs "$CLIENTID"
+            docker rm "$CLIENTID" > /dev/null
+            exit 1
+        fi
+    fi
 }
 
 clean () {
@@ -58,6 +96,11 @@ clean () {
 
     docker kill "$SERVERID" > /dev/null
     docker rm   "$SERVERID" > /dev/null
+
+    if use_client_image; then
+        docker kill "$CLIENTID" > /dev/null
+        docker rm   "$CLIENTID" > /dev/null
+    fi
 }
 
 clean_fail () {
@@ -69,9 +112,13 @@ handle_file () {
     subdir="$1"
     tosend="$(basename "$2")"
     # Grade file
-    docker exec -i "$SERVERID" \
-	   learn-ocaml-client grade --json --id="$subdir" \
-	   /home/learn-ocaml/actual/"$subdir"/"$tosend" > res.json 2> stderr.txt
+    args=(learn-ocaml-client grade --json --id="$subdir"
+          /home/learn-ocaml/actual/"$subdir"/"$tosend")
+    if use_client_image; then
+        docker exec -i "$CLIENTID" "${args[@]}" > res.json 2> stderr.txt
+    else
+        docker exec -i "$SERVERID" "${args[@]}" > res.json 2> stderr.txt
+    fi
     if [ $? -ne 0 ]; then
 	red "NOT OK: $dir/$tosend"
 	cat stderr.txt
@@ -102,9 +149,13 @@ handle_subdir () {
     subdir="$(basename "$1")"
     pushd "$1" >/dev/null
 
-    #init config
-    docker exec -i "$SERVERID" \
-	   learn-ocaml-client init --server=http://localhost:8080 --token="$token"
+    # init config
+    args=(learn-ocaml-client init --token="$token")
+    if use_client_image; then
+        docker exec -i "$CLIENTID" "${args[@]}" --server="http://host.docker.internal:8080"
+    else
+        docker exec -i "$SERVERID" "${args[@]}" --server="http://localhost:8080"
+    fi
     # For each solution
     for tosend in $(find . -name "*.ml" -type f -printf "%f\n")
     do
@@ -114,7 +165,7 @@ handle_subdir () {
     clean
 }
 
-# For each subdirectory (ie. each corpus)
+# For each subdirectory (except ./corpuses/*)
 while IFS= read -r dir;
 do
     run_server
@@ -126,7 +177,7 @@ do
     # Get the token from the sync/ directory
     token=$(find sync -maxdepth 5 -mindepth 5 | head -n 1 | sed 's|sync/||' | sed 's|/|-|g')
 
-    # For each subdir (ie. each exercice)
+    # For each subdir (i.e. each exercice)
     while IFS= read -r subdir;
     do
 	handle_subdir "$subdir"
@@ -135,6 +186,7 @@ do
     popd > /dev/null
 done < <(find . -maxdepth 1 -type d ! -path . ! -path ./corpuses)
 
+#==============================================================================
 while IFS= read -r corpus;
 do
     echo "---> Testing corpus $corpus:"
@@ -143,10 +195,11 @@ do
 	   learn-ocaml /bin/sh -c \
 	   "learn-ocaml --repo=/repository build"
     if [ $? -ne 0 ]; then
-	red "Failed to build $corpus."
+	red "Failed to build $corpus"
 	exit 1
     fi
 
+    green "OK: $corpus"
     let count++
 done < <(find ./corpuses -mindepth 1 -maxdepth 1 -type d)
 

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -206,6 +206,7 @@ handle_subdir () {
 }
 
 echo
+cd "$srcdir"
 
 # For each subdirectory (except ./corpuses/*)
 while IFS= read -r dir;
@@ -221,9 +222,12 @@ do
     done < <(find . -maxdepth 1 -type d ! -path . ! -path ./repo ! -path ./sync)
 
     popd > /dev/null || { red "popd failed"; clean_fail; }
-done < <(find . -maxdepth 1 -type d ! -path . ! -path "$srcdir"/corpuses)
+done < <(find . -maxdepth 1 -type d ! -path . ! -path ./corpuses)
 
 #==============================================================================
+echo
+cd "$srcdir"
+
 while IFS= read -r corpus;
 do
     echo "---> Testing corpus $corpus:"
@@ -237,6 +241,6 @@ do
 
     green "OK: $corpus"
     (( count++ ))
-done < <(find "$srcdir"/corpuses -mindepth 1 -maxdepth 1 -type d)
+done < <(find ./corpuses -mindepth 1 -maxdepth 1 -type d)
 
 green "\\nALL $count TESTS PASSED\\n"


### PR DESCRIPTION
With @LouisAyroles and @Fixiss, we noticed that there were some (unexpected) incompatibility between learn-ocaml-client (say, from master) and the latest release of learn-ocaml (0.12).

Here a minimal working example to reproduce the bug:

    cd .../learn-ocaml
    docker run --name=locaml -d -it -p 8080:8080 -v "$PWD/demo-repository:/repository" ocamlsf/learn-ocaml:0.12
    TOKEN=$(docker logs locaml | grep -e 'Initial teacher token created:' | sed -e 's/^.*: //')
    # then
    git checkout master
    opam install . --deps-only --locked -y
    opam install -y opam-installer.$(opam config var opam-version)
    eval $(opam env)
    make
    make opaminstall
    learn-ocaml-client init -s http://localhost:8080 -t "$TOKEN"
    touch demo.ml
    learn-ocaml-client grade demo.ml

then we were getting:    

    Fatal error: exception Json_encoding.Cannot_destruct(_)
    Called from unknown location
    Called from unknown location
    Called from unknown location
    Called from unknown location
    Called from unknown location
    Called from unknown location
    Called from unknown location

Thanks to git bisect and further explorations, it appears the issue was just introduced in PR #320.

This new PR attempts to fix this issue (very important to have some smooth experience with learn-ocaml-client and [learn-ocaml.el](https://github.com/pfitaxel/learn-ocaml.el)), and I'll proceed in a TDD-like manner (extended the GHA CI test-suite within this PR).