### PR TITLE
build(static-binaries): Fix building of static binaries on CI

### DIFF
--- a/.github/workflows/static-builds.yml
+++ b/.github/workflows/static-builds.yml
@@ -53,7 +53,6 @@ jobs:
         run: |
           bin=(./learn-ocaml-client ./learn-ocaml-server ./learn-ocaml)
           file "${bin[@]}"
-          ldd "${bin[@]}"
           for b in "${bin[@]}"; do ( set -x; "$b" --version ); done
       - name: Archive static binaries
         run: |


### PR DESCRIPTION
* **Kind:** bugfix

<!-- For a bug fix, make sure the bug was already reported in an issue. -->

* Close #496

### Description

We use another docker image to build the static binairies under GNU/Linux.
