### PR TITLE
fix(grading): avoid failing on sampling arrays with unique elements

### DIFF
--- a/src/grader/test_lib.ml
+++ b/src/grader/test_lib.ml
@@ -1762,7 +1762,7 @@ module Make
         if dups then sample else
           let prev = Hashtbl.create max_size in
           let rec sample_new steps =
-            if steps = 0 then invalid_arg "sample_array" else
+            if steps = 0 then sample () else
               let s = sample () in
               try Hashtbl.find prev s ; sample_new (steps - 1)
               with Not_found -> Hashtbl.add prev s () ; s in

--- a/src/grader/test_lib.mli
+++ b/src/grader/test_lib.mli
@@ -466,7 +466,9 @@ module type S = sig
        sorted.
 
      If [~dups:false] ([true] by default), all elements of generated
-       array are unique.*)
+       arrays are unique, or at least try hard to be in a reasonable time:
+       if the codomain of [sampler] is too small there might still be
+       duplicates.*)
     val sample_array :
       ?min_size: int -> ?max_size: int -> ?dups: bool -> ?sorted: bool
       -> 'a sampler


### PR DESCRIPTION
Closes https://github.com/ocaml-sf/learn-ocaml-corpus/issues/39

The sampler was attempting to generate N distinct elements by restarting the
provided sampler an arbitrary number of times (100). It would fail if the domain
is to small: now it might still return duplicates in this case, which is better
than failing for our use-cases.