### PR TITLE
deps(opam): Bump `ssl` version, fixes FTBFS on macOS

### DIFF
--- a/learn-ocaml-client.opam
+++ b/learn-ocaml-client.opam
@@ -28,7 +28,7 @@ depends: [
   "dune" {>= "2.3.0"}
   "ezjsonm"
   "gg"
-  "ipaddr" {= "2.8.0" }
+  "ipaddr" {= "2.9.0" }
   "lwt" {>= "4.0.0"}
   "lwt_ssl"
   "ocaml" {(>= "4.12") & (< "4.13~")}

--- a/learn-ocaml-client.opam
+++ b/learn-ocaml-client.opam
@@ -33,6 +33,7 @@ depends: [
   "lwt_ssl"
   "ocaml" {(>= "4.12") & (< "4.13~")}
   "ocamlfind" {build}
+  "ocaml-migrate-parsetree" {= "1.8.0"}
   "ocp-indent-nlfork"
   "ocplib-json-typed" {>= "0.7"}
   "ocp-ocamlres" {>= "0.4"}

--- a/learn-ocaml-client.opam
+++ b/learn-ocaml-client.opam
@@ -41,7 +41,7 @@ depends: [
   "ppxlib"
   "ppx_sexp_conv"
   "ppx_tools"
-  "ssl" {= "0.5.5"}
+  "ssl" {= "0.5.10"}
   "vg"
 ]
 build: [

--- a/learn-ocaml-client.opam.locked
+++ b/learn-ocaml-client.opam.locked
@@ -55,7 +55,7 @@ depends: [
   "fmt" {= "0.8.9"}
   "gg" {= "0.9.3"}
   "hex" {= "1.4.0"}
-  "ipaddr" {= "2.8.0"}
+  "ipaddr" {= "2.9.0"}
   "jbuilder" {= "1.0+beta20.2"}
   "js_of_ocaml" {= "3.9.0"}
   "js_of_ocaml-compiler" {= "3.9.1"}

--- a/learn-ocaml-client.opam.locked
+++ b/learn-ocaml-client.opam.locked
@@ -95,7 +95,7 @@ depends: [
   "seq" {= "0.2.2"}
   "sexplib" {= "v0.14.0"}
   "sexplib0" {= "v0.14.0"}
-  "ssl" {= "0.5.5"}
+  "ssl" {= "0.5.10"}
   "stdlib-shims" {= "0.3.0"}
   "stringext" {= "1.6.0"}
   "topkg" {= "1.0.3"}

--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -45,6 +45,7 @@ depends: [
   "markup-lwt"
   "ocaml" {(>= "4.12") & (< "4.13~")}
   "ocamlfind" {build}
+  "ocaml-migrate-parsetree" {= "1.8.0"}
   "ocp-indent-nlfork"
   "ocplib-json-typed" {>= "0.7"}
   "ocplib-json-typed-browser" {>= "0.7"}

--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -30,7 +30,7 @@ depends: [
   "dune" {>= "2.3.0"}
   "easy-format" {>= "1.3.0" }
   "ezjsonm"
-  "ipaddr" {>= "2.8.0" }
+  "ipaddr" {= "2.9.0" }
   "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
   "js_of_ocaml-compiler" {>= "3.3.0"}
   "js_of_ocaml-lwt"

--- a/learn-ocaml.opam
+++ b/learn-ocaml.opam
@@ -58,7 +58,7 @@ depends: [
   "ppx_tools"
   "ppx_tools_versioned"
   "re"
-  "ssl" {= "0.5.5"}
+  "ssl" {= "0.5.10"}
   "uutf" {>= "1.0" }
   "vg"
   "yojson" {>= "1.4.0" }

--- a/learn-ocaml.opam.locked
+++ b/learn-ocaml.opam.locked
@@ -55,7 +55,7 @@ depends: [
   "fpath" {= "0.7.3"}
   "gg" {= "0.9.3"}
   "hex" {= "1.4.0"}
-  "ipaddr" {= "2.8.0"}
+  "ipaddr" {= "2.9.0"}
   "jbuilder" {= "1.0+beta20.2"}
   "js_of_ocaml" {= "3.9.0"}
   "js_of_ocaml-compiler" {= "3.9.1"}

--- a/learn-ocaml.opam.locked
+++ b/learn-ocaml.opam.locked
@@ -107,7 +107,7 @@ depends: [
   "seq" {= "0.2.2"}
   "sexplib" {= "v0.14.0"}
   "sexplib0" {= "v0.14.0"}
-  "ssl" {= "0.5.5"}
+  "ssl" {= "0.5.10"}
   "stdlib-shims" {= "0.3.0"}
   "stringext" {= "1.6.0"}
   "topkg" {= "1.0.3"}

--- a/src/main/linking_flags.sh
+++ b/src/main/linking_flags.sh
@@ -52,7 +52,7 @@ case $(uname -s) in
     Linux)
         case $(. /etc/os-release && echo $ID) in
             alpine)
-                COMMON_LIBS="camlstr ssl_threads_stubs ssl crypto cstruct_stubs bigstringaf_stubs lwt_unix_stubs unix c"
+                COMMON_LIBS="camlstr ssl_stubs ssl crypto cstruct_stubs bigstringaf_stubs lwt_unix_stubs unix c"
                 # `m` and `pthread` are built-in musl
                 echo2 '(-noautolink'
                 echo2 ' -cclib -Wl,-Bstatic'
@@ -68,7 +68,7 @@ case $(uname -s) in
         esac
         ;;
     Darwin)
-        COMMON_LIBS="camlstr ssl_threads_stubs /usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a cstruct_stubs bigstringaf_stubs lwt_unix_stubs unix"
+        COMMON_LIBS="camlstr ssl_stubs /usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a cstruct_stubs bigstringaf_stubs lwt_unix_stubs unix"
         # `m` and `pthread` are built-in in libSystem
         echo2 '(-noautolink'
         for l in $EXTRA_LIBS $COMMON_LIBS; do


### PR DESCRIPTION
* **Kind:** bugfix

### Description

* Necessary on macOS to avoid https://github.com/savonet/ocaml-ssl/issues/34
* See also https://github.com/savonet/ocaml-ssl/releases

### Checklist

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging
* We can squash-merge 1-commit PRs (use a header with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples), add a footer with `Fix #…` if need be)