### PR TITLE
Stop using middle button to launch partition

### DIFF
--- a/.ci-macosx.sh
+++ b/.ci-macosx.sh
@@ -20,6 +20,8 @@ rm -f /usr/local/bin/idle3.11
 rm -f /usr/local/bin/pydoc3.11
 rm -f /usr/local/bin/python3.11
 rm -f /usr/local/bin/python3.11-config
+rm -f /usr/local/lib/libtcl8.6.dylib
+rm -f /usr/local/lib/libtk8.6.dylib
 brew upgrade
 
 brew install pkg-config

--- a/docs/howto-classify-students-answers.md
+++ b/docs/howto-classify-students-answers.md
@@ -21,7 +21,7 @@ Follow these steps:
 
 1. Go to the teaching tab in the LearnOCaml Web UI (needs a teacher token).
 
-2. Middle-click on the exercise `x` in the list of exercises.
+2. Hold Ctrl (on macOS: Hold ⌘) and left click on the exercise `x` in the list of exercises.
 
 3. Enter `foo` in the dialog box.
 

--- a/src/app/learnocaml_teacher_tab.ml
+++ b/src/app/learnocaml_teacher_tab.ml
@@ -236,7 +236,13 @@ let rec teacher_tab token _select _params () =
               H.a_ondblclick (fun _ -> open_exercise_ ());
               H.a_onmouseup (fun ev ->
                   Js.Optdef.case ev##.which (fun () -> true) @@ fun btn ->
-                  if btn = Dom_html.Middle_button then open_partition_ () else true);
+                  if (Js.to_bool ev##.ctrlKey ||
+                      Js.to_bool ev##.metaKey (* ⌘ on macOS *))
+                     && btn = Dom_html.Left_button
+                  then
+                    open_partition_ ()
+                  else
+                    true);
             ] [
               auto_checkbox_td ();
               H.td ~a:[indent_style group_level]


### PR DESCRIPTION
* **Kind:** bugfix / enhancement / feature

<!-- For a bug fix, make sure the bug was already reported in an issue. -->

* Close #500

### Description

Middle button is not a portable notion, especially on Mac OS. This PR
replaces middle button with a composition of key CTRL and left click.

### Checklist

<!-- You can remove all the check-boxes that are not applicable. -->

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)
* [x] Add/update [documentation](https://github.com/ocaml-sf/learn-ocaml/tree/master/docs)
  <!-- if there are some user-facing changes. -->

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging
* We can squash-merge 1-commit PRs (use a header with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples), add a footer with `Fix #…` if need be)
