### PR TITLE
feat: Build `learn-ocaml-www.zip` → `learn-ocaml --contents-dir=www`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
               mv -v -- "$d/$b" "target/$b-$d-x86_64"
             done
           done
+          mv -v -- learn-ocaml-www.zip target/learn-ocaml-www.zip
       - name: Add binaries to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/static-builds.yml
+++ b/.github/workflows/static-builds.yml
@@ -12,6 +12,29 @@ on:
     # test master every Saturday at 08:00 UTC
     - cron: '0 8 * * 6'
 jobs:
+  learn-ocaml-www-zip:
+    name: Build learn-ocaml-www.zip archive
+    if: ${{ github.event_name != 'schedule' || github.repository == 'ocaml-sf/learn-ocaml' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        archive: ["learn-ocaml-www.zip"]
+        # we could use an env var, albeit it would be less convenient
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Build learn-ocaml-compilation
+        run: 'docker build -t learn-ocaml-compilation --target=compilation .'
+      - name: Build ${{ matrix.archive }}
+        run: |
+          docker run -i --rm -w /home/opam/install-prefix/share/learn-ocaml -u 0 --entrypoint='' learn-ocaml-compilation sh -c \
+          'apk add --no-cache zip >&2 && zip -r ${{ matrix.archive }} www >&2 && tar c ${{ matrix.archive }}' | \
+          tar vx
+      - name: Upload ${{ matrix.archive }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.archive }}
+          path: ${{ matrix.archive }}
   static-bin-linux:
     name: Builds static Linux binaries
     if: ${{ github.event_name != 'schedule' || github.repository == 'ocaml-sf/learn-ocaml' }}


### PR DESCRIPTION
* **Kind:** feature

### Description

The aim is to build/deploy (among the release assets) an archive `learn-ocaml-www.zip` so that we can do:

```bash
unzip learn-ocaml-www.zip
mkdir server && cd server
learn-ocaml build serve --contents-dir="$(readlink -f ../www)"
```

### Checklist

<!-- You can remove all the check-boxes that are not applicable. -->

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)
* [ ] Add/update [documentation](https://github.com/ocaml-sf/learn-ocaml/tree/master/docs)
  <!-- if there are some user-facing changes. -->

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging
* We can squash-merge 1-commit PRs (use a header with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples), add a footer with `Fix #…` if need be)