### PR TITLE
fix: Attempt to workaround the static-bin-macos failure

### DIFF
--- a/.github/workflows/static-builds.yml
+++ b/.github/workflows/static-builds.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Prepare build environment
         run: |
           opam init -a --bare
+          brew install openssl@3  # Workaround https://github.com/ocaml/opam-repository/issues/19676
           opam switch create . ocaml-base-compiler --deps-only
       - name: Build the binaries
         run: |


### PR DESCRIPTION
The current CI failure in master is related to the static-bin-macos job, see https://github.com/ocaml/opam-repository/issues/19676
On second thought, this issue is due to both a broken depext and a (hopefully partly) broken post-check of the presence of the brew package.
So, maybe this PR could workaround the failure…😅