### PR TITLE
ci(pin-artifacts.yml): Add build artifacts links within upstream commits status

### DIFF
--- a/.github/workflows/pin-artifacts.yml
+++ b/.github/workflows/pin-artifacts.yml
@@ -1,0 +1,46 @@
+name: Pin artifacts
+on:
+  workflow_run:
+    workflows: ["Generate static binaries"]
+    types: ["completed"]
+
+jobs:
+  # Make artifacts links more visible for the upstream project
+  pin-artifacts:
+    permissions:
+      statuses: write
+    name: Add artifacts links to commit statuses
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'ocaml-sf/learn-ocaml' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add artifacts links to commit status
+        run: |
+          set -x
+          workflow_id=${{ github.event.workflow_run.workflow_id }}
+          run_id=${{ github.event.workflow_run.id }}  # instead of ${{ github.run_id }}
+          run_number=${{ github.event.workflow_run.run_number }}
+          head_branch=${{ github.event.workflow_run.head_branch }}
+          head_sha=${{ github.event.workflow_run.head_sha }}  # instead of ${{ github.event.pull_request.head.sha }} (or ${{ github.sha }})
+          check_suite_id=${{ github.event.workflow_run.check_suite_id }}
+          set +x
+
+          curl \
+          -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
+          | jq '[.artifacts | .[] | {"id": .id, "name": .name, "created_at": .created_at, "expires_at": .expires_at, "archive_download_url": .archive_download_url}] | sort_by(.name)' \
+          > artifacts.json
+
+          cat artifacts.json
+
+          < artifacts.json jq -r ".[] | \
+            .name + \"§\" + \
+            ( .id | tostring | \"https://github.com/${{ github.repository }}/suites/${check_suite_id}/artifacts/\" + . ) + \"§\" + \
+            ( \"Link to \" + .name + \".zip [\" + ( .created_at | sub(\"T.*\"; \"→\") ) + ( .expires_at | sub(\"T.*\"; \"] (you must be logged)\" ) ) )" \
+          | while IFS="§" read name url descr; do
+              curl \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ github.token }}" \
+              "https://api.github.com/repos/${{ github.repository }}/statuses/${head_sha}" \
+              -d "$( printf '{"state":"%s","target_url":"%s","description":"%s","context":"%s"}' "${{ github.event.workflow_run.conclusion }}" "$url" "$descr" "$name (artifact)" )"
+          done

--- a/.github/workflows/static-builds.yml
+++ b/.github/workflows/static-builds.yml
@@ -16,6 +16,8 @@ jobs:
     name: Build learn-ocaml-www.zip archive
     if: ${{ github.event_name != 'schedule' || github.repository == 'ocaml-sf/learn-ocaml' }}
     runs-on: ubuntu-latest
+    outputs:
+      artifact: ${{ steps.export.outputs.artifact }}
     strategy:
       matrix:
         arch_dir: ["learn-ocaml-www"]
@@ -35,10 +37,15 @@ jobs:
         with:
           name: '${{ matrix.arch_dir }}.zip'
           path: '${{ matrix.arch_dir }}.zip'
+      - id: export
+        name: Export artifact filename
+        run: echo "artifact=${{ matrix.arch_dir }}.zip" >> $GITHUB_OUTPUT
   static-bin-linux:
     name: Builds static Linux binaries
     if: ${{ github.event_name != 'schedule' || github.repository == 'ocaml-sf/learn-ocaml' }}
     runs-on: ubuntu-latest
+    outputs:
+      artifact: ${{ steps.export.outputs.artifact }}
     strategy:
       matrix:
         artifact: ["learn-ocaml-linux-x86_64.tar.gz"]
@@ -64,10 +71,15 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
+      - id: export
+        name: Export artifact filename
+        run: echo "artifact=${{ matrix.artifact }}" >> $GITHUB_OUTPUT
   static-bin-macos:
     name: Builds static Macos binaries
     if: ${{ github.event_name != 'schedule' || github.repository == 'ocaml-sf/learn-ocaml' }}
     runs-on: macos-latest
+    outputs:
+      artifact: ${{ steps.export.outputs.artifact }}
     env:
       OPAMYES: 1
       OPAMDEPEXTYES: 1
@@ -115,3 +127,6 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
+      - id: export
+        name: Export artifact filename
+        run: echo "artifact=${{ matrix.artifact }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/static-builds.yml
+++ b/.github/workflows/static-builds.yml
@@ -16,8 +16,6 @@ jobs:
     name: Build learn-ocaml-www.zip archive
     if: ${{ github.event_name != 'schedule' || github.repository == 'ocaml-sf/learn-ocaml' }}
     runs-on: ubuntu-latest
-    outputs:
-      artifact: ${{ steps.export.outputs.artifact }}
     strategy:
       matrix:
         arch_dir: ["learn-ocaml-www"]
@@ -37,15 +35,10 @@ jobs:
         with:
           name: '${{ matrix.arch_dir }}.zip'
           path: '${{ matrix.arch_dir }}.zip'
-      - id: export
-        name: Export artifact filename
-        run: echo "artifact=${{ matrix.arch_dir }}.zip" >> $GITHUB_OUTPUT
   static-bin-linux:
     name: Builds static Linux binaries
     if: ${{ github.event_name != 'schedule' || github.repository == 'ocaml-sf/learn-ocaml' }}
     runs-on: ubuntu-latest
-    outputs:
-      artifact: ${{ steps.export.outputs.artifact }}
     strategy:
       matrix:
         artifact: ["learn-ocaml-linux-x86_64.tar.gz"]
@@ -71,15 +64,10 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
-      - id: export
-        name: Export artifact filename
-        run: echo "artifact=${{ matrix.artifact }}" >> $GITHUB_OUTPUT
   static-bin-macos:
     name: Builds static Macos binaries
     if: ${{ github.event_name != 'schedule' || github.repository == 'ocaml-sf/learn-ocaml' }}
     runs-on: macos-latest
-    outputs:
-      artifact: ${{ steps.export.outputs.artifact }}
     env:
       OPAMYES: 1
       OPAMDEPEXTYES: 1
@@ -127,6 +115,3 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
-      - id: export
-        name: Export artifact filename
-        run: echo "artifact=${{ matrix.artifact }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
* **Kind:** enhancement

* Close #475

### Description

Make it easier for end-users to download static binaries from unmerged PRs.

*Note: due to the standard permissions enforced by GitHub, the provided links require end users to be logged in github.com, and only work for 90 days.*

@yurug: as this PR is not critical but very useful to address #475, **and** it can't be tested anew (beyond my separated test below) before the new `.yml` is part of the repo itself, I plan to merge it tonight; but feel free to comment meanwhile anyway, if need be!

### Screenshots as a demo

cf. https://github.com/pfitaxel/learn-ocaml-issue475-poc :

#### In commit statuses
![2022-11-26_16-49-10_Screenshot_issue475-poc_commit](https://user-images.githubusercontent.com/10367254/204097321-92cb902b-43c2-40e9-a8dc-9284ba12925f.png)

#### In PR checks
![2022-11-26_16-49-41_Screenshot_issue475-poc_PR](https://user-images.githubusercontent.com/10367254/204097312-ff09adaf-5af3-45ab-908f-0cd6ac7e9a5e.png)

### Checklist

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging
* **This PR needs to be squash-merged** (the first commit, reverted later, can be useful for historical reasons)