### PR TITLE
remove residual code from PR #320, which is no longer useful

### DIFF
--- a/src/repo/learnocaml_exercise.mli
+++ b/src/repo/learnocaml_exercise.mli
@@ -86,13 +86,6 @@ module File : sig
 
   (** Returns the (public) [descr.html] *)
   val descr: (string * string) list file
-
-  (** Returns the (public) depend file *)
-  val depend: string option file
-
-  (** [dependencies txt] create the (private, already deciphered) dependencies
-      declared in [txt] *)
-  val dependencies: string option -> string file list
 end
 
 (** Access a field from the exercise, using the [t] representation, without **


### PR DESCRIPTION
PR #481 allows external pre-compiled code to be used in the grading environment, effectively replacing 
the existing mechanism for test code reuse (PR #320). 

This existing mechanism is no longer supported (it is now ignored by grader/grading.ml), 
**but residual code continues to run**. In particular, an exception is raised when file *depend.txt* 
is present in the *exercise* folder and specifies invalid file paths.

This new PR removes residual code from PR #320

This closes issue #366
