### PR TITLE
Fix the display of utf8 characters in the code editor

### DIFF
--- a/src/ace-lib/ace.ml
+++ b/src/ace-lib/ace.ml
@@ -72,11 +72,8 @@ let get_contents ?range e =
       (* Bytes range to utf8 string range conversion *)
       let (r1,c1), (r2, c2) = read_range r in
       let l1, l2 = get_line e r1, get_line e r2 in
-      let c1, c2 =
-        min (String.length l1) c1, min (String.length l2) c2
-      in
-      let c1 = (Js.string (String.sub l1 0 c1))##.length in
-      let c2 = (Js.string (String.sub l2 0 c2))##.length in
+      let c1 = Js_utils.pos8_to_pos16 l1 c1 in
+      let c2 = Js_utils.pos8_to_pos16 l2 c2 in
       let r = create_range (create_position r1 c1) (create_position r2 c2) in
       Js.to_string @@ document##(getTextRange r)
 

--- a/src/ace-lib/ace.ml
+++ b/src/ace-lib/ace.ml
@@ -132,28 +132,10 @@ let set_mark editor ?loc ?(type_ = Message) msg =
         let sr = sr - 1 in
         let er = er - 1 in
         (* Corrects column positions for unicode strings *)
-        let char_reg =
-          new%js Js.regExp_withFlags (Js.string ".") (Js.string "gu") in
-        let unicode_chars r =
-          let line = Js.string (get_line editor r) in
-          Js.Opt.case (line##_match char_reg) (fun () -> []) (fun x ->
-            let x = Js.match_result x in
-            List.init (x##.length) (fun i ->
-              let c = Js.Optdef.get (Js.array_get x i)
-                        (fun _ -> failwith "index error") in
-              (String.length (Js.to_string c), c##.length)
-            )
-          )
-        in
-        let rec aux before c i acc = function
-          | [] -> i
-          | (x, di)::q ->
-            let acc' = acc + x in
-            if (before && (acc' > c)) || ((not before) && (acc >= c))
-              then i else aux before c (i+di) acc' q
-        in
-        let sc = aux true sc 0 0 (unicode_chars sr) in
-        let ec = aux false ec 0 0 (unicode_chars er) in
+        let sline = get_line editor sr in
+        let eline = get_line editor er in
+        let sc = Js_utils.pos8_to_pos16 sline sc in
+        let ec = Js_utils.pos8_to_pos16 ~stop_before:false eline ec in
         (* end position corrections *)
       sr, sc, Some (range sr sc er ec) in
 

--- a/src/ace-lib/ace.mli
+++ b/src/ace-lib/ace.mli
@@ -80,6 +80,7 @@ val set_custom_data: 'a editor -> 'a -> unit
 
 type token
 val token: type_:string -> string -> token
+val get_token_val: token -> string
 
 type 'state helpers = {
   initial_state: unit -> 'state;

--- a/src/ace-lib/ace_types.mli
+++ b/src/ace-lib/ace_types.mli
@@ -10,6 +10,7 @@ open Js_of_ocaml
 
 class type token = object
   method value : Js.js_string Js.t Js.prop
+  method _val : string Js.prop
   method _type : Js.js_string Js.t Js.prop
 end
 

--- a/src/ace-lib/ocaml_mode.ml
+++ b/src/ace-lib/ocaml_mode.ml
@@ -298,12 +298,14 @@ let get_line_tokens line st row doc =
         if !debug_indent > 1 && tok.token <> EOL && tok.token <> ESCAPED_EOL then
           IndentBlock.dump block;
         let st = { block; lex_ctxt; } in
+        let type_ = token_type tok.token in
         match tok.token, tokens with
         | ILLEGAL_CHAR c, t::toks ->
-          let type_ = "error" in
           let t = Ace.token ~type_ ((Ace.get_token_val t)^(String.make 1 c)) in
           iter st offset stream (t :: toks)
-
+        | STRING_CONTENT, t::toks ->
+          let t = Ace.token ~type_ ((Ace.get_token_val t)^tok.between^tok.substr) in
+          iter st offset stream (t :: toks)
         | EOL, _ | ESCAPED_EOL, _ ->
             (* FIXME some spaces ??? *)
             (st, List.rev tokens)

--- a/src/ace-lib/ocaml_mode.ml
+++ b/src/ace-lib/ocaml_mode.ml
@@ -298,11 +298,16 @@ let get_line_tokens line st row doc =
         if !debug_indent > 1 && tok.token <> EOL && tok.token <> ESCAPED_EOL then
           IndentBlock.dump block;
         let st = { block; lex_ctxt; } in
-        match tok.token with
-        | EOL | ESCAPED_EOL ->
+        match tok.token, tokens with
+        | ILLEGAL_CHAR c, t::toks ->
+          let type_ = "error" in
+          let t = Ace.token ~type_ ((Ace.get_token_val t)^(String.make 1 c)) in
+          iter st offset stream (t :: toks)
+
+        | EOL, _ | ESCAPED_EOL, _ ->
             (* FIXME some spaces ??? *)
             (st, List.rev tokens)
-        | COMMENT_OPEN_EOL ->
+        | COMMENT_OPEN_EOL, _ ->
             (st, List.rev (comment_open tok.between :: tokens))
         | _ ->
             iter st offset stream (wrap_token st tok :: tokens)

--- a/src/utils/js_utils.ml
+++ b/src/utils/js_utils.ml
@@ -31,6 +31,19 @@ let js_debug obj = Firebug.console##(debug obj)
 let js_warn obj = Firebug.console##(warn obj)
 let js_error obj = Firebug.console##(error obj)
 
+let rec pos8_to_pos16 line c8 i8 i16 stop_before = 
+    let di8, di16 = match line.[i8] with 
+      | '\x00' .. '\x7F' -> 1, 1
+      | '\xC2' .. '\xDF' -> 2, 1
+      | '\xE0' .. '\xEF' -> 3, 1
+      | '\xF0' .. '\xF4' -> 4, 2 
+      | _ -> failwith "not a character" in
+    if i8 <= c8 && c8 <= i8 + di8 then
+        if stop_before then i16 else i16+di16 
+    else pos8_to_pos16 line c8 (i8+di8) (i16+di16) stop_before
+let pos8_to_pos16 ?(stop_before = true) line c8 = 
+	pos8_to_pos16 line c8 0 0 stop_before
+
 let log fmt =
   Format.kfprintf
     (fun _ -> Firebug.console##(log (Js.string (Format.flush_str_formatter ()))))

--- a/src/utils/js_utils.ml
+++ b/src/utils/js_utils.ml
@@ -32,16 +32,17 @@ let js_warn obj = Firebug.console##(warn obj)
 let js_error obj = Firebug.console##(error obj)
 
 let rec pos8_to_pos16 line c8 i8 i16 stop_before = 
-    let di8, di16 = match line.[i8] with 
+    if i8 >= c8 || i8 >= String.length line then i16 else
+    let di8, di16 = match line.[i8] with
       | '\x00' .. '\x7F' -> 1, 1
       | '\xC2' .. '\xDF' -> 2, 1
       | '\xE0' .. '\xEF' -> 3, 1
       | '\xF0' .. '\xF4' -> 4, 2 
-      | _ -> failwith "not a character" in
-    if i8 <= c8 && c8 <= i8 + di8 then
-        if stop_before then i16 else i16+di16 
+      | _                -> 1, 1 in
+    if stop_before && i8 <= c8 && c8 < i8 + di8 then i16
     else pos8_to_pos16 line c8 (i8+di8) (i16+di16) stop_before
-let pos8_to_pos16 ?(stop_before = true) line c8 = 
+
+let pos8_to_pos16 ?(stop_before = true) line c8 =
 	pos8_to_pos16 line c8 0 0 stop_before
 
 let log fmt =

--- a/src/utils/js_utils.mli
+++ b/src/utils/js_utils.mli
@@ -32,6 +32,8 @@ val js_debug: 'a -> unit
 val js_warn: 'a -> unit
 val js_error: 'a -> unit
 
+val pos8_to_pos16: ?stop_before:bool -> string -> int -> int
+
 val reload: unit -> unit
 
 (** Gets the language configured in the browser *)


### PR DESCRIPTION
Work done by @baloone during his internship at OCamlPro. This fixes the display with invalid syntax (display in strings and comments was already OK), but it shouldn't get scrambled either way.

NOTE: should be rebased and squashed once the 4.12 PR is merged