### PR TITLE
fix(learnocaml_report.css): Display multiple spaces in code excerpts

### DIFF
--- a/static/css/learnocaml_report.css
+++ b/static/css/learnocaml_report.css
@@ -18,6 +18,7 @@
 }
 #learnocaml-report .code {
   font-family: 'Inconsolata', monospace;
+  white-space: pre-wrap;
   display: inline;
   font-size: 18px;
   line-height: 18px;


### PR DESCRIPTION
* **Kind:** bugfix

* Close #502

### Description

Fix a CSS issue in grading UI.

### Checklist

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging
* We can squash-merge 1-commit PRs (use a header with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples), add a footer with `Fix #…` if need be)