### PR TITLE
fix(docker): Add missing libs for compiler-libs related features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,11 @@ EXPOSE 8443
 USER learn-ocaml
 WORKDIR /home/learn-ocaml
 
+ARG opam_switch="/home/opam/.opam/4.12"
+
 COPY --from=compilation /home/opam/install-prefix /usr
+COPY --from=compilation "$opam_switch/bin"/ocaml* "$opam_switch/bin/"
+COPY --from=compilation "$opam_switch/lib/ocaml" "$opam_switch/lib/ocaml/"
 
 ENTRYPOINT ["dumb-init","/usr/bin/learn-ocaml","--sync-dir=/sync","--repo=/repository"]
 CMD ["build","serve"]

--- a/Dockerfile.test-server
+++ b/Dockerfile.test-server
@@ -64,7 +64,11 @@ EXPOSE 8443
 USER learn-ocaml
 WORKDIR /home/learn-ocaml
 
+ARG opam_switch="/home/opam/.opam/4.12"
+
 COPY --from=compilation /home/opam/install-prefix /usr
+COPY --from=compilation "$opam_switch/bin"/ocaml* "$opam_switch/bin/"
+COPY --from=compilation "$opam_switch/lib/ocaml" "$opam_switch/lib/ocaml/"
 
 ENTRYPOINT ["dumb-init","/usr/bin/learn-ocaml","--sync-dir=/sync","--repo=/repository"]
 CMD ["build","serve"]


### PR DESCRIPTION
Spotted with (docker, `learn-ocaml build --enable-cmo-build`) from PR #458:
```
LOGS:
Learnocaml v.0.14.0 running.
Updating app at ./www
given_int_0exo           (build .cmo)
Cannot process exercises: Env.Error(_)
```
Note: this latter exception backtrace could be improved (giving more details).

Close #438