### PR TITLE
fix(learnocaml_common.ml): change secret to token for authentificatio…

### DIFF
--- a/src/app/learnocaml_common.mli
+++ b/src/app/learnocaml_common.mli
@@ -232,7 +232,7 @@ val setup_tab_text_prelude_pane : string -> unit
 
 val setup_prelude_pane : 'a Ace.editor -> string -> unit
 
-val get_token : ?has_server:bool -> unit -> Learnocaml_data.student Learnocaml_data.token option Lwt.t
+val get_token : ?has_server:bool -> unit -> Learnocaml_data.Token.t option Lwt.t
 
 module Display_exercise :functor
   (_ : sig


### PR DESCRIPTION
* **Kind:** bugfix 


* Close #488

### Description

Change secret to token for authentification in Exercise link

### Checklist

<!-- You can remove all the check-boxes that are not applicable. -->

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)
* [ ] Add/update [tests](https://github.com/ocaml-sf/learn-ocaml/tree/master/tests#readme)
  <!-- if the change impacts the grading feature. -->
* [ ] Add/update [documentation](https://github.com/ocaml-sf/learn-ocaml/tree/master/docs)
  <!-- if there are some user-facing changes. -->
* [ ] …
  <!-- you can add more items to summarize what remains to do. -->

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging
* We can squash-merge 1-commit PRs (use a header with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples), add a footer with `Fix #…` if need be)
