### PR TITLE
feat: Add ability to assign different exercises to each student automatically

### DIFF
--- a/docs/howto-generate-assignment.md
+++ b/docs/howto-generate-assignment.md
@@ -1,0 +1,22 @@
+How to Assign Exercises Automatically
+=====================================
+
+## Context
+If you are a teacher with a large number of students and want to assign a different set of exercises to each student based on their level and exercise difficulty, this can be a time-consuming process. 
+
+With this feature, you can save time and effort when assigning exercises to your students on the Learn-OCaml platform.
+
+## How-To
+1. Assign each student with their current level. You can do this by adding a tag to each student's profile indicating whether they are in their 1st, 2nd, or 3rd year of their bachelor's degree. If no tag is provided, the system will assume that the student is in their 3rd year.
+
+2. Choose which students you want to assign exercises to. You can select individual students, groups of students, or the entire class.
+
+3. Choose which exercises you want to assign. You can select exercises based on difficulty level: basic (up to but not including 2 stars), intermediate (up to but not including 3 stars), or consolidated (everything from 3 stars).
+
+4. Click the "Generate Assignment" button.
+
+## Notes
+The assignments are generated based on the student's level and exercise difficulty. The settings for this feature can be found in the file src/app/gen_assignment.ml from line 6 to 8. Each line contains an array of arrays of integers, which represent the possible assignments that a student from each corresponding level can receive. Each inner array represents one of these possible assignments, and each integer represents an exercise with one of the difficulty levels mentioned above.
+
+
+

--- a/src/app/dune
+++ b/src/app/dune
@@ -39,7 +39,8 @@
             learnocaml_toplevel
             js_of_ocaml-ppx
             ocplib_i18n)
- (modules Learnocaml_teacher_tab
+ (modules Gen_assignment
+          Learnocaml_teacher_tab
           Learnocaml_index_main)
  (preprocess (pps ppx_ocplib_i18n js_of_ocaml-ppx))
 )

--- a/src/app/gen_assignment.ml
+++ b/src/app/gen_assignment.ml
@@ -183,8 +183,9 @@ let gen_assignment (basic, intermediate, consolidated) level =
     let rec fill_requirements = function 
       | []                  -> ()
       | (idx, exe_id)::tl ->
-        let {title;stars;id;requirements} = Hashtbl.find (match a.(idx) with | 1 -> basic | 2 -> intermediate | _ ->
-          consolidated) exe_id in
+        let {title;stars;id;_} = Hashtbl.find (match a.(idx) with | 1 -> basic | 2 -> intermediate | _ ->
+          consolidated) exe_id 
+        in
         if Array.mem title r then fill_requirements tl 
         else ( 
           let new_id = find_place stars in

--- a/src/app/gen_assignment.ml
+++ b/src/app/gen_assignment.ml
@@ -1,0 +1,245 @@
+(*
+	##########################
+	#        SETTINGS        #
+	##########################
+*)
+let p = [|[|1;1;1;2;2|]|]
+let a = [|[|1;1;2;2;2|]; [|1;1;2;2;3|]|]
+let e = [|[|2;2;3;3;3|]; [|2;2;2;3;3|]|]
+
+
+
+(*
+	#################################
+	#    DATA TYPES & EXCEPTIONS    #
+	#################################
+*)
+type difficulty = | Basic | Intermediate | Consolidated
+
+
+type exercise = {
+	title         : string;
+	stars         : difficulty;
+	id            : float;
+	requirements  : float list
+}
+
+
+type student = {
+	token : Learnocaml_data.Token.Map.key;
+	level : int
+}
+
+
+exception Invalid_argument of string
+exception No_more_exercises 
+
+
+
+(*
+	##########################
+	#     AUX FUNCTIONS      #
+	##########################
+*)
+let diff_to_int = function
+  | Basic         -> 1
+  | Intermediate  -> 2
+  | _             -> 3
+
+
+let float_to_diff = function
+	| x when x < 2. -> Basic
+	| x when x < 3. -> Intermediate
+	| _             -> Consolidated
+
+
+let htbl_to_array htbl = 
+	Array.of_list (Hashtbl.fold (fun k _ acc -> k::acc) htbl [])
+
+	
+let create_student t lvl =
+	{
+		token = t;
+		level = 
+			match lvl with
+			| "1st" -> 1
+			| "2nd" -> 2
+			| _     -> 3
+	}
+
+
+let create_htbls availabel_exercises = 
+	let basic         = Hashtbl.create 10 in
+	let intermediate  = Hashtbl.create 10 in
+	let consolidated  = Hashtbl.create 10 in
+	let add_exe_to_htbl exe = 
+		let htbl = (
+			match exe.stars with
+			| Basic         -> basic
+			| Intermediate  -> intermediate 
+			| Consolidated  -> consolidated
+		) in
+		Hashtbl.add htbl (exe.id) exe
+	in
+	let rec sort_exercises = function
+		| []    -> ()
+		| exe::t  -> add_exe_to_htbl exe; sort_exercises t
+	in
+	sort_exercises availabel_exercises;
+	basic, intermediate, consolidated
+	
+
+let gen_assignment (basic, intermediate, consolidated) level =
+	let basic_a         = htbl_to_array basic in
+	let intermediate_a  = htbl_to_array intermediate in
+	let consolidated_a  = htbl_to_array consolidated in
+	let assignment  		= 
+		match level with
+		| 1 -> p.(Random.int (Array.length p))
+		| 2 -> a.(Random.int (Array.length a))
+		| _ -> e.(Random.int (Array.length e))
+	in
+	let init_assignment () = 
+		let rec init_aux b i c idx =
+			if (idx < (Array.length assignment)) then
+				match assignment.(idx) with
+				| 1 -> if b > 0 then init_aux (b-1) i c (idx+1)
+					else if i > 0 then (assignment.(idx) <- 2; init_aux b (i-1) c (idx+1))
+					else (assignment.(idx) <- 3; init_aux b i (c-1) (idx+1))
+				| 2 -> if i > 0 then init_aux b (i-1) c (idx+1)
+					else if b > 0 then (assignment.(idx) <- 1; init_aux (b-1) i c (idx+1))
+					else (assignment.(idx) <- 3; init_aux b i (c-1) (idx+1))
+				| _ -> if c > 0 then init_aux b i (c-1) (idx+1)
+					else if i > 0 then (assignment.(idx) <- 2; init_aux b (i-1) c (idx+1))
+					else (assignment.(idx) <- 1; init_aux (b-1) i c (idx+1))
+		in
+		init_aux (Array.length basic_a) (Array.length intermediate_a) (Array.length consolidated_a) 0 
+	in
+	let diff_to_exercise a = 
+		let r = Array.make 6 "" in
+		let shuffle_a v = 
+			let n = Array.length v in
+			let v = Array.copy v in
+			for i = n - 1 downto 1 do
+				let k = Random.int (i+1) in
+				let x = v.(k) in
+				v.(k) <- v.(i);
+				v.(i) <- x
+			done;
+			v
+		in
+		let b_a = shuffle_a basic_a in
+		let i_a = shuffle_a intermediate_a in
+		let c_a = shuffle_a consolidated_a in
+    let get_requirement (k : float) =
+      match Hashtbl.find_opt basic k with
+      | Some x  -> x.requirements
+      | None    ->
+        match Hashtbl.find_opt intermediate k with
+        | Some x  -> x.requirements
+        | None    -> (Hashtbl.find consolidated k).requirements
+    in
+		let rec translate_aux b i c req idx = 
+			if (idx >= 0) then
+				match a.(idx) with
+				| 1 -> (
+          let new_req = get_requirement b_a.(b) in 
+          r.(idx) <- (Hashtbl.find basic b_a.(b)).title; 
+          translate_aux (b+1) i c (if new_req <> [] then ((idx,List.hd new_req)::req) else req) (idx - 1))
+				| 2 -> (
+          let new_req = get_requirement i_a.(i) in 
+          r.(idx) <- (Hashtbl.find intermediate i_a.(i)).title; 
+          translate_aux b (i+1) c (if new_req <> [] then ((idx,List.hd new_req)::req) else req) (idx - 1))
+				| _ -> (
+          let new_req = get_requirement c_a.(c) in 
+          r.(idx) <- (Hashtbl.find consolidated c_a.(c)).title; 
+          translate_aux b i (c+1) (if new_req <> [] then ((idx,List.hd new_req)::req) else req) (idx - 1))
+      else b,i,c,req
+		in
+    let b,i,c,req = translate_aux 0 0 0 [] ((Array.length a)-1) in
+    let changed   = Array.make 5 0 in 
+    let find_place d = 
+      let d = diff_to_int d in
+      let rec aux id =
+        if (id >= 0) then (
+          if (changed.(id) = 0) then
+            match d with
+            | 1 -> id
+            | 2 -> id
+            | _ -> id
+          else aux (id-1)
+        )
+        else -1 
+      in
+      aux 4 
+    in
+    let change_exercise idx =
+      let d = a.(idx) in
+      match d with
+      | 1 -> if b < ((Array.length b_a)-1) then b+1 else raise No_more_exercises
+      | 2 -> if i < ((Array.length i_a)-1) then i+1 else raise No_more_exercises
+      | _ -> if c < ((Array.length c_a)-1) then c+1 else raise No_more_exercises
+    in
+    let rec fill_requirements = function 
+      | []                  -> ()
+      | (idx, exe_id)::tl ->
+        let {title;stars;id;requirements} = Hashtbl.find (match a.(idx) with | 1 -> basic | 2 -> intermediate | _ ->
+          consolidated) exe_id in
+        if Array.mem title r then fill_requirements tl 
+        else ( 
+          let new_id = find_place stars in
+          changed.(idx) <- 1;
+          if new_id <> -1 then (
+            let new_req = get_requirement id in 
+            r.(new_id) <- title; 
+            changed.(new_id) <- 1;
+            fill_requirements (if new_req <> [] then ((new_id, List.hd new_req)::tl) else tl)
+          )
+          else (
+            if r.(5) = "" then (
+              let new_req = get_requirement id in 
+              r.(5) <- title; 
+              fill_requirements (if new_req <> [] then ((5, List.hd new_req)::tl) else tl)
+            )
+            else
+              try
+                let new_id = change_exercise idx in
+                let new_req = get_requirement (match a.(idx) with | 1 -> b_a.(new_id) | 2 -> i_a.(new_id) | _ -> c_a.(new_id)) in 
+                r.(idx) <-  (match a.(idx) with | 1 -> Hashtbl.find basic b_a.(new_id) | 2 -> Hashtbl.find intermediate i_a.(new_id) | _ -> Hashtbl.find consolidated c_a.(new_id)).title;
+                fill_requirements (if new_req <> [] then ((idx, List.hd new_req)::tl) else tl)
+              with _ -> ()
+          )
+        )
+    in
+    fill_requirements req;
+    r
+	in
+	init_assignment (); 
+	Array.fast_sort compare assignment;
+	let assignment = diff_to_exercise assignment in
+  let assignment = if assignment.(5) = "" then Array.sub assignment 0 5 else assignment in
+	Array.to_list assignment
+	
+
+
+(*
+	##########################
+	#          MAIN          #
+	##########################
+*)
+let iter_tokens tokens availabel_exercises = 
+	let tbl = create_htbls availabel_exercises in
+	let assignments = Hashtbl.create 25 in
+	let rec assignment_to_string_list acc = function
+		| []      -> acc
+		| exe::t  -> assignment_to_string_list (exe.title::acc) t 
+	in
+	let rec aux_tokens = function
+		| []    -> assignments
+		| {token; level}::t  -> 
+        if ((List.length availabel_exercises) < 6) then 
+          (Hashtbl.add assignments (assignment_to_string_list [] availabel_exercises) token; aux_tokens t)
+        else 
+          (Hashtbl.add assignments (gen_assignment tbl level) token; aux_tokens t)
+	in
+	aux_tokens tokens

--- a/src/app/learnocaml_teacher_tab.ml
+++ b/src/app/learnocaml_teacher_tab.ml
@@ -722,21 +722,108 @@ let rec teacher_tab token _select _params () =
     in
     let new_assg_id = "new_assignment" in
     let new_assg_button = H.button [H.txt [%i"New assignment"]] in
+    let gen_assg_button = H.button [H.txt [%i"Generate assignment"]] in
     let table = H.table [] in
     let new_assg_line =
       H.tr ~a:[
         H.a_id new_assg_id;
       ] [
-        H.td ~a:[H.a_colspan 10] [ new_assg_button ]
+        H.td ~a:[H.a_colspan 10] [ new_assg_button; gen_assg_button ]
       ]
     in
-    let new_assignment () =
-      let start, stop =
-        let tm = Unix.(gmtime (time ())) in
-        let tm = Unix.{tm with tm_hour = 0; tm_min = 0; tm_sec = 0} in
-        fst Unix.(mktime {tm with tm_mday = tm.tm_mday + 1}),
-        fst Unix.(mktime {tm with tm_mday = tm.tm_mday + 8})
+    let gen_timestamp () =
+      let tm = Unix.(gmtime (time ())) in
+      let tm = Unix.{tm with tm_hour = 0; tm_min = 0; tm_sec = 0} in
+      fst Unix.(mktime {tm with tm_mday = tm.tm_mday + 1}),
+      fst Unix.(mktime {tm with tm_mday = tm.tm_mday + 8})
+    in
+    let gen_assignment () =
+      let open Gen_assignment in
+      let get_exercise_meta id = 
+      (* Find exercise and get meta *)
+        let rec iter_exercises_index = function
+          | []                  -> {title = ""; stars = Basic; id = -1.; requirements = []}
+          | (idx, Some meta)::t -> if id = idx then {title = idx; stars = Gen_assignment.float_to_diff meta.Exercise.Meta.stars; id = float_of_string (Option.get meta.Exercise.Meta.id); requirements = (List.map float_of_string meta.Exercise.Meta.requirements)}
+                                   else iter_exercises_index t 
+          | _                   -> {title = ""; stars = Basic; id = -3.; requirements = []}
+        in
+        let rec iter_groups (l : (string * Learnocaml_data.Exercise.Index.group) list) = 
+          match l with
+          | []          -> {title = ""; stars = Basic; id = -2.; requirements = []}
+          | (_, gp)::t  -> let open Learnocaml_data.Exercise.Index in
+                           let exe =
+                            (match gp.contents with
+                            | Exercise.Index.Exercises exlist -> iter_exercises_index exlist
+                            | _                               -> {title = ""; stars = Basic; id = -4.; requirements = []}) in
+                           if exe.id >= 0. then exe else iter_groups t
+        in                            
+        match !exercises_index with
+        | Exercise.Index.Groups gplist  -> iter_groups gplist
+        | _                             -> {title = ""; stars = Basic; id = -5.; requirements = []}
       in
+      let rec create_exercise_list acc = function
+        | []    -> acc
+        | id::t -> create_exercise_list ((get_exercise_meta id)::acc) t
+      in
+      let get_all_assignments htbl = 
+      (* Create assignment list *)
+        let rec iter_htbl acc ht = function
+          | []      -> acc
+          | exel::t ->
+            let tkl = Hashtbl.find_all ht exel in
+            while Hashtbl.mem ht exel do
+              Hashtbl.remove ht exel
+            done;
+            let exe_set = List.fold_left (fun s id -> SSet.add id s) SSet.empty exel in
+            let token_list = Learnocaml_data.Token.Set.of_list tkl in
+            iter_htbl ((exe_set, token_list)::acc) ht t 
+        in
+        let uniq_list l = 
+          List.fold_left (fun l ele -> if List.mem ele l then l else ele::l) [] l 
+        in
+        let keys = uniq_list (htbl_keys htbl) in
+        iter_htbl [] htbl keys
+      in
+      let add_assignments_to_tbl l = 
+      (* Add all assignments to table *)
+        let rec aux = function
+          | []                      -> ()
+          | (exercises, tokens)::t  -> 
+            let start, stop = gen_timestamp () in
+            let line = make_line (start, stop) tokens exercises false in
+            let id = !line_n in
+            Dom.insertBefore (H.toelt table)
+              (H.toelt line)
+              (Js.some (H.toelt new_assg_line));
+            !assignment_change id;
+            !toggle_select_assignment id;
+            aux t
+        in
+        aux l
+      in
+      let create_student x = 
+      (* Get students meta *)
+        let open Learnocaml_data.Student in
+        let student = get_student x in
+        let tags    = Learnocaml_data.SSet.elements student.tags in
+        try
+          Gen_assignment.create_student x (List.hd tags)
+        with _ -> Gen_assignment.create_student x ""
+      in
+      let get_students_meta () =
+        let tokens,_ = get_student_selection () in
+        let tokens = Learnocaml_data.Token.Set.elements tokens in
+        List.map (fun x -> create_student x) tokens
+      in
+      let exercises = htbl_keys selected_exercises in
+      let exercises = create_exercise_list [] exercises in
+      let tokens = get_students_meta () in
+      let assignments = Gen_assignment.iter_tokens tokens exercises in
+      let new_assignment_list = get_all_assignments assignments in
+      add_assignments_to_tbl new_assignment_list
+    in
+    let new_assignment () =
+      let start, stop = gen_timestamp () in
       let tokens, default = get_student_selection () in
       let exercises =
         Hashtbl.fold (fun id () -> SSet.add id) selected_exercises SSet.empty
@@ -755,6 +842,7 @@ let rec teacher_tab token _select _params () =
       !toggle_select_assignment id
     in
     Manip.Ev.onclick new_assg_button (fun _ -> new_assignment (); false);
+    Manip.Ev.onclick gen_assg_button (fun _ -> gen_assignment (); false);
     Manip.replaceChildren table @@
     List.map (fun (assg, tokens, dft, exos) -> make_line assg tokens exos dft)
       assignments @
@@ -1362,3 +1450,4 @@ let rec teacher_tab token _select _params () =
   fill_control_div ();
   fill_students_progression ();
   Lwt.return div
+

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -677,6 +677,10 @@ msgstr "%d+ étudiants"
 msgid "New assignment"
 msgstr "Nouveau devoir"
 
+#: File "src/app/learnocaml_teacher_tab.ml", line 726, characters 47-65
+msgid "Generate assignment"
+msgstr "Générer un devoir"
+
 #: File "src/app/learnocaml_teacher_tab.ml", line 821, characters 16-28
 msgid "Open/Close"
 msgstr "Ouvrir/Fermer"


### PR DESCRIPTION
* Kind: feature

* Close #531 

### Description
If you are a teacher with a large number of students and want to assign a different set of exercises to each student based on their level and exercise difficulty, this can be a time-consuming process. 

With this feature, you can save time and effort when assigning exercises to your students on the Learn-OCaml platform.

### Checklist
* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)
* [x] Add/update [documentation](https://github.com/ocaml-sf/learn-ocaml/tree/master/docs)
  <!-- if there are some user-facing changes. -->

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR).
* Make sure the PR has a **milestone**.
* ***Assign*** yourself before merging.
* Either do a regular **merge**:
  * for PRs containing *several commits* following [conventional-commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits),
  * or for PRs containing 1 commit shared with a later PR (to preserve the SHA1)
* Or do a **squash-merge**:
  * for PRs containing *only 1 commit* (not shared with a later PR),
  * or for PRs containing several commits that need not be kept in the history;
  * → ***Update the commit message header*** with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples),
  * → ***Add a footer*** `Close #…` if a related issue exists.
