### PR TITLE
docs: Improve `{ISSUE,PULL_REQUEST}_TEMPLATE`s, slightly

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,9 +40,11 @@ Steps to reproduce the behavior:
 
 ## Current configuration
 
+<!-- You can write "N/A" for the items that sound irrelevant to you -->
 * OS name (and version): 
 * Browser name (and version): 
 * `learn-ocaml --version`: 
+* `git describe --long --always --abbrev=40`: 
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -28,9 +28,11 @@ assignees: ''
 
 ## Current configuration
 
+<!-- You can write "N/A" for the items that sound irrelevant to you -->
 * OS name (and version): 
 * Browser name (and version): 
 * `learn-ocaml --version`: 
+* `git describe --long --always --abbrev=40`: 
 
 ## Additional context
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,3 +28,4 @@
 * Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
 * Make sure the PR has a milestone
 * Assign yourself before merging
+* We can squash-merge 1-commit PRs (use a header with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples), add a footer with `Fix #…` if need be)


### PR DESCRIPTION
* **Kind:** enhancement

### Description

This patch is a follow-up of PR ocaml-sf/learn-ocaml#453

### Checklist

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging
* We can squash-merge 1-commit PRs (use a header with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples), add a footer with `Fix #…` if need be)