### PR TITLE
fix(UI): Restore the UX of welcome message "Choose an activity."

### DIFF
--- a/static/css/learnocaml_main.css
+++ b/static/css/learnocaml_main.css
@@ -303,7 +303,7 @@ body {
 
 /* -- Activity place-holder ------------------------------------------------ */
 
-#Learnocaml-main-content > .placeholder {
+#learnocaml-main-content > .placeholder {
   position: absolute;
   left: 0; top: 0; right: 0; bottom: 0;
   background: #eee;
@@ -323,7 +323,7 @@ body {
 }
 
 @media (min-width: 1000px) {
-  #Learnocaml-main-content > .placeholder {
+  #learnocaml-main-content > .placeholder {
     background: linear-gradient(to right, #aaa 0px, #eee 8px);
   }
 }


### PR DESCRIPTION
Hi @yurug,

I had noticed a small regression from 0.12 with Learn-OCaml's welcome message after connecting, which is fixed by this PR.

(FWIW, I was puzzled to see that the initial commit that introduced this issue was very old − maybe, there was some duplicate CSS somewhere that first hid this error.)

<table>
<thead>
<tr>
<td>Beforehand</td>
<td>Henceforth</td>
</tr>
</thead>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/10367254/139964422-87ff5833-f150-4009-ac08-a8b758dae524.png" alt="2021-11-03_00-02-42_Screenshot_beforehand" width="100%"></td>
    <td><img src="https://user-images.githubusercontent.com/10367254/139964419-1fd761e0-8a13-4caa-acac-bec09a8bad08.png" alt="2021-11-03_00-03-07_Screenshot_henceforth" width="100%"></td>
  </tr>
</table>

(to be squash-merged)