### PR TITLE
fix: Change `learn-ocaml-www.zip` inner dir (`www` → `learn-ocaml-www`)

### DIFF
--- a/.github/workflows/static-builds.yml
+++ b/.github/workflows/static-builds.yml
@@ -18,23 +18,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        archive: ["learn-ocaml-www.zip"]
+        arch_dir: ["learn-ocaml-www"]
         # we could use an env var, albeit it would be less convenient
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Build learn-ocaml-compilation
         run: 'docker build -t learn-ocaml-compilation --target=compilation .'
-      - name: Build ${{ matrix.archive }}
+      - name: 'Build ${{ matrix.arch_dir }}.zip'
         run: |
           docker run -i --rm -w /home/opam/install-prefix/share/learn-ocaml -u 0 --entrypoint='' learn-ocaml-compilation sh -c \
-          'apk add --no-cache zip >&2 && zip -r ${{ matrix.archive }} www >&2 && tar c ${{ matrix.archive }}' | \
+          'mv www "${{ matrix.arch_dir }}" >&2 && apk add --no-cache zip >&2 && zip -r "${{ matrix.arch_dir }}.zip" "${{ matrix.arch_dir }}" >&2 && tar c "${{ matrix.arch_dir }}.zip"' | \
           tar vx
-      - name: Upload ${{ matrix.archive }}
+      - name: 'Upload ${{ matrix.arch_dir }}.zip'
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.archive }}
-          path: ${{ matrix.archive }}
+          name: '${{ matrix.arch_dir }}.zip'
+          path: '${{ matrix.arch_dir }}.zip'
   static-bin-linux:
     name: Builds static Linux binaries
     if: ${{ github.event_name != 'schedule' || github.repository == 'ocaml-sf/learn-ocaml' }}


### PR DESCRIPTION
* **Kind:** minor bugfix

### Description

Motivation: avoid a conflict between "source www" and "generated www",
doing `unzip learn-ocaml-www.zip; learn-ocaml build --contents-dir=…`.

Related: e36d874551f453231142fdabf8971ea708437687

### Checklist

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging
* We can squash-merge 1-commit PRs (use a header with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples), add a footer with `Fix #…` if need be)