### PR TITLE
QoL: reset the toplevel every time before evaluating code from the editor

### DIFF
--- a/src/app/learnocaml_common.ml
+++ b/src/app/learnocaml_common.ml
@@ -894,6 +894,7 @@ module Editor_button (E : Editor_info) = struct
   let eval top select_tab =
     editor_button
       ~icon: "run" [%i"Eval code"] @@ fun () ->
+      Learnocaml_toplevel.reset top >>= fun () ->
       Learnocaml_toplevel.execute_phrase top (Ace.get_contents E.ace) >>= fun _ ->
       select_tab "toplevel";
       Lwt.return_unit


### PR DESCRIPTION
You might lose what you manually typed directly in the toplevel pane, but that 
shouldn't be a problem, and most importantly it will avoid already defined ids 
to clutter the environment.

These often cause student confusion with cases like "type t instead of t", or
a missing `rec` keyword that compiles because using an older definition.