### PR TITLE
feat: Improve description entrypoint

### DIFF
--- a/src/app/learnocaml_description_main.ml
+++ b/src/app/learnocaml_description_main.ml
@@ -51,9 +51,21 @@ let () =
              d##write (Js.string (exercise_text ex_meta exo));
              d##close) ;
          (* display meta *)
-         display_meta (Some token) ex_meta id
+         display_meta (Some token) ex_meta id >>= fun () ->
+         (* hide the initial/loading phase curtain *)
+         Lwt.return @@ hide_loading ~id:"learnocaml-exo-loading" ()
        end
      with Not_found ->
-       Lwt.return @@
-         Manip.replaceChildren text_container
-           Tyxml_js.Html5.[ h1 [ txt "Error: Missing token" ] ]
+       let elt = find_div_or_append_to_body "learnocaml-exo-loading" in
+       Manip.(addClass elt "loading-layer") ;
+       Manip.(removeClass elt "loaded") ;
+       Manip.(addClass elt "loading") ;
+       Manip.replaceChildren elt
+         Tyxml_js.Html5.[
+           h1 [ txt "Error: missing token. \
+                     Use a link from ";
+                (* Note: could be put in a global constant *)
+                a ~a:[ a_href "https://github.com/pfitaxel/learn-ocaml.el" ]
+                  [ txt "learn-ocaml-mode" ];
+                txt "?" ] ];
+       Lwt.return_unit

--- a/static/css/learnocaml_description.css
+++ b/static/css/learnocaml_description.css
@@ -141,6 +141,16 @@ body {
 
 /* BEGIN excerpt from learnocaml_exercise.css */
 
+/* -------------------- loading splash screen --------------------- */
+#learnocaml-exo-loading {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+}
+#learnocaml-exo-loading.loading,
+#learnocaml-exo-loading.loaded {
+  background: rgba(200,200,200,0.9);
+}
+
 .learnocaml-exo-meta-category ~ .exercise + .exercise {
   border-top: 1px #333 solid;
 }

--- a/static/description.html
+++ b/static/description.html
@@ -19,6 +19,27 @@
 </head>
 
 <body>
+    <!-- Should be kept untouched. -->
+    <div style="display:none">
+      <!-- (Weakly) preload images. -->
+      <img src="/icons/tryocaml_loading_1.gif"><img src="/icons/tryocaml_loading_2.gif">
+      <img src="/icons/tryocaml_loading_3.gif"><img src="/icons/tryocaml_loading_4.gif">
+      <img src="/icons/tryocaml_loading_5.gif"><img src="/icons/tryocaml_loading_6.gif">
+      <img src="/icons/tryocaml_loading_7.gif"><img src="/icons/tryocaml_loading_8.gif">
+      <img src="/icons/tryocaml_loading_9.gif">
+    </div>
+    <!-- Three states: .initial, .loading and .loaded.
+         Set to .loaded when initial loading finished.
+         Set to .loading while loading, then to .loaded. -->
+    <div id="learnocaml-exo-loading" class="loading-layer initial">
+      <div id="chamo"><img id="chamo-img" src="/icons/tryocaml_loading_5.gif"></div>
+      <div class="messages"><ul><li id="txt_preparing">Preparing the environment</li></ul></div>
+    </div>
+    <script language="JavaScript">
+      var n = Math.floor (Math.random () * 8.99) + 1;
+      document.getElementById('chamo-img').src = learnocaml_config.baseUrl + '/icons/tryocaml_loading_' + n + '.gif';
+    </script>
+    <!-- Anything below could be recreated dynamically, but IDs must be kept. -->
     <div id="learnocaml-exo-toolbar">
         <div class="logo">
             <img src="/icons/logo_ocaml.svg">


### PR DESCRIPTION
This 2-commits PR builds upon #393; which should be merged before merging this one, #423 (with an _optional_ rebase).

This PR implements the following item mentioned in #418:

* **Dev** base64 encoding for `/description` endpoint URL  
  (following an idea discussed with @yurug some weeks ago)

It also incorporates a change (separate commit) to improve the `/description` UI/UX a bit regarding loading time,  
and error rendering:

![2021-09-26_21-57-48_Screenshot_description_missing_token](https://user-images.githubusercontent.com/10367254/134822330-93d6d02a-f3ad-4267-982f-bfe83b2cc169.png)