### PR TITLE
chore(macos): Fix `brew upgrade` failure

### DIFF
--- a/.ci-macosx.sh
+++ b/.ci-macosx.sh
@@ -24,6 +24,11 @@ rm -f /usr/local/lib/libtcl8.6.dylib
 rm -f /usr/local/lib/libtk8.6.dylib
 rm -f /usr/local/bin/go
 rm -f /usr/local/bin/gofmt
+rm -f /usr/local/lib/node_modules/npm/bin/npm.ps1
+rm -f /usr/local/lib/node_modules/npm/bin/npx.ps1
+rm -f /usr/local/lib/node_modules/npm/lib/cli-entry.js
+rm -f /usr/local/lib/node_modules/npm/lib/es6/validate-engines.js
+rm -fr /usr/local/lib/node_modules/npm/node_modules/
 
 brew upgrade
 


### PR DESCRIPTION
* **Kind:** bugfix

### Description

cf. https://github.com/ocaml-sf/learn-ocaml/wiki/(CI)(macOS)-How-to-fix-spurious-brew-link-failures

### Checklist

<!-- You can remove all the check-boxes that are not applicable. -->

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR).
* Make sure the PR has a **milestone**.
* ***Assign*** yourself before merging.
* [ ] Either do a regular **merge**:
  * for PRs containing *several commits* following [conventional-commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits),
  * or for PRs containing 1 commit shared with a later PR (to preserve the SHA1)
* [x] Or do a **squash-merge**:
  * for PRs containing *only 1 commit* (not shared with a later PR),
  * or for PRs containing several commits that need not be kept in the history;
  * → ***Update the commit message header*** with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples),
  * → ***Add a footer*** `Close #…` if a related issue exists.