### PR TITLE
feat(UI): Add possibility to choose exercise display order

### DIFF
--- a/src/state/learnocaml_data.ml
+++ b/src/state/learnocaml_data.ml
@@ -906,7 +906,7 @@ module Exercise = struct
         List.fold_left (fun exs skill ->
             List.fold_left (fun exs id ->
                 (ex_node exercises id, [Skill skill]) :: exs)
-              exs (SMap.find skill focus)
+              exs (try SMap.find skill focus with Not_found -> [])
           ) exs ex_meta.Meta.requirements
       in
       let exs = merge_children exs in
@@ -964,6 +964,27 @@ module Exercise = struct
         end
       in
       compute [] graph
+
+    let fold f acc graph =
+      let visited_nodes = Hashtbl.create 17 in
+      let rec fold_nodes acc graph =
+        let rec fold_children acc node =
+          if Hashtbl.mem visited_nodes node.name
+          then acc
+          else let acc =
+            List.fold_left
+              fold_children acc
+              (List.map fst node.children)
+          in
+          Hashtbl.add visited_nodes node.name ();
+          f acc node
+        in
+        match graph with
+        | [] -> acc
+        | node :: nodes ->
+          fold_nodes (fold_children acc node) nodes
+      in
+      fold_nodes acc graph
 
     let dump_dot fmt nodes =
       let print_kind fmt = function

--- a/src/state/learnocaml_data.mli
+++ b/src/state/learnocaml_data.mli
@@ -303,6 +303,9 @@ module Exercise: sig
         exercise. *)
     val compute_exercise_set : node -> string list
 
+    (** Fold function that handles every exercise's dependency before handling exercise itself *)
+    val fold : ('a -> node -> 'a) -> 'a -> node list -> 'a
+
     (** Dumps the graph as a `dot` representation, into the given formatter. *)
     val dump_dot : Format.formatter -> node list -> unit
 

--- a/static/css/learnocaml_main.css
+++ b/static/css/learnocaml_main.css
@@ -418,6 +418,23 @@ body {
 
 /* -- Exercises activity --------------------------------------------------- */
 
+#learnocaml-main-exercise-bar {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+#learnocaml-main-exercise-bar button {
+  flex-grow: 1;
+  background: linear-gradient(to bottom, #9bd 0%, #5581ff 100%);
+  color: #fff;
+  text-shadow: 0 0 10px #000;
+}
+
+#learnocaml-main-exercise-bar button.active {
+  background: linear-gradient(to bottom, #f29100 0%, #ec670f 100%);
+}
+
 #learnocaml-main-exercise-list > .exercise + .exercise {
   border-top: 1px #333 solid;
 }

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -431,6 +431,18 @@ msgstr "Temps restant: %s"
 msgid "No open exercises at the moment"
 msgstr "Aucun exercice n'est encore ouvert"
 
+#: File "src/app/learnocaml_index_main.ml", line 209, characters 54-65
+msgid "By legacy"
+msgstr "Par groupe"
+
+#: File "src/app/learnocaml_index_main.ml", line 211, characters 50-60
+msgid "By order"
+msgstr "Par ordre"
+
+#: File "src/app/learnocaml_index_main.ml", line 213, characters 52-61
+msgid "By stars"
+msgstr "Par difficulté"
+
 #: File "src/app/learnocaml_index_main.ml", line 161, characters 18-38
 msgid "Loading playground"
 msgstr "Chargement du bac-à-sable"


### PR DESCRIPTION
* **Kind:** enhancement

<!-- For a bug fix, make sure the bug was already reported in an issue. -->

* Related to this [PR on public corpus](https://github.com/ocaml-sf/learn-ocaml-corpus/pull/37) 

### Description

This PR provides users with the ability to sort exercises in the exercises index based on various criteria derived from metadata. The initial version relies solely on groups structured according to the exercise provider's preference, which we refer to as "By legacy". The list of newly added sorting options includes:

- **By deps**: This sorting does not divide exercises into specific subgroups. It uses an algorithm to determine dependencies between exercises based on the skills they train and require, as well as any connections between two exercises.
- **By stars**: This groups exercises based on their star ratings, from easiest to most difficult.

This PR is closely related to the [upgrade of the public corpus](https://github.com/ocaml-sf/learn-ocaml-corpus/pull/37), which adds a logical progression to follow and fresh new exercises for practicing OCaml programming language.

Regarding the specific code base changes, all callbacks triggered by clicking on one of the buttons (Exercises, Playground, Lessons, etc.) now have a common type called `tab_handler`. Previously, each of these callbacks generated the content of the main page without allowing the main page to be divided into multiple modes (in our case, these modes are exercise sorting modes). To address this, an optional argument `?clear_cache` was added to prevent the page from always rendering in its initial state.

Co-authored-by: Dario Pinto (@RadioPotin)