### PR TITLE
ci(macos): Fix `brew upgrade` failure, bis

### DIFF
--- a/.ci-macosx.sh
+++ b/.ci-macosx.sh
@@ -20,6 +20,8 @@ rm -f /usr/local/bin/idle3.11
 rm -f /usr/local/bin/pydoc3.11
 rm -f /usr/local/bin/python3.11
 rm -f /usr/local/bin/python3.11-config
+rm -f /usr/local/lib/libtcl8.6.dylib
+rm -f /usr/local/lib/libtk8.6.dylib
 brew upgrade
 
 brew install pkg-config


### PR DESCRIPTION
* **Kind:** bugfix

### Description

cf. https://github.com/ocaml-sf/learn-ocaml/wiki/(CI)(macOS)-How-to-fix-spurious-brew-link-failures

### Checklist

<!-- You can remove all the check-boxes that are not applicable. -->

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)
* [x] Add/update [documentation](https://github.com/ocaml-sf/learn-ocaml/tree/master/docs)

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR)
* Make sure the PR has a milestone
* Assign yourself before merging
* We can squash-merge 1-commit PRs (use a header with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples), add a footer with `Fix #…` if need be)