### PR TITLE
ci: Fix jekyll-build-pages source for https://ocaml-sf.org/learn-ocaml/

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./docs
           destination: ./_site
       # Not the default gh download-artifact action, which doesn't work
       # between workflows


### PR DESCRIPTION
* **Kind:** bugfix

* Follows-up: #576

### Description

the merge of #576 slightly broke the deployment of the regular website on https://ocaml-sf.org/learn-ocaml/
in particular this link does not work anymore: https://ocaml-sf.org/learn-ocaml/howto-deploy-learn-ocaml-statically

I believe this is because the gh pages source has been set to `./` instead of `./docs`,
so the HTML index unexpectedly comes from the README.md, instead of `docs/index.md`

@AltGr do you think this patch will work out-of-the-box as is, or I need to tweak another path?

If you're not sure, this can be tested after-the-fact anyway…

### Checklist

<!-- You can remove all the check-boxes that are not applicable. -->

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR).
* Make sure the PR has a **milestone**.
* ***Assign*** yourself before merging.
* [ ] Either do a regular **merge**:
  * for PRs containing *several commits* following [conventional-commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits),
  * or for PRs containing 1 commit shared with a later PR (to preserve the SHA1)
* [x] Or do a **squash-merge**:
  * for PRs containing *only 1 commit* (not shared with a later PR),
  * or for PRs containing several commits that need not be kept in the history;
  * → ***Update the commit message header*** with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples),
  * → ***Add a footer*** `Close #…` if a related issue exists.
