### PR TITLE
[build] Generate `given_exo.{cmi,cmo,cmt}` files

### DIFF
--- a/demo-repository/exercises/demo3/demo/descr.md
+++ b/demo-repository/exercises/demo3/demo/descr.md
@@ -1,0 +1,22 @@
+# id: `demo3/demo`
+
+This example demonstrates the ability to put exercises in sub-directories.
+
+## Questions
+
+Define four functions matching the usual arithmetic operations:
+
+```
+plus : int -> int -> int
+times : int -> int -> int
+minus : int -> int -> int
+divide : int -> int -> int
+```
+
+## Bonus question
+
+The hidden prelude (so-called `prepare.ml`) contains a predicate
+
+`mystere_int : int -> bool`
+
+so could you find for which `n` we get `mystere_int n = true` ?

--- a/demo-repository/exercises/demo3/demo/meta.json
+++ b/demo-repository/exercises/demo3/demo/meta.json
@@ -1,0 +1,2 @@
+{"learnocaml_version":"1","kind":"exercise","stars":0,
+ "title":"Demo exercise (in a sub-directory)"}

--- a/demo-repository/exercises/demo3/demo/prelude.ml
+++ b/demo-repository/exercises/demo3/demo/prelude.ml
@@ -1,0 +1,2 @@
+(* Some code is loaded in the toplevel before your code. *)
+let greetings = "Hello world!"

--- a/demo-repository/exercises/demo3/demo/prepare.ml
+++ b/demo-repository/exercises/demo3/demo/prepare.ml
@@ -1,0 +1,1 @@
+let mystere_int n = n = 12345

--- a/demo-repository/exercises/demo3/demo/solution.ml
+++ b/demo-repository/exercises/demo3/demo/solution.ml
@@ -1,0 +1,4 @@
+let plus = (+)
+let times = ( * )
+let minus = ( - )
+let divide = ( / )

--- a/demo-repository/exercises/demo3/demo/template.ml
+++ b/demo-repository/exercises/demo3/demo/template.ml
@@ -1,0 +1,6 @@
+
+let plus x y = x + y ;;
+
+let minus x y = y - x ;;
+
+let times x y = x *

--- a/demo-repository/exercises/demo3/demo/test.ml
+++ b/demo-repository/exercises/demo3/demo/test.ml
@@ -1,0 +1,26 @@
+open Test_lib
+open Report
+
+let () =
+  set_result @@
+  ast_sanity_check code_ast @@ fun () ->
+  [ Section
+      ([ Text "Function:" ; Code "plus" ],
+       test_function_2_against_solution
+         [%ty : int -> int -> int ] "plus"
+         [ (1, 1) ; (2, 2) ; (10, -10) ]) ;
+    Section
+      ([ Text "Function:" ; Code "minus" ],
+       test_function_2_against_solution
+         [%ty : int -> int -> int ] "minus"
+         [ (1, 1) ; (4, -2) ; (0, 10) ]) ;
+    Section
+      ([ Text "Function:" ; Code "times" ],
+       test_function_2_against_solution
+         [%ty : int -> int -> int ] "times"
+         [ (1, 3) ; (2, 4) ; (3, 0) ]) ;
+    Section
+      ([ Text "Function:" ; Code "divide" ],
+       test_function_2_against_solution
+         [%ty : int -> int -> int ] "divide"
+         [ (12, 4) ; (12, 5) ; (3, 0) ]) ]

--- a/demo-repository/exercises/index.json
+++ b/demo-repository/exercises/index.json
@@ -2,4 +2,4 @@
   "groups":
   { "demo":
     { "title": "Demo exercise pack",
-      "exercises": [ "demo", "demo2" ] } } }
+      "exercises": [ "demo", "demo2", "demo3/demo" ] } } }

--- a/src/grader/cmo_builder.ml
+++ b/src/grader/cmo_builder.ml
@@ -1,0 +1,63 @@
+(* This file is part of Learn-OCaml.
+ *
+ * Copyright (C) 2021-2022  OCaml Software Foundation.
+ *
+ * Learn-OCaml is distributed under the terms of the MIT license. See the
+ * included LICENSE file for details. *)
+
+open Lwt
+
+let re_given = "^given_[0-9A-Za-z_]+$"
+
+let check_given str =
+  Str.string_match (Str.regexp re_given) str 0
+
+let re_shortid_ascii = "^[0-9A-Za-z_-]+$"
+
+let check_shortid_ascii id =
+  Str.string_match (Str.regexp re_shortid_ascii) id 0
+
+let given_of_shortid id =
+  if not (check_shortid_ascii id) then
+    Format.printf "Warning: Short id '%s' does not match '%s'."
+      id re_shortid_ascii;
+  Str.global_replace (Str.regexp "_") "_0" id
+  |> Str.global_replace (Str.regexp "-") "_1"
+  |> fun s -> "given_" ^ s
+
+let shortid_of_given str =
+  if not (check_given str) then
+    failwith
+      (Format.sprintf "Incorrect given prefix: '%s' does not match '%s'."
+         str re_given);
+  Str.replace_first (Str.regexp "^given_") "" str
+  |> Str.global_replace (Str.regexp "_1") "-"
+  |> Str.global_replace (Str.regexp "_0") "_"
+
+let compile_given exo json_path =
+  (* let subdir = "gen.learn-ocaml" in *)
+  let dir, base = Filename.dirname json_path, Filename.basename json_path in
+  let given =
+    Str.replace_first (Str.regexp "\\.json$") "" base
+    |> given_of_shortid in
+  let output_prefix = Filename.concat dir given in
+  let output_ml =  Filename.concat dir (given ^ ".ml") in
+  let prelude = Learnocaml_exercise.(decipher File.prelude exo) in
+  let prepare = Learnocaml_exercise.(decipher File.prepare exo) in
+  let both = prelude ^ " ;;\n" ^ prepare in
+  let write filename str =
+    Lwt_io.with_file ~mode:Lwt_io.Output filename
+      (fun oc -> Lwt_io.write oc str) in
+  let compile source_file output_prefix =
+    let orig = !Clflags.binary_annotations in
+    Clflags.binary_annotations := true;
+    Compile.implementation ~start_from:Clflags.Compiler_pass.Parsing
+      ~source_file ~output_prefix;
+    Clflags.binary_annotations := orig in
+  (* minor detail: display the basename "given_exo.ml" instead of subdir/exo *)
+  Format.printf "%-24s (build .cmo)@." given;
+  Lwt_utils.mkdir_p dir >>= fun () ->
+  write output_ml both >>= fun () ->
+  Lwt.return (compile output_ml output_prefix) >>= fun () ->
+  (* then overwrite to remove prepare.ml *)
+  write output_ml prelude

--- a/src/grader/cmo_builder.mli
+++ b/src/grader/cmo_builder.mli
@@ -1,0 +1,27 @@
+(* This file is part of Learn-OCaml.
+ *
+ * Copyright (C) 2021-2022  OCaml Software Foundation.
+ *
+ * Learn-OCaml is distributed under the terms of the MIT license. See the
+ * included LICENSE file for details. *)
+
+(** Return [true] if the string matches [^[0-9A-Za-z_-]+$] *)
+val check_shortid_ascii: string -> bool
+
+(** Return [true] if the string matches [^given_[0-9A-Za-z_]+$] *)
+val check_given: string -> bool
+
+(** Escape "-" and "_" & Prepend "given_".
+    Emit a warning if [check_shortid_ascii] doesn't hold on the input string. *)
+val given_of_shortid: string -> string
+
+(** Remove "given_" prefix & Unescape "-" and "_".
+    Raise a [Failure] if [check_given] doesn't hold on the input string. *)
+val shortid_of_given: string -> string
+
+(** Take an exercise and a json filename "./www/exercises/part/exo.json",
+    compile [prelude ^ " ;;\n" ^ prepare]
+    to "./www/exercises/part/given_exo.{cmi,cmo,cmt}",
+    and write prelude (even if that last step is somewhat redundant)
+    to "./www/exercises/part/given_exo.ml" *)
+val compile_given : Learnocaml_exercise.t -> string -> unit Lwt.t

--- a/src/grader/dune
+++ b/src/grader/dune
@@ -175,6 +175,15 @@
  (preprocess (per_module ((pps ppx_ocplib_i18n learnocaml_ppx_metaquot) Grading)))
 )
 
+(library
+ (name cmo_builder)
+ (wrapped false)
+ (modes byte)
+ (libraries compiler-libs.bytecomp
+  	    lwt_utils
+	    learnocaml_data)
+ (modules Cmo_builder)
+)
 
 (library
  (name grading_cli)
@@ -185,6 +194,7 @@
             ocplib-ocamlres
             ezjsonm
             lwt_utils
+	    cmo_builder
             learnocaml_report
             learnocaml_data)
  (modules Grading_cli Grader_cli)

--- a/src/grader/grader_cli.ml
+++ b/src/grader/grader_cli.ml
@@ -6,6 +6,8 @@
  * Learn-OCaml is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+let build_cmo = ref false
+let build_grade = ref true
 let display_std_outputs = ref false
 let dump_outputs = ref None
 let dump_reports = ref None
@@ -48,6 +50,15 @@ let read_student_file exercise_dir path =
     Lwt_io.with_file ~mode:Lwt_io.Input fn Lwt_io.read
 
 let grade ?(print_result=false) ?dirname meta exercise output_json =
+  (if !build_cmo then
+          match output_json with
+          | Some json_path ->
+             (* Note: fails if the prelude/prepare don't compile *)
+             Cmo_builder.compile_given exercise json_path
+          | None ->
+             Lwt_io.eprintf "[Warning] json_path = None; please report.@."
+    else Lwt.return_unit) >>= fun () ->
+  if not !build_grade then Lwt.return (Ok ()) else
   Lwt.catch
     (fun () ->
        let code_to_grade = match !grade_student with

--- a/src/grader/grader_cli.mli
+++ b/src/grader/grader_cli.mli
@@ -8,6 +8,27 @@
 
 (** {2 Configuration options} *)
 
+(** Should should generate exo.{cmi,cmo,cmt} for [prelude ^ " ;;\n" ^ prepare].
+
+    This experimental option can be set from command-line
+    (explicit mode: learn-ocaml build [--enable-cmo-build|--disable-cmo-build])
+    and thereby regenerate [*.cm*] files unconditionally.
+    Otherwise (implicit mode), it is on by default for changed exercises only.
+
+    This feature is useful for learn-ocaml.el but optional (it can be disabled)
+    yet it may become mandatory (not an option anymore) if/when the js_of_ocaml
+    frontend also fetches [*.cmo] binaries for [{solution,test}.ml].
+
+    Note: the initial value of this [bool ref] (in [*.ml]) is a dummy value. *)
+val build_cmo: bool ref
+
+(** Grade the exercise (to be set to [false] if the exercise did not change).
+
+    Use case: if we run [learn-ocaml build --enable-cmo-build] (explicit mode)
+    on an unchanged exercise, we will have [!build_cmo && not !build_grade], so
+    the [*.cmo] will be built, but the grading will be skipped. *)
+val build_grade: bool ref
+
 (** Should stdout / stderr of the grader be echoed *)
 val display_std_outputs: bool ref
 

--- a/src/main/learnocaml_main.ml
+++ b/src/main/learnocaml_main.ml
@@ -187,7 +187,8 @@ module Args = struct
 
     let jobs =
       value & opt int 1 & info ["jobs";"j"] ~docv:"INT" ~doc:
-        "Number of building jobs to run in parallel"
+        "Number of building jobs to run in parallel \
+         (only accept '$(b,--jobs=1)' for now, cf. issue #414)."
 
     type t = {
       contents_dir: string;
@@ -216,8 +217,10 @@ module Args = struct
           repo_dir/"tutorials";
         Learnocaml_process_playground_repository.playground_dir :=
           repo_dir/"playground";
-        Learnocaml_process_exercise_repository.n_processes := jobs;
-        ()
+        Learnocaml_process_exercise_repository.n_processes := 1;
+        if jobs >= 2
+        then failwith "only accept --jobs=1 for now (cf. issue #414)"
+        else ()
       in
       Term.(const apply $repo_dir $exercises_filtered $jobs)
 

--- a/src/repo/dune
+++ b/src/repo/dune
@@ -50,6 +50,8 @@
             lwt_utils
             omd
             markup
+	    compiler-libs
+	    cmo_builder
             grading_cli
             learnocaml_repository
             learnocaml_store

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -227,6 +227,7 @@ let main dest_dir =
                Grader_cli.grade ?print_result ?dirname meta exercise json_path
                >|= fun r -> print_grader_error exercise r; r
            else
+             let () = failwith "only accept --jobs=1 for now (cf. issue #414)" in
              Lwt_list.map_p,
              spawn_grader
          in

--- a/src/repo/learnocaml_process_exercise_repository.mli
+++ b/src/repo/learnocaml_process_exercise_repository.mli
@@ -17,5 +17,5 @@ val n_processes: int ref
 
 (** Main *)
 
-(** [dest_dir] -> success *)
-val main: string -> bool Lwt.t
+(** [build_cmo] -> [dest_dir] -> success *)
+val main: bool option -> string -> bool Lwt.t

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -84,7 +84,7 @@ run_server () {
         red "PROBLEM, server is not running.\\n"
 
         red "LS:"
-        ls -Rl "$dir"
+        ls -Rl "$srcdir/$dir"
         echo ""
 
         red "LOGS:"


### PR DESCRIPTION
* **Kind:** feature

* Address #414 first (disabling broken option `learn-ocaml build --jobs=2`)

### Description

* Add option **`learn-ocaml build --enable-cmo-build`**
* This new experimental option is on by default (implicit mode) and generates `given_exo.{cmi,cmo,cmt}` in the www folder for each `prelude ^ " ;;\n" ^ prepare`.
* This is a key feature for [learn-ocaml.el](https://github.com/pfitaxel/learn-ocaml.el) (the Tuareg/Merlin frontend for Learn-OCaml); it can be disabled using the flag:
  ```
  $ learn-ocaml build --disable-cmo-build
  ```
* If the www/exo.json file is up-to-date, the `exo.cm*` are not built.
* But we can **force** the `exo.cm*` build (explicit mode) even for un-changed exercises using the flag:
  ```
  $ learn-ocaml build --enable-cmo-build
  ```
* This option may later become mandatory if/when the js_of_ocaml front-end also fetches similar `*.cmo` files.
* Regarding the `ocamlc` **naming convention**:  
  require that the input exercise id basename `exo-name` matches `[0-9A-Za-z_-]+`, otherwise raise a warning,  
  then bijectively replace `_` → `_0` and `-` → `_1` in `exo`, then yield the output filename `dir/given_exo_1name.cmo`.

### Checklist

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide.
* [x] Add/update [tests](https://github.com/ocaml-sf/learn-ocaml/tree/master/tests#readme)
* [ ] Implement the `learn-ocaml-client` counterpart of this feature within this PR
  <!-- you can add more items to summarize what remains to do. -->

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging (using a regular `Merge` for this one)