### PR TITLE
feat(server): add a `--replace` option

### DIFF
--- a/src/main/learnocaml_server_args.ml
+++ b/src/main/learnocaml_server_args.ml
@@ -19,6 +19,7 @@ module type S = sig
     base_url: string;
     port: int;
     cert: string option;
+    replace: bool;
   }
 
   val term: string Cmdliner.Term.t -> string Cmdliner.Term.t -> t Cmdliner.Term.t
@@ -51,15 +52,21 @@ module Args (SN : Section_name) = struct
           HTTPS is enabled."
           default_http_port default_https_port)
 
+  let replace =
+    value & flag &
+    info ["replace"] ~doc:
+      "Replace a previously running instance of the server on the same port."
+
   type t = {
     sync_dir: string;
     base_url: string;
     port: int;
     cert: string option;
+    replace: bool;
   }
 
   let term app_dir base_url =
-    let apply app_dir sync_dir base_url port cert =
+    let apply app_dir sync_dir base_url port cert replace =
       Learnocaml_store.static_dir := app_dir;
       Learnocaml_store.sync_dir := sync_dir;
       let port = match port, cert with
@@ -73,10 +80,10 @@ module Args (SN : Section_name) = struct
         | None -> None);
       Learnocaml_server.port := port;
       Learnocaml_server.base_url := base_url;
-      { sync_dir; base_url; port; cert }
+      { sync_dir; base_url; port; cert; replace }
     in
   (* warning: if you add any options here, remember to pass them through when
      calling the native server from learn-ocaml main *)
-    Term.(const apply $ app_dir $ sync_dir $ base_url $ port $ cert)
+    Term.(const apply $ app_dir $ sync_dir $ base_url $ port $ cert $ replace)
 
 end

--- a/src/main/learnocaml_server_args.mli
+++ b/src/main/learnocaml_server_args.mli
@@ -16,6 +16,7 @@ module type S = sig
     base_url: string;
     port: int;
     cert: string option;
+    replace: bool;
   }
 
   val term: string Cmdliner.Term.t -> string Cmdliner.Term.t -> t Cmdliner.Term.t

--- a/src/main/learnocaml_server_main.ml
+++ b/src/main/learnocaml_server_main.ml
@@ -31,6 +31,17 @@ let main o =
     Learnocaml_api.version o.port;
   if o.base_url <> "" then
     Printf.printf "Base URL: %s\n%!" o.base_url;
+  let () =
+    match Learnocaml_server.check_running (), o.replace with
+    | None, _ -> ()
+    | Some _, false ->
+        Printf.eprintf "Error: another server is already running on port %d \
+                        (consider using option `--replace`)\n%!"
+          !Learnocaml_server.port;
+        exit 10
+    | Some pid, true ->
+        Learnocaml_server.kill_running pid
+  in
   let rec run () =
     let minimum_duration = 15. in
     let t0 = Unix.time () in

--- a/src/repo/learnocaml_process_exercise_repository.ml
+++ b/src/repo/learnocaml_process_exercise_repository.ml
@@ -62,7 +62,7 @@ let spawn_grader
     ?print_result ?dirname meta ex_dir output_json =
   let rec sleep () =
     if !n_processes <= 0 then
-      Lwt_main.yield () >>= sleep
+      Lwt.pause () >>= sleep
     else (
       decr n_processes; Lwt.return_unit
     )

--- a/src/server/learnocaml_server.mli
+++ b/src/server/learnocaml_server.mli
@@ -16,5 +16,12 @@ val args: (Arg.key * Arg.spec * Arg.doc) list
 
 (** Main *)
 
-(* Returns [false] if interrupted prematurely due to an error *)
+val check_running: unit -> int option
+(** Returns the pid or an existing process listening on the tcp port *)
+
+val kill_running: int -> unit
+(** Kills the given process and waits for termination (fails upon
+    reaching a timeout) *)
+
 val launch: unit -> bool Lwt.t
+(** Returns [false] if interrupted prematurely due to an error *)


### PR DESCRIPTION
Closes #529 which seemed to be a common complaint among teachers.

* `learn-ocaml serve --replace` will kill an existing server (running on the
  same port) just before starting

* `learn-ocaml build serve` with an existing server on the same port will fail
  fast (before actually doing the build)

* `learn-ocaml build serve --replace` is more clever:
  - it will do the build **in a temporary directory**
  - then, only if everything is ok, kill the older server
  - swap the files and start the new server

This is all done in order to minimise downtime and be convenient for server
updates.

~~Note that this PR sits on top of #481 and should be rebased once it's
merged.~~