### PR TITLE
Add a missing link in the Howtos section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Howtos
 * [How to submit an exercise to the global corpus?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-submit-an-exercise.md)
 * [How to deploy an instance of Learn OCaml?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-deploy-a-learn-ocaml-instance.md)
 * [How to deploy Learn-OCaml statically?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-deploy-learn-ocaml-statically.md)
+* [How to practice OCaml with Learn-OCaml?](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-practice-ocaml.md)
 
 Contacts
 --------


### PR DESCRIPTION
There is a missing link in the README to [./docs/howto-practice-ocaml.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/docs/howto-practice-ocaml.md).