### PR TITLE
chore(test-opam-publish.yml): Update preflight workflow

### DIFF
--- a/.github/workflows/test-opam-publish.yml
+++ b/.github/workflows/test-opam-publish.yml
@@ -16,16 +16,18 @@ jobs:
   call-opam-publish:
     uses: ./.github/workflows/opam-publish.yml
     with:
-      # release: "false" # by default
-      tag_name: "v0.15.0"
+      # release: "false"  # beware: keep this flag set to false
+      tag_name: "v0.16.0" # beware: put here an existing (old) tag
       body: |
         Cc @erikmd
 
-        ## [0.15.0](https://github.com/ocaml-sf/learn-ocaml/compare/v0.14.1...v0.15.0) (2023-08-23)
-        
+        ## [1.0.0](https://github.com/ocaml-sf/learn-ocaml/compare/v0.16.0...v1.0.0) (2024-02-12)
+
+        Preflight!
+
         ### Features
         
-        * **partition-view:** Add a selector to show (tokens, nicks, or anon IDs) (`#540`) ([58b3644](https://github.com/ocaml-sf/learn-ocaml/commit/58b3644a6d5a3f43cf8d7cb21ebbe40b588f176f)), closes `#528`
+        * **pre-compilation:** Implement pre-compilation of exercises and graders ([b03bdfe](https://github.com/ocaml-sf/learn-ocaml/commit/b03bdfe5a7c9ed5d4677b1ee2eb11d37e953cbe3))
         * etc.
     secrets:
       OPAM_RELEASE: ${{ secrets.OPAM_RELEASE }}


### PR DESCRIPTION
* **Kind:** preflight

### Description

a chore, dry-run PR (that will be able to be integrated after the 1.0.0 release) just to test that the automatic opam-publish job will succeed after the PR https://github.com/ocaml-sf/learn-ocaml/pull/572 is merged.

### Checklist

* [x] Read the [CONTRIBUTING.md](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md) guide and:
  * [x] Use [Atomic Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#atomic-commits) so each commit gathers a single logical change
  * [x] Use [Conventional Commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits) regarding commit messages (needed by our release toolchain)

<!-- You can leave this note below as a reminder for maintainers: -->
### Note to maintainers

* Read [this wiki page](https://github.com/ocaml-sf/learn-ocaml/wiki/Checklist-for-testing-and-merging-a-PR).
* Make sure the PR has a **milestone**.
* ***Assign*** yourself before merging.
* [ ] Either do a regular **merge**:
  * for PRs containing *several commits* following [conventional-commits](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits),
  * or for PRs containing 1 commit shared with a later PR (to preserve the SHA1)
* [x] Or do a **squash-merge**:
  * for PRs containing *only 1 commit* (not shared with a later PR),
  * or for PRs containing several commits that need not be kept in the history;
  * → ***Update the commit message header*** with a [conventional-commit type](https://github.com/ocaml-sf/learn-ocaml/blob/master/CONTRIBUTING.md#conventional-commits-examples),
  * → ***Add a footer*** `Close #…` if a related issue exists.