### PR TITLE
chore(.github/ISSUE_TEMPLATE/*.md): Add `--tags`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,7 +44,7 @@ Steps to reproduce the behavior:
 * OS name (and version): 
 * Browser name (and version): 
 * `learn-ocaml --version`: 
-* `git describe --long --always --abbrev=40`: 
+* `git describe --long --always --abbrev=40 --tags`: 
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -32,7 +32,7 @@ assignees: ''
 * OS name (and version): 
 * Browser name (and version): 
 * `learn-ocaml --version`: 
-* `git describe --long --always --abbrev=40`: 
+* `git describe --long --always --abbrev=40 --tags`: 
 
 ## Additional context
 


### PR DESCRIPTION
* **Kind:** documentation

### Description

Add `--tags`

Otherwise, `git describe` does not seem to read tags created by release-please.