### PR TITLE
docs: Improve the new text of the old "API version mismatch" error

### DIFF
--- a/src/main/learnocaml_client.ml
+++ b/src/main/learnocaml_client.ml
@@ -532,7 +532,10 @@ let check_server_version ?(allow_static=false) server =
         (Api.Version ()) (* TODO: pass more precise requests *)
       >|= function
       | Ok _server_version -> true
-      | Error msg -> Printf.eprintf "%s\n" msg; exit 1)
+      | Error msg -> (* See [Learnocaml_api.is_supported]'s message *)
+         Printf.eprintf
+           "[ERROR] %s\nDo you use the latest learn-ocaml-client binary?\n" msg;
+         exit 1)
   @@ fun e ->
      if not allow_static then
        begin


### PR DESCRIPTION
* Now we'll get:
  ```
  [ERROR] API request not supported by server v.%s using client v.%s
  Do you use the latest learn-ocaml-client binary?
  ```
* (Just a heads-up PR; I'll merge it when CI is green)