### PR TITLE
fix(grader): Workaround issue #457 about the `Introspection` module

### DIFF
--- a/src/grader/grading.ml
+++ b/src/grader/grading.ml
@@ -139,6 +139,10 @@ let get_grade
       handle_error (internal_error [%i"while preparing the tests"]) @@
       Toploop_ext.use_string ~print_outcome ~ppf_answer
         "module Report = Learnocaml_report" ;
+      (* The following 3 lines are just a workaround for issue #457 *)
+      handle_error (internal_error [%i"while preparing the tests"]) @@
+      Toploop_ext.use_string ~print_outcome ~ppf_answer
+        "module Introspection = Introspection" ;
       set_progress [%i"Launching the test bench."] ;
 
       let () =


### PR DESCRIPTION
Graders using module `Introspection` (which used to work with 0.12)
should now work with `ocamlsf/learn-ocaml:master` as well, i.e., they
should not raise `Ctype.Unification_trace.Unify(_)` any longer.

href: https://github.com/ocaml-sf/learn-ocaml/issues/457#issuecomment-962979327

Close #457